### PR TITLE
Hotfix v0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v0.22.1 (May 2, 2018)
+
+**Fixes:**
+- Fixed a bug where the Files and Revisions pages would break if they contained
+  a PDF document
+
 ## v0.22 (April 25, 2018)
 
 **New Features:**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Openly One
 
-[![GitHub release](https://img.shields.io/badge/version-0.22-blue.svg)](https://github.com/OpenlyOne/openly)
+[![GitHub release](https://img.shields.io/badge/version-0.22.1-blue.svg)](https://github.com/OpenlyOne/openly)
 [![Build Status](https://travis-ci.org/OpenlyOne/openly.svg?branch=master)](https://travis-ci.org/OpenlyOne/openly)
 [![codecov](https://codecov.io/gh/OpenlyOne/openly/branch/master/graph/badge.svg)](https://codecov.io/gh/OpenlyOne/openly)
 

--- a/app/models/providers/google_drive/link.rb
+++ b/app/models/providers/google_drive/link.rb
@@ -9,8 +9,8 @@ module Providers
       end
 
       def self.for(external_id:, mime_type:)
-        mime_type_symbol = MimeType.to_symbol(mime_type)
-        send(:"for_#{mime_type_symbol}", external_id)
+        type_symbol = MimeType.to_symbol(mime_type)
+        safe_send(:"for_#{type_symbol}", external_id) || for_other(external_id)
       end
 
       def self.for_document(id)
@@ -39,6 +39,11 @@ module Providers
 
       def self.for_other(id)
         "#{base_path(:drive)}/file/d/#{id}"
+      end
+
+      # Send the method with arguments if the method exists. Else, return nil.
+      def self.safe_send(method, arguments)
+        send(method, arguments) if respond_to?(method)
       end
     end
   end

--- a/spec/factories/file_resource/snapshots.rb
+++ b/spec/factories/file_resource/snapshots.rb
@@ -12,5 +12,9 @@ FactoryBot.define do
     trait :folder do
       mime_type { 'application/vnd.google-apps.folder' }
     end
+
+    trait :pdf do
+      mime_type { Providers::GoogleDrive::MimeType.pdf }
+    end
   end
 end

--- a/spec/models/providers/google_drive/link_spec.rb
+++ b/spec/models/providers/google_drive/link_spec.rb
@@ -12,7 +12,19 @@ RSpec.describe Providers::GoogleDrive::Link, type: :model do
     after { link.for(external_id: 'external-id', mime_type: 'type') }
 
     it 'calls #for_{symbolic_mime_type} with external_id' do
-      expect(link).to receive(:send).with(:for_symbolic_type, 'external-id')
+      expect(link)
+        .to receive(:safe_send).with(:for_symbolic_type, 'external-id')
+    end
+
+    context 'when safe_send returns nil' do
+      before do
+        allow(Providers::GoogleDrive::Link)
+          .to receive(:safe_send)
+          .with(:for_symbolic_type, 'external-id')
+          .and_return nil
+      end
+
+      it { expect(link).to receive(:for_other).with('external-id') }
     end
   end
 
@@ -49,5 +61,28 @@ RSpec.describe Providers::GoogleDrive::Link, type: :model do
   describe '.for_other(id)' do
     subject { link.for_other('FILE-ID') }
     it { is_expected.to eq 'https://drive.google.com/file/d/FILE-ID' }
+  end
+
+  describe '.safe_send(method, arguments)' do
+    before do
+      allow(link).to receive(:respond_to?).and_call_original
+      allow(link)
+        .to receive(:respond_to?).with(:method_name).and_return method_exists
+    end
+
+    after { link.safe_send(:method_name, a: 1, b: 2) }
+
+    context 'when method exists' do
+      let(:method_exists) { true }
+
+      it { is_expected.to receive(:send).with(:method_name, a: 1, b: 2) }
+    end
+
+    context 'when method does not exist' do
+      let(:method_exists) { false }
+
+      it { is_expected.not_to receive(:send).with(:method_name, a: 1, b: 2) }
+      it { expect(link.safe_send(:method_name, a: 1, b: 2)).to eq nil }
+    end
   end
 end

--- a/spec/regressions/views/revisions/index_spec.rb
+++ b/spec/regressions/views/revisions/index_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe 'revisions/index', type: :view do
+  let(:project)     { build_stubbed :project }
+  let(:revisions)   { build_stubbed_list :revision, 3 }
+  let(:snapshots)   { build_stubbed_list(:file_resource_snapshot, 3) }
+  let(:diffs) do
+    snapshots.map do |snapshot|
+      FileDiff.new(file_resource_id: 12,
+                   current_snapshot: snapshot,
+                   first_three_ancestors: [])
+    end
+  end
+
+  before do
+    assign(:project, project)
+    assign(:revisions, revisions)
+    controller.request.path_parameters[:profile_handle] = project.owner.to_param
+    controller.request.path_parameters[:project_slug] = project.to_param
+
+    root = instance_double FileResource
+    allow(project).to receive(:root_folder).and_return root
+    allow(root).to receive(:provider).and_return Providers::GoogleDrive
+    allow(revisions.first).to receive(:file_diffs).and_return diffs
+  end
+
+  context 'rendering PDF documents' do
+    let(:snapshots) { build_stubbed_list(:file_resource_snapshot, 3, :pdf) }
+
+    it 'does not raise an error' do
+      render
+      snapshots.each do |snapshot|
+        expect(rendered).to have_text snapshot.name
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixed a bug where the Files and Revisions pages would break if they contained a PDF document.