### PR TITLE
Add File Backups

### DIFF
--- a/app/helpers/file_helper.rb
+++ b/app/helpers/file_helper.rb
@@ -19,4 +19,18 @@ module FileHelper
 
     link_to(path, options) { capture(&block) }
   end
+
+  # Wrap block into a link to the file's snapshot backup
+  # If the file snapshot has not been backed up, does not wrap block into a
+  # link.
+  def link_to_file_backup(file_snapshot, options = {}, &block)
+    path = file_snapshot.backup&.file_resource&.external_link
+
+    if path
+      options = options.reverse_merge target: '_blank'
+      link_to(path, options) { capture(&block) }
+    else
+      content_tag(:span) { capture(&block) }
+    end
+  end
 end

--- a/app/models/concerns/backupable.rb
+++ b/app/models/concerns/backupable.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# A backupable FileResource
+module Backupable
+  extend ActiveSupport::Concern
+
+  included do
+    # Callbacks
+    after_save :perform_backup, if: :backup_on_save?
+  end
+
+  # Has this file resource already been backed up?
+  def backed_up?
+    current_snapshot&.backup&.persisted?
+  end
+
+  # Should this file resource be backed up on save?
+  # No, if folder.
+  # No, if deleted.
+  # No, if already backed up.
+  def backup_on_save?
+    !folder? && !deleted? && !backed_up?
+  end
+
+  private
+
+  # The action for performing the backup
+  def perform_backup
+    FileResource::Backup.backup(self)
+    true
+  end
+end

--- a/app/models/file_resource.rb
+++ b/app/models/file_resource.rb
@@ -6,6 +6,8 @@ class FileResource < ApplicationRecord
   include Snapshotable
   include Stageable
   include Syncable
+  # must be last, so that backup is made after snapshot is persisted
+  include Backupable
 
   self.inheritance_column = 'provider_id'
 

--- a/app/models/file_resource/backup.rb
+++ b/app/models/file_resource/backup.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class FileResource
+  # A permanent backup of a file resource snapshot
+  class Backup < ApplicationRecord
+    # Associations
+    belongs_to :file_resource_snapshot, class_name: 'FileResource::Snapshot',
+                                        dependent: false
+    belongs_to :archive, class_name: 'Project::Archive', dependent: false
+    belongs_to :file_resource, dependent: false
+
+    # Validations
+    validates :file_resource_snapshot_id,
+              uniqueness: { message: 'already has a backup' }
+
+    # TODO: after_destroy --> destroy backup if this is last reference to it
+  end
+end

--- a/app/models/file_resource/backup.rb
+++ b/app/models/file_resource/backup.rb
@@ -17,6 +17,14 @@ class FileResource
 
     # TODO: after_destroy --> destroy backup if this is last reference to it
 
+    # Create a backup for the provided file resource
+    def self.backup(file_resource_to_backup)
+      new(
+        file_resource_snapshot: file_resource_to_backup.current_snapshot,
+        archive: file_resource_to_backup.staging_projects.first&.archive
+      ).tap(&:capture).tap(&:save)
+    end
+
     # Capture a backup of the file resource snapshot and store in archive
     def capture
       return false unless valid?(:capture)

--- a/app/models/file_resource/backup.rb
+++ b/app/models/file_resource/backup.rb
@@ -53,7 +53,7 @@ class FileResource
       self.file_resource = file_resource_class.create!(
         external_id: external_id,
         name: 'Backup',
-        mime_type: 'Backup',
+        mime_type: file_resource_snapshot.mime_type,
         content_version: 0
       )
     end

--- a/app/models/file_resource/backup.rb
+++ b/app/models/file_resource/backup.rb
@@ -7,12 +7,63 @@ class FileResource
     belongs_to :file_resource_snapshot, class_name: 'FileResource::Snapshot',
                                         dependent: false
     belongs_to :archive, class_name: 'Project::Archive', dependent: false
-    belongs_to :file_resource, dependent: false
+    belongs_to :file_resource, dependent: false, optional: true
 
     # Validations
     validates :file_resource_snapshot_id,
               uniqueness: { message: 'already has a backup' }
+    validates :file_resource, presence: { message: 'must exist' },
+                              on: %i[create update]
 
     # TODO: after_destroy --> destroy backup if this is last reference to it
+
+    # Capture a backup of the file resource snapshot and store in archive
+    def capture
+      return false unless valid?(:capture)
+
+      # Create backup
+      # TODO: Refactor to file_resource.duplicate_remote
+      file = file_resource_remote.duplicate(
+        name: file_resource_snapshot.name,
+        parent_id: archive_folder_id
+      )
+
+      return false unless file.present?
+      create_file_resource!(file.id)
+    end
+
+    private
+
+    def archive_folder_id
+      archive.file_resource.external_id
+    end
+
+    # Create the file resource (backup)
+    # TODO: Add support for is_tracked: false and avoid saving generic data
+    # TODO: Store actual mime type for link generation
+    def create_file_resource!(external_id)
+      self.file_resource = file_resource_class.create!(
+        external_id: external_id,
+        name: 'Backup',
+        mime_type: 'Backup',
+        content_version: 0
+      )
+    end
+
+    def file_resource_remote
+      sync_adapter_class.new(file_resource_snapshot.external_id)
+    end
+
+    def file_resource_class
+      "FileResources::#{provider}".constantize
+    end
+
+    def provider
+      'GoogleDrive'
+    end
+
+    def sync_adapter_class
+      "Providers::#{provider}::FileSync".constantize
+    end
   end
 end

--- a/app/models/file_resource/snapshot.rb
+++ b/app/models/file_resource/snapshot.rb
@@ -8,6 +8,9 @@ class FileResource
     # Associations
     belongs_to :file_resource, autosave: false, optional: false
     belongs_to :parent, class_name: 'FileResource', optional: true
+    has_one :backup, class_name: 'FileResource::Backup',
+                     dependent: :destroy,
+                     foreign_key: :file_resource_snapshot_id
 
     has_many :committing_files, class_name: 'CommittedFile',
                                 foreign_key: :file_resource_snapshot_id

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -51,6 +51,8 @@ class Project < ApplicationRecord
     end
   end
 
+  has_one :archive, dependent: :destroy
+
   # Attributes
   # Do not allow owner change
   attr_readonly :owner_id

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -56,6 +56,8 @@ class Project < ApplicationRecord
   # Attributes
   # Do not allow owner change
   attr_readonly :owner_id
+  # Set to true to skip archive setup
+  attr_accessor :skip_archive_setup
 
   # Delegations
   delegate :in_progress?, :completed?, to: :setup, prefix: true, allow_nil: true
@@ -63,6 +65,8 @@ class Project < ApplicationRecord
   # Callbacks
   # Auto-generate slug from title
   before_validation :generate_slug_from_title, if: :title?, unless: :slug?
+  # Set up archive for storing file backups
+  after_create :setup_archive, unless: :skip_archive_setup
 
   # Scopes
   # Projects where profile is owner or collaborator
@@ -161,6 +165,13 @@ class Project < ApplicationRecord
       .strip                    # trim whitespaces
       .tr(' ', '-')             # replace whitespaces with dashes
       .downcase                 # all lowercase
+  end
+
+  # Set up the archive folder for this project
+  def setup_archive
+    build_archive unless archive.present?
+    archive.setup unless archive.setup_completed?
+    archive.save
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/project/archive.rb
+++ b/app/models/project/archive.rb
@@ -13,11 +13,16 @@ class Project
     # Set up the archive folder with the provider by creating it and granting
     # view access to the repository owner
     def setup
-      raise 'Already set up' if file_resource.present?
+      raise 'Already set up' if setup_completed?
 
       create_external_folder
       grant_view_access_to_repository_owner
       file_resource.pull
+    end
+
+    # Return true if setup has been completed (i.e. file resource is present)
+    def setup_completed?
+      file_resource.present?
     end
 
     private

--- a/app/models/project/archive.rb
+++ b/app/models/project/archive.rb
@@ -6,6 +6,7 @@ class Project
     # Associations
     belongs_to :project
     belongs_to :file_resource
+    has_many :backups, class_name: 'FileResource::Backup', dependent: :destroy
 
     # Validations
     validates :project_id, uniqueness: { message: 'already has an archive' }

--- a/app/models/project/archive.rb
+++ b/app/models/project/archive.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Project
+  # The archive for storing file backups, just like a .git folder
+  class Archive < ApplicationRecord
+    # Associations
+    belongs_to :project
+    belongs_to :file_resource
+
+    # Validations
+    validates :project_id, uniqueness: { message: 'already has an archive' }
+  end
+end

--- a/app/models/project/archive.rb
+++ b/app/models/project/archive.rb
@@ -9,5 +9,58 @@ class Project
 
     # Validations
     validates :project_id, uniqueness: { message: 'already has an archive' }
+
+    # Set up the archive folder with the provider by creating it and granting
+    # view access to the repository owner
+    def setup
+      raise 'Already set up' if file_resource.present?
+
+      create_external_folder
+      grant_view_access_to_repository_owner
+      file_resource.pull
+    end
+
+    private
+
+    # Creates the archive folder with the provider
+    def create_external_folder
+      folder = sync_adapter_class.create(
+        name: "#{project.title} (Archive)",
+        parent_id: 'root',
+        mime_type: mime_type_class.folder
+      )
+      self.file_resource = file_resource_class.new(external_id: folder.id)
+    end
+
+    # Grants view access to the archive folder to the repository owner
+    def grant_view_access_to_repository_owner
+      api_connection_class
+        .default
+        .share_file(file_resource.external_id, owner_account_email, :reader)
+    end
+
+    delegate :owner, to: :project
+    delegate :account, to: :owner, prefix: true
+    delegate :email, to: :owner_account, prefix: true
+
+    def api_connection_class
+      "Providers::#{provider}::ApiConnection".constantize
+    end
+
+    def file_resource_class
+      "FileResources::#{provider}".constantize
+    end
+
+    def mime_type_class
+      "Providers::#{provider}::MimeType".constantize
+    end
+
+    def provider
+      'GoogleDrive'
+    end
+
+    def sync_adapter_class
+      "Providers::#{provider}::FileSync".constantize
+    end
   end
 end

--- a/app/models/providers/google_drive/api_connection.rb
+++ b/app/models/providers/google_drive/api_connection.rb
@@ -195,7 +195,7 @@ module Providers
 
       # The default fields for file query methods
       def default_file_fields
-        %w[id name mimeType parents trashed thumbnailLink
+        %w[id name mimeType parents permissions trashed thumbnailLink
            thumbnailVersion].join(',')
       end
 

--- a/app/models/providers/google_drive/api_connection.rb
+++ b/app/models/providers/google_drive/api_connection.rb
@@ -40,6 +40,32 @@ module Providers
         drive_service.delete_file(id)
       end
 
+      # Copy a file by ID, optionally providing new name and parent ID
+      # TODO: Support duplication without explicit name and parent ID
+      def duplicate_file(id, name:, parent_id:)
+        duplicate_file!(id, name: name, parent_id: parent_id)
+      rescue Google::Apis::ClientError => error
+        # only rescue not found errors
+        raise unless error.message.starts_with?('cannotCopyFile')
+        nil
+      end
+
+      # Copy a file by ID, optionally providing new name and parent ID.
+      # Raise error if file cannot be copied.
+      # TODO: Support duplication without explicit name and parent ID
+      def duplicate_file!(id, name:, parent_id:)
+        target = GoogleDrive::File.new(name: name, parents: [parent_id])
+        drive_service.copy_file(id, target, fields: default_file_fields)
+      end
+
+      # Get the file's content by file ID
+      def file_content(id)
+        content_io = StringIO.new
+        drive_service.export_file(id, 'text/plain', download_dest: content_io)
+        # Remove BOM
+        content_io.string.sub(/^\xEF\xBB\xBF/, '')
+      end
+
       # Find a file by ID. Return nil if file not found
       def find_file(id)
         find_file!(id)

--- a/app/models/providers/google_drive/file_sync.rb
+++ b/app/models/providers/google_drive/file_sync.rb
@@ -3,6 +3,7 @@
 module Providers
   module GoogleDrive
     # API Adapter for CRUD operations on Google Drive files
+    # rubocop:disable Metrics/ClassLength
     class FileSync
       attr_reader :id
 
@@ -28,6 +29,12 @@ module Providers
         @children ||= fetch_children_as_file_syncs
       end
 
+      # TODO: Add support for getting content of different file formats
+      def content
+        return nil if deleted?
+        @content ||= fetch_content
+      end
+
       def content_version
         return nil if deleted?
         @content_version ||= fetch_content_version
@@ -35,6 +42,13 @@ module Providers
 
       def deleted?
         file&.trashed
+      end
+
+      # TODO: support duplication without explicit name and parent_id
+      def duplicate(name:, parent_id:)
+        copy =
+          api_connection.duplicate_file(id, name: name, parent_id: parent_id)
+        self.class.new(copy.id, file: copy)
       end
 
       def mime_type
@@ -99,6 +113,11 @@ module Providers
         end
       end
 
+      # Fetch the content
+      def fetch_content
+        api_connection.file_content(id)
+      end
+
       # Fetch the content version
       def fetch_content_version
         api_connection.file_head_revision(id)
@@ -137,4 +156,5 @@ module Providers
       end
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/app/models/providers/google_drive/file_sync.rb
+++ b/app/models/providers/google_drive/file_sync.rb
@@ -49,6 +49,10 @@ module Providers
         file&.parents&.first
       end
 
+      def permissions
+        file&.permissions
+      end
+
       # Relocate the file to a new parent, optionally removing old parent
       def relocate(to:, from:)
         @file =

--- a/app/views/revisions/_file_change.slim
+++ b/app/views/revisions/_file_change.slim
@@ -23,7 +23,7 @@ div.file[class=file_change.symbolic_mime_type
     span.name-and-description
       / print: filename in bold
       b
-        = link_to_file(file_change.current_or_previous_snapshot, project, link_options) do
+        = link_to_file_backup(file_change.current_or_previous_snapshot, link_options) do
           = file_change.name
 
       / print: added/modified/moved/renamed/deleted text

--- a/db/migrate/20181018063101_create_project_archives.rb
+++ b/db/migrate/20181018063101_create_project_archives.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Create archives for storing file copies/blobs
+class CreateProjectArchives < ActiveRecord::Migration[5.1]
+  def change
+    create_table :project_archives do |t|
+      t.belongs_to :project, foreign_key: true, null: false,
+                             index: { unique: true }
+      t.belongs_to :file_resource, foreign_key: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20181018222521_create_file_resource_backups.rb
+++ b/db/migrate/20181018222521_create_file_resource_backups.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Create table for storing file resource backups
+class CreateFileResourceBackups < ActiveRecord::Migration[5.1]
+  def change
+    create_table :file_resource_backups do |t|
+      t.belongs_to :file_resource_snapshot, foreign_key: true,
+                                            null: false,
+                                            index: { unique: true }
+      t.belongs_to :archive, foreign_key: { to_table: :project_archives },
+                             null: false
+      t.belongs_to :file_resource, foreign_key: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180425151936) do
+ActiveRecord::Schema.define(version: 20181018063101) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -209,6 +209,15 @@ ActiveRecord::Schema.define(version: 20180425151936) do
     t.index ["project_id", "profile_id"], name: "index_profiles_projects_on_project_id_and_profile_id", unique: true
   end
 
+  create_table "project_archives", force: :cascade do |t|
+    t.bigint "project_id", null: false
+    t.bigint "file_resource_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["file_resource_id"], name: "index_project_archives_on_file_resource_id"
+    t.index ["project_id"], name: "index_project_archives_on_project_id", unique: true
+  end
+
   create_table "project_setups", force: :cascade do |t|
     t.bigint "project_id", null: false
     t.boolean "is_completed", default: false, null: false
@@ -287,6 +296,8 @@ ActiveRecord::Schema.define(version: 20180425151936) do
   add_foreign_key "file_resources", "file_resource_thumbnails", column: "thumbnail_id"
   add_foreign_key "file_resources", "file_resources", column: "parent_id"
   add_foreign_key "profiles", "accounts"
+  add_foreign_key "project_archives", "file_resources"
+  add_foreign_key "project_archives", "projects"
   add_foreign_key "project_setups", "projects"
   add_foreign_key "resources", "profiles", column: "owner_id"
   add_foreign_key "revisions", "profiles", column: "author_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181018063101) do
+ActiveRecord::Schema.define(version: 20181018222521) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -105,6 +105,17 @@ ActiveRecord::Schema.define(version: 20181018063101) do
     t.index ["file_resource_id"], name: "index_file_diffs_on_file_resource_id"
     t.index ["previous_snapshot_id"], name: "index_file_diffs_on_previous_snapshot_id"
     t.index ["revision_id", "file_resource_id"], name: "index_file_diffs_on_revision_id_and_file_resource_id", unique: true
+  end
+
+  create_table "file_resource_backups", force: :cascade do |t|
+    t.bigint "file_resource_snapshot_id", null: false
+    t.bigint "archive_id", null: false
+    t.bigint "file_resource_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["archive_id"], name: "index_file_resource_backups_on_archive_id"
+    t.index ["file_resource_id"], name: "index_file_resource_backups_on_file_resource_id"
+    t.index ["file_resource_snapshot_id"], name: "index_file_resource_backups_on_file_resource_snapshot_id", unique: true
   end
 
   create_table "file_resource_snapshots", force: :cascade do |t|
@@ -290,6 +301,9 @@ ActiveRecord::Schema.define(version: 20181018063101) do
   add_foreign_key "file_diffs", "file_resource_snapshots", column: "previous_snapshot_id"
   add_foreign_key "file_diffs", "file_resources"
   add_foreign_key "file_diffs", "revisions"
+  add_foreign_key "file_resource_backups", "file_resource_snapshots"
+  add_foreign_key "file_resource_backups", "file_resources"
+  add_foreign_key "file_resource_backups", "project_archives", column: "archive_id"
   add_foreign_key "file_resource_snapshots", "file_resource_thumbnails", column: "thumbnail_id"
   add_foreign_key "file_resource_snapshots", "file_resources", column: "parent_id"
   add_foreign_key "file_resources", "file_resource_snapshots", column: "current_snapshot_id"

--- a/lib/tasks/performance/copy_files.rake
+++ b/lib/tasks/performance/copy_files.rake
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+desc 'Performance: Copy files'
+# rubocop:disable Metrics/BlockLength
+namespace :performance do
+  task copy_files: :environment do
+    connection = Providers::GoogleDrive::ApiConnection.default
+    drive_service = connection.instance_variable_get(:@drive_service)
+
+    source_folder_id = '1-93WT5q7UbzirOr-xow-Fo4hQZ1_3bXp'
+    target_folder_id = '1MQjbCuXiZ6vCnB2Y9ZjAHSbRXsHBJlFX'
+    target_folder = Google::Apis::DriveV3::File.new(parents: [target_folder_id])
+
+    # Fetch all items (files & folders) in source folder
+    files = connection.find_files_by_parent_id(source_folder_id)
+    # Aggregate file IDs (reject folders)
+    file_ids = files.reject do |file|
+      file.mime_type == Providers::GoogleDrive::MimeType.folder
+    end.map(&:id)
+
+    puts "Benchmarking copying files with #{file_ids.count} records"
+    statuses = []
+    time = Benchmark.realtime do
+      threads = []
+      # start 10 threads, each copying an equal share of the files
+      # source: http://heyrod.com/snippets/split-ruby-array-equally.html
+      file_ids.a.each_slice((a.size / 10.to_f).round).to_a do |file_ids_slice|
+        threads << Thread.new do
+          # execute copying as batch request
+          drive_service.batch do |request|
+            file_ids_slice.each do |id|
+              request.copy_file(id, target_folder) do |_file, status|
+                # store status
+                statuses << status
+              end
+            end
+          end
+        end
+      end
+      threads.map(&:join)
+    end
+    puts "Completed in #{time} seconds"
+    puts statuses
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/spec/controllers/file_infos_controller_spec.rb
+++ b/spec/controllers/file_infos_controller_spec.rb
@@ -7,7 +7,7 @@ require 'controllers/shared_examples/setting_project.rb'
 RSpec.describe FileInfosController, type: :controller do
   let(:root)    { create :file_resource, :folder }
   let(:folder)  { create :file_resource, :folder, parent: root }
-  let(:project) { create :project, :setup_complete }
+  let(:project) { create :project, :setup_complete, :skip_archive_setup }
   let(:default_params) do
     {
       profile_handle: project.owner.to_param,

--- a/spec/controllers/folders_controller_spec.rb
+++ b/spec/controllers/folders_controller_spec.rb
@@ -7,7 +7,7 @@ require 'controllers/shared_examples/setting_project.rb'
 RSpec.describe FoldersController, type: :controller do
   let(:root)    { create :file_resource, :folder }
   let(:folder)  { create :file_resource, :folder, parent: root }
-  let(:project) { create :project, :setup_complete }
+  let(:project) { create :project, :setup_complete, :skip_archive_setup }
   let(:default_params) do
     {
       profile_handle: project.owner.to_param,

--- a/spec/controllers/force_syncs_controller_spec.rb
+++ b/spec/controllers/force_syncs_controller_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe ForceSyncsController, type: :controller do
     let(:run_request) { post :create, params: params }
 
     before do
+      allow_any_instance_of(FileResource)
+        .to receive(:backup_on_save?).and_return false
       allow_any_instance_of(FileResource).to receive(:pull)
       allow_any_instance_of(FileResource).to receive(:pull_children)
     end

--- a/spec/controllers/force_syncs_controller_spec.rb
+++ b/spec/controllers/force_syncs_controller_spec.rb
@@ -9,7 +9,7 @@ require 'controllers/shared_examples/setting_project.rb'
 RSpec.describe ForceSyncsController, type: :controller do
   let(:root)    { create :file_resource, :folder }
   let(:folder)  { create :file_resource, :folder, parent: root }
-  let(:project) { create :project, :setup_complete }
+  let(:project) { create :project, :setup_complete, :skip_archive_setup }
   let(:default_params) do
     {
       profile_handle: project.owner.to_param,

--- a/spec/controllers/project_overviews_controller_spec.rb
+++ b/spec/controllers/project_overviews_controller_spec.rb
@@ -4,7 +4,7 @@ require 'controllers/shared_examples/authorizing_project_access.rb'
 require 'controllers/shared_examples/setting_project.rb'
 
 RSpec.describe ProjectOverviewsController, :delayed_job, type: :controller do
-  let!(:project) { create :project }
+  let!(:project) { create :project, :skip_archive_setup }
   let(:default_params) do
     {
       profile_handle: project.owner.to_param,

--- a/spec/controllers/project_setups_controller_spec.rb
+++ b/spec/controllers/project_setups_controller_spec.rb
@@ -7,7 +7,7 @@ require 'controllers/shared_examples/setting_project.rb'
 require 'controllers/shared_examples/successfully_rendering_view.rb'
 
 RSpec.describe ProjectSetupsController, :delayed_job, type: :controller do
-  let!(:project)      { create :project }
+  let!(:project)      { create :project, :skip_archive_setup }
   let(:file_resource) { create :file_resource, :folder }
   let(:link)          { file_resource.external_link }
   let(:default_params) do

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'integrations/shared_contexts/skip_project_archive_setup'
 require 'controllers/shared_examples/a_redirect_with_success.rb'
 require 'controllers/shared_examples/an_authenticated_action.rb'
 require 'controllers/shared_examples/an_authorized_action.rb'
@@ -8,6 +9,8 @@ require 'controllers/shared_examples/raise_404_if_non_existent.rb'
 require 'controllers/shared_examples/setting_project.rb'
 
 RSpec.describe ProjectsController, type: :controller do
+  include_context 'skip project archive setup'
+
   let!(:project)        { create(:project) }
   let(:default_params)  do
     {

--- a/spec/controllers/revisions_controller_spec.rb
+++ b/spec/controllers/revisions_controller_spec.rb
@@ -9,7 +9,7 @@ require 'controllers/shared_examples/setting_project.rb'
 require 'controllers/shared_examples/successfully_rendering_view.rb'
 
 RSpec.describe RevisionsController, type: :controller do
-  let!(:project) { create :project, :setup_complete }
+  let!(:project) { create :project, :setup_complete, :skip_archive_setup }
   let(:default_params) do
     {
       profile_handle: project.owner.to_param,

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -2,8 +2,12 @@
 
 FactoryBot.define do
   factory :account do
+    transient do
+      force_email nil
+    end
+
     user { build(:user, account: Account.new) }
-    email { Faker::Internet.unique.email(user.name) }
+    email { force_email || Faker::Internet.unique.email(user.name) }
     password { Faker::Internet.password(8, 128) }
     admin false
 

--- a/spec/factories/file_resource/file_resource_backups.rb
+++ b/spec/factories/file_resource/file_resource_backups.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :file_resource_backup, class: 'FileResource::Backup' do
+    file_resource_snapshot
+    association :archive, factory: :project_archive
+    file_resource
+  end
+end

--- a/spec/factories/file_resource/snapshots.rb
+++ b/spec/factories/file_resource/snapshots.rb
@@ -16,5 +16,12 @@ FactoryBot.define do
     trait :pdf do
       mime_type { Providers::GoogleDrive::MimeType.pdf }
     end
+
+    trait :with_backup do
+      backup do
+        build(:file_resource_backup,
+              file_resource_snapshot: FileResource::Snapshot.new)
+      end
+    end
   end
 end

--- a/spec/factories/profiles/base.rb
+++ b/spec/factories/profiles/base.rb
@@ -2,9 +2,16 @@
 
 FactoryBot.define do
   factory :profiles_base do
+    transient do
+      account_email nil
+    end
+
     name      { Faker::Name.name }
     about     { Faker::Lorem.paragraph }
-    account   { build(:account, user: Profiles::User.new(name: name)) }
+    account do
+      build(:account, user: Profiles::User.new(name: name),
+                      force_email: account_email)
+    end
     handle    { Faker::Internet.user_name(name.first(26).strip, %w[_]) }
     location  { "#{city}, #{state}, USA" }
 

--- a/spec/factories/project/archives.rb
+++ b/spec/factories/project/archives.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :project_archive, class: 'Project::Archive' do
-    project
+    association :project, :skip_archive_setup
     file_resource
   end
 end

--- a/spec/factories/project/archives.rb
+++ b/spec/factories/project/archives.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :project_archive, class: 'Project::Archive' do
+    project
+    file_resource
+  end
+end

--- a/spec/factories/project/archives.rb
+++ b/spec/factories/project/archives.rb
@@ -2,7 +2,15 @@
 
 FactoryBot.define do
   factory :project_archive, class: 'Project::Archive' do
-    association :project, :skip_archive_setup
+    transient do
+      project_owner_account_email nil
+    end
+
+    project do
+      build(:project,
+            :skip_archive_setup,
+            owner_account_email: project_owner_account_email)
+    end
     file_resource
   end
 end

--- a/spec/factories/project/setups.rb
+++ b/spec/factories/project/setups.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :project_setup, class: 'Project::Setup' do
-    project
+    association :project, :skip_archive_setup
     is_completed false
     link { '' }
 

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -2,13 +2,17 @@
 
 FactoryBot.define do
   factory :project do
+    transient do
+      owner_account_email nil
+    end
+
     sequence(:title) do |n|
       "#{n} #{Faker::HitchhikersGuideToTheGalaxy.starship}".first(50).strip
     end
     description     { Faker::Lorem.paragraph }
     tags            { Faker::Lorem.words }
     sequence(:slug) { |n| "project-slug-#{n}" }
-    owner           { build(:user) }
+    owner           { build(:user, account_email: owner_account_email) }
     is_public       false
 
     trait :public do
@@ -19,6 +23,10 @@ FactoryBot.define do
       after(:create) do |project|
         create(:project_setup, :completed, project: project)
       end
+    end
+
+    trait :skip_archive_setup do
+      skip_archive_setup true
     end
   end
 end

--- a/spec/factories/revisions.rb
+++ b/spec/factories/revisions.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :revision do
     author
-    project
+    association :project, :skip_archive_setup
     title         { Faker::HarryPotter.quote }
     summary       { Faker::Lorem.paragraph }
     is_published  false

--- a/spec/factories/stage/file_diffs.rb
+++ b/spec/factories/stage/file_diffs.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :staged_file_diff, class: Stage::FileDiff do
-    project
+    association :project, :skip_archive_setup
     association :staged_snapshot, factory: :file_resource_snapshot
     association :committed_snapshot, factory: :file_resource_snapshot
   end

--- a/spec/factories/staged_files.rb
+++ b/spec/factories/staged_files.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :staged_file do
-    project
+    association :project, :skip_archive_setup
     file_resource
     is_root false
 

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -67,7 +67,7 @@ feature 'Account' do
     # given I am a signed-in user
     account = create(:account)
     # and have lots of data (this is to test foreign key constraints)
-    create_list(:project, 3, owner: account.user)
+    create_list(:project, 3, :skip_archive_setup, owner: account.user)
     # sign in
     sign_in_as account
     # and I am on the homepage

--- a/spec/features/collaborator_spec.rb
+++ b/spec/features/collaborator_spec.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 feature 'Collaborators' do
+  let(:project) { create(:project, :skip_archive_setup) }
+
   scenario 'As a collaborator, the project is listed on my profile' do
     # given there is a project
-    project = create :project
+    project
     # and I am signed in as a user
     me = create :user
     sign_in_as me.account
@@ -19,7 +21,7 @@ feature 'Collaborators' do
 
   scenario 'As a collaborator, I can view a private project' do
     # given there is a project
-    project = create :project
+    project
     # and I am signed in as a user
     me = create :user
     sign_in_as me.account
@@ -37,7 +39,7 @@ feature 'Collaborators' do
 
   scenario 'As a collaborator, I can setup a project' do
     # given there is a project
-    project = create :project
+    project
     # and I am signed in as a user
     me = create :user
     sign_in_as me.account
@@ -57,8 +59,9 @@ feature 'Collaborators' do
   end
 
   scenario 'As a collaborator, I can create a new revision' do
-    # given there is a project
-    project = create :project, :setup_complete
+    # given there is a project with complete setup
+    project
+    create(:project_setup, :completed, project: project)
     # and I am signed in as a user
     me = create :user
     sign_in_as me.account

--- a/spec/features/file_info_spec.rb
+++ b/spec/features/file_info_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 feature 'File Info' do
-  let(:project) { create :project, :setup_complete }
+  let(:project) { create :project, :setup_complete, :skip_archive_setup }
   let(:root)    { create :file_resource, :folder }
   before { project.root_folder = root }
   before { sign_in_as project.owner.account }

--- a/spec/features/file_update_spec.rb
+++ b/spec/features/file_update_spec.rb
@@ -22,7 +22,7 @@ feature 'File Update', :vcr do
     allow_any_instance_of(FileUpdateJob).to receive(:list_changes_on_next_page)
   end
 
-  let(:current_account) { create :account }
+  let(:current_account) { create :account, email: user_acct }
   let(:project) { create :project, owner: current_account.user }
   let(:setup) { create :project_setup, link: link_to_folder, project: project }
   let(:link_to_folder) do

--- a/spec/features/folder_import_spec.rb
+++ b/spec/features/folder_import_spec.rb
@@ -50,5 +50,8 @@ feature 'Folder Import', :vcr do
     # and I should see one revision
     click_on 'Revisions'
     expect(page).to have_text 'Import Files'
+
+    # and have 3 files in archive
+    expect(project.archive.backups.count).to eq 3
   end
 end

--- a/spec/features/folder_import_spec.rb
+++ b/spec/features/folder_import_spec.rb
@@ -53,5 +53,9 @@ feature 'Folder Import', :vcr do
 
     # and have 3 files in archive
     expect(project.archive.backups.count).to eq 3
+    external_archive =
+      Providers::GoogleDrive::FileSync
+      .new(project.archive.file_resource.external_id)
+    expect(external_archive.children.count).to eq 3
   end
 end

--- a/spec/features/folder_import_spec.rb
+++ b/spec/features/folder_import_spec.rb
@@ -13,7 +13,9 @@ feature 'Folder Import', :vcr do
 
   scenario 'Files are imported' do
     # given there is a project
-    project = create(:project, title: 'My Awesome New Project!')
+    project = create(:project,
+                     title: 'My Awesome New Project!',
+                     owner_account_email: user_acct)
 
     # and a Google Drive folder that contains three files
     3.times do

--- a/spec/features/folder_spec.rb
+++ b/spec/features/folder_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 feature 'Folder' do
-  let(:project) { create :project, :setup_complete }
+  let(:project) { create :project, :setup_complete, :skip_archive_setup }
   let(:root)    { create :file_resource, :folder }
   let(:files)   { create_list :file_resource, 5, parent: root }
   let(:create_revision) do

--- a/spec/features/force_sync_spec.rb
+++ b/spec/features/force_sync_spec.rb
@@ -59,5 +59,15 @@ feature 'Force Sync', :vcr do
     expect(page).to have_css '.file.modification', text: 'Doc ABC'
     expect(page).to have_css '.file.rename', text: 'Doc ABC'
     expect(page).to have_css '.file.movement', text: 'Doc ABC'
+
+    # and have a backup of the file
+    # TODO: Refactor
+    file_snapshot = FileResource.find_by_external_id(file.id).current_snapshot
+    external_id_of_backup = file_snapshot.backup.file_resource.external_id
+    external_backup =
+      Providers::GoogleDrive::FileSync.new(external_id_of_backup)
+    expect(external_backup.name).to eq(file_snapshot.name)
+    expect(external_backup.parent_id)
+      .to eq(project.archive.file_resource.external_id)
   end
 end

--- a/spec/features/force_sync_spec.rb
+++ b/spec/features/force_sync_spec.rb
@@ -16,7 +16,7 @@ feature 'Force Sync', :vcr do
   # delete test folder
   after { tear_down_google_drive_test(api_connection) }
 
-  let(:current_account) { create :account }
+  let(:current_account) { create :account, email: user_acct }
   let(:project) { create :project, owner: current_account.user }
   let(:setup) { create :project_setup, link: link_to_folder, project: project }
   let(:link_to_folder) do

--- a/spec/features/notification_spec.rb
+++ b/spec/features/notification_spec.rb
@@ -22,7 +22,7 @@ feature 'Notification' do
     # given I have an account
     account = create :account
     # and there is a project with a revision
-    project = create :project, :setup_complete
+    project = create :project, :setup_complete, :skip_archive_setup
     revision = create :revision, project: project
     # and I have a notification for the revision
     create(:notification, target: account, notifiable: revision)

--- a/spec/features/project_spec.rb
+++ b/spec/features/project_spec.rb
@@ -23,6 +23,8 @@ feature 'Project' do
     expect(page).to have_text 'My Awesome New Project!'
     # and see a success message
     expect(page).to have_text 'Project successfully created.'
+    # and have set up an archive folder on Google Drive
+    expect(Project.first.archive).to be_present
   end
 
   scenario 'User can view project' do

--- a/spec/features/revision_spec.rb
+++ b/spec/features/revision_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 feature 'Revision' do
-  let(:project) { create :project, :setup_complete }
+  let(:project) { create :project, :setup_complete, :skip_archive_setup }
   let(:root)    { create :file_resource, :folder }
   before { project.root_folder = root }
   let(:create_revision) do

--- a/spec/features/session_spec.rb
+++ b/spec/features/session_spec.rb
@@ -45,7 +45,7 @@ feature 'Session' do
     # given I have an account but I am not logged in
     account = create :account
     # and there is a project that I want to visit
-    project = create :project, :public
+    project = create :project, :public, :skip_archive_setup
 
     # when I visit a project page
     visit profile_project_path(project.owner, project)

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -5,7 +5,7 @@ feature 'User' do
     # given there is a user
     user = create(:user)
     # with three projects
-    projects = create_list(:project, 3, owner: user)
+    projects = create_list(:project, 3, :skip_archive_setup, owner: user)
 
     # when I visit the user profile
     visit "/#{user.handle}"

--- a/spec/helpers/file_helper_spec.rb
+++ b/spec/helpers/file_helper_spec.rb
@@ -65,4 +65,59 @@ RSpec.describe FileHelper, type: :helper do
       end
     end
   end
+
+  describe '#link_to_file_backup(file_snapshot, options = {}, &block)' do
+    subject(:method)  { helper.link_to_file_backup(snapshot) {} }
+    let(:snapshot)    { instance_double FileResource::Snapshot }
+    let(:backup)      { instance_double FileResource::Backup }
+    let(:file)        { instance_double FileResource }
+
+    before do
+      allow(snapshot).to receive(:backup).and_return backup
+      allow(backup).to receive(:file_resource).and_return(file) if backup
+      allow(file).to receive(:external_link).and_return 'external-link'
+    end
+
+    it 'returns url to backup' do
+      expect(helper).to receive(:link_to).with('external-link', kind_of(Hash))
+      method
+    end
+
+    it 'sets target to _blank' do
+      expect(helper).to receive(:link_to).with(
+        kind_of(String),
+        hash_including(target: '_blank')
+      )
+      method
+    end
+
+    context 'when file does not have backup' do
+      let(:backup) { nil }
+
+      it 'returns content tag span' do
+        expect(helper).to receive(:content_tag).with(:span)
+        method
+      end
+    end
+
+    context 'when options are passed' do
+      subject(:method)  { helper.link_to_file_backup(snapshot, options) {} }
+      let(:options)     { {} }
+
+      it 'does not modify the passed options hash' do
+        expect { method }.not_to(change { options })
+      end
+
+      context "when options include target: '_blank'" do
+        let(:options) { { target: '_blank' } }
+
+        it 'passes options to #link_to' do
+          expect(helper)
+            .to receive(:link_to)
+            .with(kind_of(String), hash_including(target: '_blank'))
+          method
+        end
+      end
+    end
+  end
 end

--- a/spec/integrations/file_diff/changes/deletion_spec.rb
+++ b/spec/integrations/file_diff/changes/deletion_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
+require 'integrations/shared_contexts/skip_project_archive_setup'
+
 RSpec.describe FileDiff::Changes::Deletion, type: :model do
+  include_context 'skip project archive setup'
+
   subject             { revision }
   let(:change)        { file_diffs.find(diff.id).changes.first }
   let(:child1_change) { file_diffs.find(child1_diff.id).changes.first }

--- a/spec/integrations/file_resource/backup_spec.rb
+++ b/spec/integrations/file_resource/backup_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+RSpec.describe FileResource::Backup, type: :model do
+  let(:project)         { build(:project, title: 'Demo', owner: owner) }
+  let(:owner)           { build(:user, account: account) }
+  let(:account)         { build(:account, email: account_email) }
+  let(:account_email)   { ENV['GOOGLE_DRIVE_USER_ACCOUNT'] }
+  let(:external_folder) { archive.file_resource }
+
+  describe '#capture', :vcr do
+    before  { prepare_google_drive_test }
+    after   { tear_down_google_drive_test }
+
+    subject(:backup) do
+      FileResource::Backup
+        .new(archive: archive, file_resource_snapshot: snapshot)
+    end
+
+    let(:user_acct)     { ENV['GOOGLE_DRIVE_USER_ACCOUNT'] }
+    let(:snapshot)      { file_resource.current_snapshot }
+    let(:file_name)     { 'An Awesome File' }
+    let(:file_resource) do
+      FileResources::GoogleDrive
+        .new(external_id: external_file.id).tap(&:pull)
+    end
+    let(:external_file) do
+      Providers::GoogleDrive::FileSync.create(
+        name: file_name,
+        parent_id: google_drive_test_folder_id,
+        mime_type: Providers::GoogleDrive::MimeType.document
+      )
+    end
+    let(:archive_folder_id) { archive.file_resource.external_id }
+    let(:archive)           { project.archive }
+    let(:project)           { create(:project, owner_account_email: user_acct) }
+
+    before { backup.capture }
+
+    after do
+      # cleanup
+      Providers::GoogleDrive::ApiConnection
+        .default.delete_file(archive_folder_id)
+    end
+
+    it 'stores a copy of the file snapshot in archive' do
+      backup.file_resource.fetch
+      expect(backup.file_resource).to have_attributes(
+        name: file_name,
+        parent: FileResource.find_by_external_id(archive_folder_id)
+      )
+    end
+
+    it 'inherits access permissions from archive folder' do
+      archive_permissions_hash =
+        Providers::GoogleDrive::FileSync
+        .new(archive.file_resource.external_id)
+        .permissions
+        .map(&:to_h)
+      backup_permissions_hash =
+        Providers::GoogleDrive::FileSync
+        .new(backup.file_resource.external_id)
+        .permissions
+        .map(&:to_h)
+      expect(backup_permissions_hash).to match_array(archive_permissions_hash)
+    end
+  end
+end

--- a/spec/integrations/file_resources/google_drive_spec.rb
+++ b/spec/integrations/file_resources/google_drive_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'integrations/shared_contexts/skip_project_archive_setup'
 require 'integrations/shared_examples/including_snapshotable_integration.rb'
 require 'integrations/shared_examples/including_stageable_integration.rb'
 require 'integrations/shared_examples/including_syncable_integration.rb'
@@ -34,6 +35,8 @@ RSpec.describe FileResources::GoogleDrive, type: :model do
   end
 
   describe 'snapshotable + stageable + syncable', :vcr do
+    include_context 'skip project archive setup'
+
     before { prepare_google_drive_test }
     after  { tear_down_google_drive_test }
     let!(:file_sync) do

--- a/spec/integrations/project/archive_spec.rb
+++ b/spec/integrations/project/archive_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe Project::Archive, type: :model do
+  subject(:archive)     { Project::Archive.new(project: project) }
+  let(:project)         { build(:project, title: 'Demo', owner: owner) }
+  let(:owner)           { build(:user, account: account) }
+  let(:account)         { build(:account, email: account_email) }
+  let(:account_email)   { ENV['GOOGLE_DRIVE_USER_ACCOUNT'] }
+  let(:external_folder) { archive.file_resource }
+
+  describe '#setup', :vcr do
+    before  { prepare_google_drive_test }
+    after   { tear_down_google_drive_test }
+
+    let(:remote_folder_id) { external_folder.external_id }
+
+    before { archive.setup }
+    after do
+      # cleanup
+      Providers::GoogleDrive::ApiConnection
+        .default.delete_file(remote_folder_id)
+    end
+
+    it 'creates a folder in Google Drive' do
+      folder = FileResources::GoogleDrive.new(external_id: remote_folder_id)
+      folder.fetch
+      expect(folder).to have_attributes(
+        name: "#{project.title} (Archive)",
+        mime_type: Providers::GoogleDrive::MimeType.folder,
+        parent_id: nil
+      )
+    end
+
+    it 'shares view access to the archive with the repository owner' do
+      folder = Providers::GoogleDrive::FileSync.new(remote_folder_id)
+      expect(folder.permissions.count).to eq 2
+      expect(folder.permissions).to be_any do |permission|
+        permission.role == 'reader' &&
+          permission.email_address == account_email
+      end
+    end
+  end
+end

--- a/spec/integrations/project_spec.rb
+++ b/spec/integrations/project_spec.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe Project, type: :model do
-  subject(:project) { create :project }
+  subject(:project)         { create :project }
+  let(:skip_archive_setup)  { true }
+
+  before do
+    next unless skip_archive_setup
+    allow_any_instance_of(Project::Archive).to receive(:setup)
+  end
 
   describe 'deleteable', :delayed_job do
     before do

--- a/spec/integrations/providers/google_drive/file_sync_spec.rb
+++ b/spec/integrations/providers/google_drive/file_sync_spec.rb
@@ -31,6 +31,11 @@ RSpec.describe Providers::GoogleDrive::FileSync, type: :model, vcr: true do
     it 'sets mime type to document' do
       expect(created_file.mime_type).to eq document_type
     end
+
+    it 'restricts access to creator' do
+      expect(created_file.permissions.map(&:email_address))
+        .to contain_exactly(Settings.google_drive_tracking_account)
+    end
   end
 
   describe '#content_version' do

--- a/spec/integrations/providers/google_drive/file_sync_spec.rb
+++ b/spec/integrations/providers/google_drive/file_sync_spec.rb
@@ -38,6 +38,28 @@ RSpec.describe Providers::GoogleDrive::FileSync, type: :model, vcr: true do
     end
   end
 
+  describe '#content' do
+    subject(:file_with_content) do
+      described_class.create(
+        name: 'A File with Content',
+        parent_id: google_drive_test_folder_id,
+        mime_type: Providers::GoogleDrive::MimeType.document
+      )
+    end
+
+    let(:content) { "Super super amazing content!\r\nHello world!" }
+
+    before do
+      # Write content to the file
+      Providers::GoogleDrive::ApiConnection
+        .default.update_file_content(file_with_content.id, content)
+    end
+
+    it 'retrieves the content' do
+      expect(file_with_content.content).to eq(content)
+    end
+  end
+
   describe '#content_version' do
     subject(:content_version) do
       described_class.new(file_sync.id).content_version
@@ -66,6 +88,43 @@ RSpec.describe Providers::GoogleDrive::FileSync, type: :model, vcr: true do
     context 'when file is folder' do
       let(:mime_type) { Providers::GoogleDrive::MimeType.folder }
       it { is_expected.to eq 1 }
+    end
+  end
+
+  describe '#duplicate(name:, parent_id:)' do
+    subject(:duplicated_file) { @duplicated_file }
+
+    let(:original_file) do
+      described_class.create(
+        name: 'Test File',
+        parent_id: google_drive_test_folder_id,
+        mime_type: Providers::GoogleDrive::MimeType.document
+      )
+    end
+
+    let(:subfolder) do
+      described_class.create(
+        name: 'Subfolder',
+        parent_id: google_drive_test_folder_id,
+        mime_type: Providers::GoogleDrive::MimeType.folder
+      )
+    end
+
+    before do
+      # Write content to the original file
+      Providers::GoogleDrive::ApiConnection
+        .default
+        .update_file_content(original_file.id, "Amazing content!\r\nYes!")
+
+      # Duplicate the file
+      @duplicated_file =
+        original_file.duplicate(name: 'Duplicate', parent_id: subfolder.id)
+    end
+
+    it 'duplicates the file' do
+      expect(duplicated_file.content).to eq(original_file.content)
+      expect(duplicated_file.name).to eq 'Duplicate'
+      expect(duplicated_file.parent_id).to eq subfolder.id
     end
   end
 

--- a/spec/integrations/revision_spec.rb
+++ b/spec/integrations/revision_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
+require 'integrations/shared_contexts/skip_project_archive_setup'
+
 RSpec.describe Revision, type: :model do
+  include_context 'skip project archive setup'
+
   subject(:revision) { build(:revision) }
 
   describe 'notifications' do

--- a/spec/integrations/shared_contexts/skip_project_archive_setup.rb
+++ b/spec/integrations/shared_contexts/skip_project_archive_setup.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'skip project archive setup' do
+  before { allow_any_instance_of(Project::Archive).to receive(:setup) }
+end

--- a/spec/integrations/shared_examples/including_stageable_integration.rb
+++ b/spec/integrations/shared_examples/including_stageable_integration.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
+require 'integrations/shared_contexts/skip_project_archive_setup'
+
 RSpec.shared_examples 'including stageable integration' do
+  include_context 'skip project archive setup'
+
   subject(:staged_projects) { stageable.staging_projects.to_a }
   let(:p1) { create :project }
   let(:p2) { create :project }

--- a/spec/integrations/stage/file_diff/ancestry_spec.rb
+++ b/spec/integrations/stage/file_diff/ancestry_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
+require 'integrations/shared_contexts/skip_project_archive_setup'
+
 RSpec.describe Stage::FileDiff::Ancestry, type: :model do
+  include_context 'skip project archive setup'
+
   describe '.for(file_resource_snapshot:, project:)' do
     subject(:ancestors) do
       described_class.for(file_resource_snapshot: snapshot, project: project)

--- a/spec/integrations/stage/file_diff/children_query_spec.rb
+++ b/spec/integrations/stage/file_diff/children_query_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
+require 'integrations/shared_contexts/skip_project_archive_setup'
+
 RSpec.describe Stage::FileDiff::ChildrenQuery, type: :model do
+  include_context 'skip project archive setup'
+
   subject(:diffs) do
     described_class.new(project: project, parent_id: folder.id)
   end

--- a/spec/integrations/stage/file_diff_spec.rb
+++ b/spec/integrations/stage/file_diff_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
+require 'integrations/shared_contexts/skip_project_archive_setup'
+
 RSpec.describe Stage::FileDiff, type: :model do
+  include_context 'skip project archive setup'
+
   describe '#find_by!(external_id:, project:)' do
     subject(:find) do
       Stage::FileDiff.find_by!(external_id: external_id, project: project)

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Ability, type: :model do
 
   context 'Revisions' do
     actions = %i[new create]
-    let(:project)   { create :project }
+    let(:project)   { create :project, :skip_archive_setup }
     let(:revision)  { project.repository.build_revision }
     let(:object)    { [:revision, project] }
 

--- a/spec/models/file_resource/backup_spec.rb
+++ b/spec/models/file_resource/backup_spec.rb
@@ -44,6 +44,41 @@ RSpec.describe FileResource::Backup, type: :model do
     end
   end
 
+  describe '.backup(file_resource_to_backup)' do
+    subject(:method) { described_class.backup(file_resource) }
+
+    let(:file_resource) { instance_double FileResource }
+    let(:new_backup)    { instance_double described_class }
+    let(:p1)            { instance_double Project }
+    let(:p2)            { instance_double Project }
+
+    before do
+      allow(file_resource).to receive(:current_snapshot).and_return 'snapshot'
+      allow(file_resource).to receive(:staging_projects).and_return [p1, p2]
+      allow(p1).to receive(:archive).and_return 'archive'
+      allow(described_class).to receive(:new).with(
+        file_resource_snapshot: 'snapshot',
+        archive: 'archive'
+      ).and_return new_backup
+      allow(new_backup).to receive(:capture)
+      allow(new_backup).to receive(:save)
+    end
+
+    it 'calls capture on new backup' do
+      method
+      expect(new_backup).to have_received(:capture)
+    end
+
+    it 'calls save on new backup' do
+      method
+      expect(new_backup).to have_received(:save)
+    end
+
+    it 'returns the new backup' do
+      is_expected.to eq new_backup
+    end
+  end
+
   describe '#capture' do
     subject(:method) { backup.capture }
 

--- a/spec/models/file_resource/backup_spec.rb
+++ b/spec/models/file_resource/backup_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.describe FileResource::Backup, type: :model do
+  subject(:backup) { build_stubbed :file_resource_backup }
+
+  describe 'associations' do
+    it do
+      is_expected
+        .to belong_to(:file_resource_snapshot)
+        .class_name('FileResource::Snapshot')
+        .validate(false)
+        .dependent(false)
+    end
+    it do
+      is_expected
+        .to belong_to(:archive)
+        .class_name('Project::Archive')
+        .validate(false)
+        .dependent(false)
+    end
+    it do
+      is_expected.to belong_to(:file_resource).validate(false).dependent(false)
+    end
+  end
+
+  describe 'validations' do
+    subject(:backup) { build :file_resource_backup }
+
+    it do
+      is_expected
+        .to validate_presence_of(:file_resource_snapshot)
+        .with_message('must exist')
+    end
+    it do
+      is_expected
+        .to validate_presence_of(:archive).with_message('must exist')
+    end
+
+    it do
+      is_expected
+        .to validate_uniqueness_of(:file_resource_snapshot_id)
+        .with_message('already has a backup')
+        .case_insensitive
+    end
+  end
+end

--- a/spec/models/file_resource/backup_spec.rb
+++ b/spec/models/file_resource/backup_spec.rb
@@ -157,12 +157,19 @@ RSpec.describe FileResource::Backup, type: :model do
   describe '#create_file_resource!(external_id)' do
     subject(:method) { backup.send(:create_file_resource!, 'ext-id') }
 
+    let(:snapshot) { instance_double FileResource::Snapshot }
+
+    before do
+      allow(backup).to receive(:file_resource_snapshot).and_return snapshot
+      allow(snapshot).to receive(:mime_type).and_return 'mime-type-of-snapshot'
+    end
+
     it 'creates a FileResource' do
       method
       expect(FileResource).to exist(
         external_id: 'ext-id',
         name: 'Backup',
-        mime_type: 'Backup',
+        mime_type: 'mime-type-of-snapshot',
         content_version: 0
       )
     end

--- a/spec/models/file_resource/snapshot_spec.rb
+++ b/spec/models/file_resource/snapshot_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe FileResource::Snapshot, type: :model do
     end
     it do
       is_expected
+        .to have_one(:backup)
+        .class_name('FileResource::Backup')
+        .dependent(:destroy)
+    end
+    it do
+      is_expected
         .to have_many(:committing_files)
         .class_name('CommittedFile')
         .with_foreign_key(:file_resource_snapshot_id)

--- a/spec/models/file_resources/google_drive_spec.rb
+++ b/spec/models/file_resources/google_drive_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'models/shared_examples/being_a_file_resource.rb'
+require 'models/shared_examples/being_backupable.rb'
 require 'models/shared_examples/being_resourceable.rb'
 require 'models/shared_examples/being_snapshotable.rb'
 require 'models/shared_examples/being_stageable.rb'
@@ -12,6 +13,10 @@ RSpec.describe FileResources::GoogleDrive, type: :model do
   it_should_behave_like 'being a file resource' do
     let(:file_resource) { file }
     let(:mime_type_class) { Providers::GoogleDrive::MimeType }
+  end
+
+  it_should_behave_like 'being backupable' do
+    let(:backupable) { file }
   end
 
   it_should_behave_like 'being resourceable' do

--- a/spec/models/project/archive_spec.rb
+++ b/spec/models/project/archive_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe Project::Archive, type: :model do
+  subject(:archive) { build_stubbed :project_archive }
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:project).validate(false).dependent(false) }
+    it do
+      is_expected.to belong_to(:file_resource).validate(false).dependent(false)
+    end
+  end
+
+  describe 'validations' do
+    subject(:archive) { build :project_archive }
+
+    it do
+      is_expected.to validate_presence_of(:project).with_message('must exist')
+    end
+    it do
+      is_expected
+        .to validate_presence_of(:file_resource).with_message('must exist')
+    end
+
+    it do
+      is_expected
+        .to validate_uniqueness_of(:project_id)
+        .with_message('already has an archive')
+        .case_insensitive
+    end
+  end
+end

--- a/spec/models/project/archive_spec.rb
+++ b/spec/models/project/archive_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe Project::Archive, type: :model do
     it do
       is_expected.to belong_to(:file_resource).validate(false).dependent(false)
     end
+    it do
+      is_expected
+        .to have_many(:backups)
+        .class_name('FileResource::Backup')
+        .dependent(:destroy)
+    end
   end
 
   describe 'validations' do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe Project, type: :model do
         .conditions(is_published: true)
         .dependent(false)
     end
+    it { is_expected.to have_one(:archive).dependent(:destroy) }
   end
 
   describe 'attributes' do

--- a/spec/models/providers/google_drive/file_sync_spec.rb
+++ b/spec/models/providers/google_drive/file_sync_spec.rb
@@ -128,6 +128,30 @@ RSpec.describe Providers::GoogleDrive::FileSync, type: :model do
     end
   end
 
+  describe '#duplicate(name:, parent_id:)' do
+    subject(:duplicate) { file_sync.duplicate(name: 'abc', parent_id: 'p-id') }
+
+    let(:file) { Google::Apis::DriveV3::File.new(id: 'dup-id') }
+
+    before  { file_sync.instance_variable_set :@id, 'id' }
+    before  { allow(api).to receive(:duplicate_file).and_return file }
+    after   { duplicate }
+
+    it 'duplicates the file' do
+      duplicate
+      expect(api)
+        .to have_received(:duplicate_file)
+        .with('id', name: 'abc', parent_id: 'p-id')
+    end
+
+    it 'returns new instance with dup-id and @file' do
+      expect(duplicate).to be_an_instance_of(described_class)
+      expect(duplicate).not_to equal file_sync
+      expect(duplicate.id).to eq 'dup-id'
+      expect(duplicate.instance_variable_get(:@file)).to be_present
+    end
+  end
+
   describe '#mime_type' do
     subject(:mime_type) { file_sync.mime_type }
     let(:file)          { Google::Apis::DriveV3::File.new(mime_type: 'type') }

--- a/spec/models/providers/google_drive/file_sync_spec.rb
+++ b/spec/models/providers/google_drive/file_sync_spec.rb
@@ -177,6 +177,24 @@ RSpec.describe Providers::GoogleDrive::FileSync, type: :model do
     end
   end
 
+  describe '#permissions' do
+    subject(:permissions) { file_sync.permissions }
+
+    let(:file)  { Google::Apis::DriveV3::File.new(permissions: [p1, p2]) }
+    let(:p1)    { instance_double Google::Apis::DriveV3::Permission }
+    let(:p2)    { instance_double Google::Apis::DriveV3::Permission }
+
+    before { allow(file_sync).to receive(:file).and_return file }
+
+    it { is_expected.to contain_exactly(p1, p2) }
+
+    context 'when file is not is set' do
+      let(:file) { nil }
+
+      it { is_expected.to eq nil }
+    end
+  end
+
   describe '#relocate(to:, from:)' do
     subject(:relocate) { file_sync.relocate(to: 'to', from: 'from') }
     before  { file_sync.instance_variable_set :@id, 'id' }

--- a/spec/models/shared_examples/being_backupable.rb
+++ b/spec/models/shared_examples/being_backupable.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'being backupable' do
+  describe 'callbacks' do
+    describe 'after save' do
+      subject { backupable }
+
+      before do
+        allow(backupable).to receive(:perform_backup)
+        allow(backupable).to receive(:backup_on_save?).and_return backup_on_save
+        backupable.save
+      end
+
+      context 'when backup_on_save? is true' do
+        let(:backup_on_save) { true }
+
+        it { is_expected.to have_received(:perform_backup) }
+      end
+
+      context 'when backup_on_save? is false' do
+        let(:backup_on_save) { false }
+
+        it { is_expected.not_to have_received(:perform_backup) }
+      end
+    end
+  end
+
+  describe '#backed_up?' do
+    subject { backupable }
+
+    let(:snapshot)      { instance_double FileResource::Snapshot }
+    let(:backup)        { instance_double FileResource::Backup }
+    let(:is_persisted)  { false }
+
+    before do
+      allow(backupable).to receive(:current_snapshot).and_return snapshot
+      next unless snapshot.present?
+      allow(snapshot).to receive(:backup).and_return backup
+      next unless backup.present?
+      allow(backup).to receive(:persisted?).and_return is_persisted
+    end
+
+    it { is_expected.not_to be_backed_up }
+
+    context 'when backup is persisted' do
+      let(:is_persisted) { true }
+
+      it { is_expected.to be_backed_up }
+    end
+
+    context 'when current_snapshot is nil' do
+      let(:snapshot) { nil }
+
+      it { is_expected.not_to be_backed_up }
+    end
+
+    context 'when backup of current_snapshot is present' do
+      let(:backup) { nil }
+
+      it { is_expected.not_to be_backed_up }
+    end
+  end
+
+  describe '#backup_on_save?' do
+    subject { backupable }
+
+    let(:is_folder)     { false }
+    let(:is_deleted)    { false }
+    let(:is_backed_up)  { false }
+
+    before do
+      allow(backupable).to receive(:folder?).and_return is_folder
+      allow(backupable).to receive(:deleted?).and_return is_deleted
+      allow(backupable).to receive(:backed_up?).and_return is_backed_up
+    end
+
+    it { is_expected.to be_backup_on_save }
+
+    context 'when folder' do
+      let(:is_folder) { true }
+
+      it { is_expected.not_to be_backup_on_save }
+    end
+
+    context 'when deleted' do
+      let(:is_deleted) { true }
+
+      it { is_expected.not_to be_backup_on_save }
+    end
+
+    context 'when backed up' do
+      let(:is_backed_up) { true }
+
+      it { is_expected.not_to be_backup_on_save }
+    end
+  end
+
+  describe '#perform_backup' do
+    subject(:method) { backupable.send(:perform_backup) }
+
+    it 'calls .backup on FileResource::Backup with self' do
+      expect(FileResource::Backup).to receive(:backup).with(backupable)
+      method
+    end
+
+    it 'returns true' do
+      allow(FileResource::Backup).to receive(:backup).and_return 'some-output'
+      expect(method).to be true
+    end
+  end
+end

--- a/spec/support/fixtures/vcr_cassettes/FileResource_Backup/_capture/inherits_access_permissions_from_archive_folder.yml
+++ b/spec/support/fixtures/vcr_cassettes/FileResource_Backup/_capture/inherits_access_permissions_from_archive_folder.yml
@@ -1,0 +1,981 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://www.googleapis.com/oauth2/v4/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR TRACKING ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.14.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Fri, 19 Oct 2018 08:03:39 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:03:39 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-19
+        08:03:39 UTC","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:03:39 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:03:40 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1K4XhPKsF75puVhuxYB0rueAitJTQJqh7",
+         "name": "Test @ 2018-10-19 08:03:39 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:03:40 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"1 Golgafrinchan
+        Ark Fleet Ship B (Archive)","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:03:40 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:03:41 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1LVmseHP2C4EPlo87Dsv4o_X_C6Iu4hgc",
+         "name": "1 Golgafrinchan Ark Fleet Ship B (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:03:41 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1LVmseHP2C4EPlo87Dsv4o_X_C6Iu4hgc/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:03:41 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:03:42 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "13193959451567607887",
+         "type": "user",
+         "role": "reader"
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:03:42 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1LVmseHP2C4EPlo87Dsv4o_X_C6Iu4hgc?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:03:42 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 19 Oct 2018 08:03:43 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:03:43 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1LVmseHP2C4EPlo87Dsv4o_X_C6Iu4hgc",
+         "name": "1 Golgafrinchan Ark Fleet Ship B (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:03:43 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1LVmseHP2C4EPlo87Dsv4o_X_C6Iu4hgc/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:03:43 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Fri, 19 Oct 2018 08:03:43 GMT
+      Expires:
+      - Fri, 19 Oct 2018 08:03:43 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:03:43 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"An Awesome
+        File","parents":["1K4XhPKsF75puVhuxYB0rueAitJTQJqh7"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:03:43 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:03:44 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1EnhPFw9YZiE5EVZQs2IxlNoLeiJSGEStmT0I2NwLyKc",
+         "name": "An Awesome File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1K4XhPKsF75puVhuxYB0rueAitJTQJqh7"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:03:45 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1EnhPFw9YZiE5EVZQs2IxlNoLeiJSGEStmT0I2NwLyKc?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:03:45 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 19 Oct 2018 08:03:45 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:03:45 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1EnhPFw9YZiE5EVZQs2IxlNoLeiJSGEStmT0I2NwLyKc",
+         "name": "An Awesome File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1K4XhPKsF75puVhuxYB0rueAitJTQJqh7"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:03:45 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1EnhPFw9YZiE5EVZQs2IxlNoLeiJSGEStmT0I2NwLyKc/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:03:45 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 19 Oct 2018 08:03:45 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:03:45 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-19T08:03:43.573Z"
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:03:45 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1EnhPFw9YZiE5EVZQs2IxlNoLeiJSGEStmT0I2NwLyKc/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"An Awesome File","parents":["1LVmseHP2C4EPlo87Dsv4o_X_C6Iu4hgc"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:03:46 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:03:49 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1jCm9aqvG_qKAJ0DB1LVtEGuULrqJS2mwK5xkfZ6Uu-I",
+         "name": "An Awesome File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1LVmseHP2C4EPlo87Dsv4o_X_C6Iu4hgc"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:03:49 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1LVmseHP2C4EPlo87Dsv4o_X_C6Iu4hgc?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:03:49 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 19 Oct 2018 08:03:49 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:03:49 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1LVmseHP2C4EPlo87Dsv4o_X_C6Iu4hgc",
+         "name": "1 Golgafrinchan Ark Fleet Ship B (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:03:49 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1jCm9aqvG_qKAJ0DB1LVtEGuULrqJS2mwK5xkfZ6Uu-I?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:03:49 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 19 Oct 2018 08:03:49 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:03:49 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1jCm9aqvG_qKAJ0DB1LVtEGuULrqJS2mwK5xkfZ6Uu-I",
+         "name": "An Awesome File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1LVmseHP2C4EPlo87Dsv4o_X_C6Iu4hgc"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:03:49 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1LVmseHP2C4EPlo87Dsv4o_X_C6Iu4hgc
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:03:49 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:03:50 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:03:50 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1K4XhPKsF75puVhuxYB0rueAitJTQJqh7
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:03:50 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:03:51 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:03:51 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/FileResource_Backup/_capture/stores_a_copy_of_the_file_snapshot_in_archive.yml
+++ b/spec/support/fixtures/vcr_cassettes/FileResource_Backup/_capture/stores_a_copy_of_the_file_snapshot_in_archive.yml
@@ -1,0 +1,957 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://www.googleapis.com/oauth2/v4/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR TRACKING ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.14.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Fri, 19 Oct 2018 08:00:26 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:00:26 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-19
+        08:00:26 UTC","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:00:26 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:00:27 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "13MWrGMsAbCkoIkGPVfXDXgh1TfLzMMvW",
+         "name": "Test @ 2018-10-19 08:00:26 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:00:27 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"190 Golgafrinchan
+        Ark Fleet Ship B (Archive)","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:00:27 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:00:28 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1LW6QR6lN7xMEDjsveBuDsai3fONslnwD",
+         "name": "190 Golgafrinchan Ark Fleet Ship B (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:00:28 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1LW6QR6lN7xMEDjsveBuDsai3fONslnwD/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:00:28 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:00:29 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "13193959451567607887",
+         "type": "user",
+         "role": "reader"
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:00:29 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1LW6QR6lN7xMEDjsveBuDsai3fONslnwD?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:00:29 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 19 Oct 2018 08:00:29 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:00:29 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1LW6QR6lN7xMEDjsveBuDsai3fONslnwD",
+         "name": "190 Golgafrinchan Ark Fleet Ship B (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:00:29 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1LW6QR6lN7xMEDjsveBuDsai3fONslnwD/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:00:29 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Fri, 19 Oct 2018 08:00:29 GMT
+      Expires:
+      - Fri, 19 Oct 2018 08:00:29 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:00:29 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"An Awesome
+        File","parents":["13MWrGMsAbCkoIkGPVfXDXgh1TfLzMMvW"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:00:29 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:00:31 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1kSUVpskyWeb2FE169Z7knb4t9C-dUXVyXbXGzHGoRSY",
+         "name": "An Awesome File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "13MWrGMsAbCkoIkGPVfXDXgh1TfLzMMvW"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:00:31 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1kSUVpskyWeb2FE169Z7knb4t9C-dUXVyXbXGzHGoRSY?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:00:31 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 19 Oct 2018 08:00:31 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:00:31 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1kSUVpskyWeb2FE169Z7knb4t9C-dUXVyXbXGzHGoRSY",
+         "name": "An Awesome File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "13MWrGMsAbCkoIkGPVfXDXgh1TfLzMMvW"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:00:31 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1kSUVpskyWeb2FE169Z7knb4t9C-dUXVyXbXGzHGoRSY/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:00:31 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 19 Oct 2018 08:00:31 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:00:31 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-19T08:00:30.143Z"
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:00:31 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1kSUVpskyWeb2FE169Z7knb4t9C-dUXVyXbXGzHGoRSY/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"An Awesome File","parents":["1LW6QR6lN7xMEDjsveBuDsai3fONslnwD"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:00:31 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:00:34 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1mcF50PYLnoflUgGfGOoiNpuAtSQC-Iqfy2RVQGYeyZs",
+         "name": "An Awesome File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1LW6QR6lN7xMEDjsveBuDsai3fONslnwD"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:00:34 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1mcF50PYLnoflUgGfGOoiNpuAtSQC-Iqfy2RVQGYeyZs?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:00:35 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 19 Oct 2018 08:00:35 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:00:35 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1mcF50PYLnoflUgGfGOoiNpuAtSQC-Iqfy2RVQGYeyZs",
+         "name": "An Awesome File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1LW6QR6lN7xMEDjsveBuDsai3fONslnwD"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:00:35 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1mcF50PYLnoflUgGfGOoiNpuAtSQC-Iqfy2RVQGYeyZs/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:00:35 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 19 Oct 2018 08:00:35 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:00:35 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-19T08:00:33.386Z"
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:00:35 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1LW6QR6lN7xMEDjsveBuDsai3fONslnwD
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:00:35 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:00:36 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:00:36 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/13MWrGMsAbCkoIkGPVfXDXgh1TfLzMMvW
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:00:36 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:00:36 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:00:37 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/FileResources_GoogleDrive/it_should_behave_like_including_syncable_integration/_fetch/sets_correct_attributes.yml
+++ b/spec/support/fixtures/vcr_cassettes/FileResources_GoogleDrive/it_should_behave_like_including_syncable_integration/_fetch/sets_correct_attributes.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,49 +21,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 20:41:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:28:37 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:17 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:37 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        20:41:17 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:28:37 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -72,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:17 GMT
+      - Thu, 18 Oct 2018 09:28:37 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -89,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:17 GMT
+      - Thu, 18 Oct 2018 09:28:38 GMT
       Vary:
       - Origin
       - X-Origin
@@ -106,31 +103,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "10s24Xh-IAHyysP_n3ifobxrp7pIfSlAh",
-         "name": "Test @ 2018-03-18 20:41:17 UTC",
+         "id": "1lIZ-7miXTIP7GekpgaFKxZ97aCoUIvha",
+         "name": "Test @ 2018-10-18 09:28:37 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:18 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:38 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["10s24Xh-IAHyysP_n3ifobxrp7pIfSlAh"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1lIZ-7miXTIP7GekpgaFKxZ97aCoUIvha"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -139,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:18 GMT
+      - Thu, 18 Oct 2018 09:28:38 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -156,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:18 GMT
+      - Thu, 18 Oct 2018 09:28:38 GMT
       Vary:
       - Origin
       - X-Origin
@@ -173,28 +180,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1UKQRyjEr6u7A9E2RS4yA6v8FE9FesJyINtcIAXFSIqg",
+         "id": "1zDuvFlmCDgtuWlexBMMTsosL2aS6aAHBXpi4g_klWMA",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "10s24Xh-IAHyysP_n3ifobxrp7pIfSlAh"
+          "1lIZ-7miXTIP7GekpgaFKxZ97aCoUIvha"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:18 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:39 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/upload/drive/v3/files/1UKQRyjEr6u7A9E2RS4yA6v8FE9FesJyINtcIAXFSIqg
+    uri: https://www.googleapis.com/upload/drive/v3/files/1zDuvFlmCDgtuWlexBMMTsosL2aS6aAHBXpi4g_klWMA
     body:
       encoding: UTF-8
       string: ''
@@ -206,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:18 GMT
+      - Thu, 18 Oct 2018 09:28:39 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       X-Goog-Upload-Protocol:
@@ -225,22 +242,22 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2UoETI07RIUjDeI2bJ-I-zTrVI6oKIfozqmcuWhOqt-U_yn-fjVV2lpWtHCwNcqwJnB5WN4ORC9LG4m1s45VBOXrhHNEHQ
+      - AEnB2Up0jhQ83cNbC5vqpFLkUKuOmnSbUjloj-Y4yiGFufywJ99ciiAEFXH7A0si-AcM57ZkZMdkqPlbWLrihXutRIAO_gU-D0MOhpnfiFaIHcFI8KrB-NY
       X-Goog-Upload-Status:
       - active
       X-Goog-Upload-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1UKQRyjEr6u7A9E2RS4yA6v8FE9FesJyINtcIAXFSIqg?upload_id=AEnB2UoETI07RIUjDeI2bJ-I-zTrVI6oKIfozqmcuWhOqt-U_yn-fjVV2lpWtHCwNcqwJnB5WN4ORC9LG4m1s45VBOXrhHNEHQ&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1zDuvFlmCDgtuWlexBMMTsosL2aS6aAHBXpi4g_klWMA?upload_id=AEnB2Up0jhQ83cNbC5vqpFLkUKuOmnSbUjloj-Y4yiGFufywJ99ciiAEFXH7A0si-AcM57ZkZMdkqPlbWLrihXutRIAO_gU-D0MOhpnfiFaIHcFI8KrB-NY&upload_protocol=resumable
       X-Goog-Upload-Control-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1UKQRyjEr6u7A9E2RS4yA6v8FE9FesJyINtcIAXFSIqg?upload_id=AEnB2UoETI07RIUjDeI2bJ-I-zTrVI6oKIfozqmcuWhOqt-U_yn-fjVV2lpWtHCwNcqwJnB5WN4ORC9LG4m1s45VBOXrhHNEHQ&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1zDuvFlmCDgtuWlexBMMTsosL2aS6aAHBXpi4g_klWMA?upload_id=AEnB2Up0jhQ83cNbC5vqpFLkUKuOmnSbUjloj-Y4yiGFufywJ99ciiAEFXH7A0si-AcM57ZkZMdkqPlbWLrihXutRIAO_gU-D0MOhpnfiFaIHcFI8KrB-NY&upload_protocol=resumable
       X-Goog-Upload-Chunk-Granularity:
       - '262144'
       X-Goog-Upload-Header-Vary:
       - Origin
       - X-Origin
       X-Goog-Upload-Header-X-Google-Backends:
-      - iofy20:4872
+      - ioal131:4120
       X-Goog-Upload-Header-X-Google-Session-Info:
-      - CLrLzJuGFRoCGAY6bwoPZHJpdmUtcm9zeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqYARKEAXlhMjkuR2wyQ0JSQXB4NUFsdU96SzV3VGtScGtMckpYWFR3OU9ReF9NLTIwc3NzVkp1TzRTZjNvY2V1Vllld3RsdE16eU4tbFMzT2ZpelYwVW9rbXdKbkVxOGRTVEF5RVBHY0Y3X2xkU3BoT1laSDdsTm43OEpjbTFjSG1ZUVVhTVQtRTAEOg0xLzdZYTRzRm02VnZ-
+      - CLrLzJuGFRoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqVARKBAXlhMjkuR2xzNkJ1VUVZUHQyQ2NtWGF5RFN2emdsN2NDRUlZN09tZTZ3cFFVUWJkcHh3UEE0b0lDbEJ5ZllyMkxWcmhZWnhwRTVkWDZldTB5SkQ1N0VCU2Q5LWl1VkUyMEZKeEFCWmZTU0hwQ1NjTUlfWUxWU0V3bVUxQnhwVDltQTAEOg0xLzJNM1JHd3dWbFp-
       X-Goog-Upload-Header-Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       X-Goog-Upload-Header-Pragma:
@@ -248,26 +265,25 @@ http_interactions:
       X-Goog-Upload-Header-Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       X-Goog-Upload-Header-Date:
-      - Sun, 18 Mar 2018 20:41:19 GMT
+      - Thu, 18 Oct 2018 09:28:39 GMT
       Content-Length:
       - '0'
       Date:
-      - Sun, 18 Mar 2018 20:41:19 GMT
+      - Thu, 18 Oct 2018 09:28:39 GMT
       Server:
       - UploadServer
       Content-Type:
       - text/html; charset=UTF-8
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:19 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:39 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/upload/drive/v3/files/1UKQRyjEr6u7A9E2RS4yA6v8FE9FesJyINtcIAXFSIqg?upload_id=AEnB2UoETI07RIUjDeI2bJ-I-zTrVI6oKIfozqmcuWhOqt-U_yn-fjVV2lpWtHCwNcqwJnB5WN4ORC9LG4m1s45VBOXrhHNEHQ&upload_protocol=resumable
+    uri: https://www.googleapis.com/upload/drive/v3/files/1zDuvFlmCDgtuWlexBMMTsosL2aS6aAHBXpi4g_klWMA?upload_id=AEnB2Up0jhQ83cNbC5vqpFLkUKuOmnSbUjloj-Y4yiGFufywJ99ciiAEFXH7A0si-AcM57ZkZMdkqPlbWLrihXutRIAO_gU-D0MOhpnfiFaIHcFI8KrB-NY&upload_protocol=resumable
     body:
       encoding: UTF-8
       string: new file content
@@ -279,7 +295,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:19 GMT
+      - Thu, 18 Oct 2018 09:28:39 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       X-Goog-Upload-Command:
@@ -294,7 +310,7 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2UoETI07RIUjDeI2bJ-I-zTrVI6oKIfozqmcuWhOqt-U_yn-fjVV2lpWtHCwNcqwJnB5WN4ORC9LG4m1s45VBOXrhHNEHQ
+      - AEnB2Up0jhQ83cNbC5vqpFLkUKuOmnSbUjloj-Y4yiGFufywJ99ciiAEFXH7A0si-AcM57ZkZMdkqPlbWLrihXutRIAO_gU-D0MOhpnfiFaIHcFI8KrB-NY
       X-Goog-Upload-Status:
       - final
       Vary:
@@ -309,28 +325,27 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:20 GMT
+      - Thu, 18 Oct 2018 09:28:40 GMT
       Content-Length:
       - '156'
       Server:
       - UploadServer
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: |
         {
          "kind": "drive#file",
-         "id": "1UKQRyjEr6u7A9E2RS4yA6v8FE9FesJyINtcIAXFSIqg",
+         "id": "1zDuvFlmCDgtuWlexBMMTsosL2aS6aAHBXpi4g_klWMA",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:20 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:40 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1UKQRyjEr6u7A9E2RS4yA6v8FE9FesJyINtcIAXFSIqg?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1zDuvFlmCDgtuWlexBMMTsosL2aS6aAHBXpi4g_klWMA?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -342,7 +357,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:25 GMT
+      - Thu, 18 Oct 2018 09:28:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -353,9 +368,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 20:41:25 GMT
+      - Thu, 18 Oct 2018 09:28:45 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:25 GMT
+      - Thu, 18 Oct 2018 09:28:45 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -374,29 +389,39 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1UKQRyjEr6u7A9E2RS4yA6v8FE9FesJyINtcIAXFSIqg",
+         "id": "1zDuvFlmCDgtuWlexBMMTsosL2aS6aAHBXpi4g_klWMA",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "10s24Xh-IAHyysP_n3ifobxrp7pIfSlAh"
+          "1lIZ-7miXTIP7GekpgaFKxZ97aCoUIvha"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1UKQRyjEr6u7A9E2RS4yA6v8FE9FesJyINtcIAXFSIqg&v=1&s=AMedNnoAAAAAWq7rFYl-Vp1CkcBed7d1SC_m8uCRZAzS&sz=s220",
-         "thumbnailVersion": "1"
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1zDuvFlmCDgtuWlexBMMTsosL2aS6aAHBXpi4g_klWMA&v=1&s=AMedNnoAAAAAW8hubXejqk8foDHFADhUqKPf6hma6v7d&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:25 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:45 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1UKQRyjEr6u7A9E2RS4yA6v8FE9FesJyINtcIAXFSIqg/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1zDuvFlmCDgtuWlexBMMTsosL2aS6aAHBXpi4g_klWMA/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -408,7 +433,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:25 GMT
+      - Thu, 18 Oct 2018 09:28:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -419,9 +444,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 20:41:25 GMT
+      - Thu, 18 Oct 2018 09:28:45 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:25 GMT
+      - Thu, 18 Oct 2018 09:28:45 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -440,8 +465,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -451,13 +475,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "3",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-03-18T20:41:19.699Z"
+         "modifiedTime": "2018-10-18T09:28:39.605Z"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:25 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:45 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1UKQRyjEr6u7A9E2RS4yA6v8FE9FesJyINtcIAXFSIqg&s=AMedNnoAAAAAWq7rFYl-Vp1CkcBed7d1SC_m8uCRZAzS&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1zDuvFlmCDgtuWlexBMMTsosL2aS6aAHBXpi4g_klWMA&s=AMedNnoAAAAAW8hubXejqk8foDHFADhUqKPf6hma6v7d&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -469,7 +493,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:25 GMT
+      - Thu, 18 Oct 2018 09:28:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -500,7 +524,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Sun, 18 Mar 2018 20:41:25 GMT
+      - Thu, 18 Oct 2018 09:28:45 GMT
       Server:
       - fife
       Content-Length:
@@ -508,17 +532,16 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:25 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:45 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/10s24Xh-IAHyysP_n3ifobxrp7pIfSlAh
+    uri: https://www.googleapis.com/drive/v3/files/1lIZ-7miXTIP7GekpgaFKxZ97aCoUIvha
     body:
       encoding: UTF-8
       string: ''
@@ -530,7 +553,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:25 GMT
+      - Thu, 18 Oct 2018 09:28:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -547,18 +570,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:26 GMT
+      - Thu, 18 Oct 2018 09:28:46 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:26 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:46 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/FileResources_GoogleDrive/it_should_behave_like_including_syncable_integration/_fetch/when_file_is_removed/1_3_1_3_1.yml
+++ b/spec/support/fixtures/vcr_cassettes/FileResources_GoogleDrive/it_should_behave_like_including_syncable_integration/_fetch/when_file_is_removed/1_3_1_3_1.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,49 +21,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 20:41:27 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:28:46 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:27 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:46 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        20:41:27 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:28:46 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -72,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:27 GMT
+      - Thu, 18 Oct 2018 09:28:46 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -89,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:27 GMT
+      - Thu, 18 Oct 2018 09:28:46 GMT
       Vary:
       - Origin
       - X-Origin
@@ -106,31 +103,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1rVCGVkMAqYJlrzQWInbQer-HXXgqxyFF",
-         "name": "Test @ 2018-03-18 20:41:27 UTC",
+         "id": "1ovpgigwpcP_tO-PEDXKmp6SohFmQ6RoG",
+         "name": "Test @ 2018-10-18 09:28:46 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:27 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:47 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1rVCGVkMAqYJlrzQWInbQer-HXXgqxyFF"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1ovpgigwpcP_tO-PEDXKmp6SohFmQ6RoG"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -139,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:27 GMT
+      - Thu, 18 Oct 2018 09:28:47 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -156,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:28 GMT
+      - Thu, 18 Oct 2018 09:28:48 GMT
       Vary:
       - Origin
       - X-Origin
@@ -173,28 +180,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "127jZCX1YVVYzR0MTLXvuyuyb3REfbPQ0fTHlGa9hfrI",
+         "id": "10equOmHWFLgXU2xJPe2io6UBzavKCUZARcRmWxag1fo",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1rVCGVkMAqYJlrzQWInbQer-HXXgqxyFF"
+          "1ovpgigwpcP_tO-PEDXKmp6SohFmQ6RoG"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:28 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:48 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/upload/drive/v3/files/127jZCX1YVVYzR0MTLXvuyuyb3REfbPQ0fTHlGa9hfrI
+    uri: https://www.googleapis.com/upload/drive/v3/files/10equOmHWFLgXU2xJPe2io6UBzavKCUZARcRmWxag1fo
     body:
       encoding: UTF-8
       string: ''
@@ -206,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:28 GMT
+      - Thu, 18 Oct 2018 09:28:48 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       X-Goog-Upload-Protocol:
@@ -225,22 +242,22 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2UpIccCAXR9Hjj5gqc3Zg1HhIY2TFawJO6IzSp5cVOe7Lg07gQkY15wPc6W3OLewSxKmAIAEIPZvX2zkayGYLthfZyq-dQ
+      - AEnB2Upjsaq1o-HGrNpab42qMfcrrcfnH05cxeApASrMk6tNTPZN24rhrtuyokQmWK6oTG-V2rirAw8y0DGFT7vctErpA_J65IlkA_z0OLHSr8k9z3rH_2w
       X-Goog-Upload-Status:
       - active
       X-Goog-Upload-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/127jZCX1YVVYzR0MTLXvuyuyb3REfbPQ0fTHlGa9hfrI?upload_id=AEnB2UpIccCAXR9Hjj5gqc3Zg1HhIY2TFawJO6IzSp5cVOe7Lg07gQkY15wPc6W3OLewSxKmAIAEIPZvX2zkayGYLthfZyq-dQ&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/10equOmHWFLgXU2xJPe2io6UBzavKCUZARcRmWxag1fo?upload_id=AEnB2Upjsaq1o-HGrNpab42qMfcrrcfnH05cxeApASrMk6tNTPZN24rhrtuyokQmWK6oTG-V2rirAw8y0DGFT7vctErpA_J65IlkA_z0OLHSr8k9z3rH_2w&upload_protocol=resumable
       X-Goog-Upload-Control-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/127jZCX1YVVYzR0MTLXvuyuyb3REfbPQ0fTHlGa9hfrI?upload_id=AEnB2UpIccCAXR9Hjj5gqc3Zg1HhIY2TFawJO6IzSp5cVOe7Lg07gQkY15wPc6W3OLewSxKmAIAEIPZvX2zkayGYLthfZyq-dQ&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/10equOmHWFLgXU2xJPe2io6UBzavKCUZARcRmWxag1fo?upload_id=AEnB2Upjsaq1o-HGrNpab42qMfcrrcfnH05cxeApASrMk6tNTPZN24rhrtuyokQmWK6oTG-V2rirAw8y0DGFT7vctErpA_J65IlkA_z0OLHSr8k9z3rH_2w&upload_protocol=resumable
       X-Goog-Upload-Chunk-Granularity:
       - '262144'
       X-Goog-Upload-Header-Vary:
       - Origin
       - X-Origin
       X-Goog-Upload-Header-X-Google-Backends:
-      - ioin32:4528
+      - ioqk5:4131
       X-Goog-Upload-Header-X-Google-Session-Info:
-      - CLrLzJuGFRoCGAY6bwoPZHJpdmUtcm9zeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqYARKEAXlhMjkuR2wyQ0JaU2JRd3BFSVJqUTlSY1ZNcEEzdXJCa2ZWVjg5MEpZaFg1TmV3ZFNwUTE3Q2F6MVFqOFZhQ2ZRZ2tEMVFaTThmUzNXQmhhaW14OXV2LWVfT1N4eGtYVkZ0d3JScDB4OFNHVVFJT2Y2bHVZN1kzdTVPTEVyS1JCSndXczAEOg0xLzdZYTRzRm02VnZ-
+      - CLrLzJuGFRoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqVARKBAXlhMjkuR2xzNkJqWU5YYjVHZ21JWExzNzBmbnlsSWRxb2RETmJpdjZiVnV0Y2I5YkhDRU0tWk9ZcWZpSkxfVFdGY0tSNEVadDRFSWI4cEw3cnJZOXRlT3ZEeXM5M0hqRUdmOEpYVDRQZWdOUm9OX09oZkVDU0hHS0J1bkZ4UU4xaDAEOg0xLzJNM1JHd3dWbFp-
       X-Goog-Upload-Header-Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       X-Goog-Upload-Header-Pragma:
@@ -248,26 +265,25 @@ http_interactions:
       X-Goog-Upload-Header-Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       X-Goog-Upload-Header-Date:
-      - Sun, 18 Mar 2018 20:41:28 GMT
+      - Thu, 18 Oct 2018 09:28:48 GMT
       Content-Length:
       - '0'
       Date:
-      - Sun, 18 Mar 2018 20:41:28 GMT
+      - Thu, 18 Oct 2018 09:28:48 GMT
       Server:
       - UploadServer
       Content-Type:
       - text/html; charset=UTF-8
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:29 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:48 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/upload/drive/v3/files/127jZCX1YVVYzR0MTLXvuyuyb3REfbPQ0fTHlGa9hfrI?upload_id=AEnB2UpIccCAXR9Hjj5gqc3Zg1HhIY2TFawJO6IzSp5cVOe7Lg07gQkY15wPc6W3OLewSxKmAIAEIPZvX2zkayGYLthfZyq-dQ&upload_protocol=resumable
+    uri: https://www.googleapis.com/upload/drive/v3/files/10equOmHWFLgXU2xJPe2io6UBzavKCUZARcRmWxag1fo?upload_id=AEnB2Upjsaq1o-HGrNpab42qMfcrrcfnH05cxeApASrMk6tNTPZN24rhrtuyokQmWK6oTG-V2rirAw8y0DGFT7vctErpA_J65IlkA_z0OLHSr8k9z3rH_2w&upload_protocol=resumable
     body:
       encoding: UTF-8
       string: new file content
@@ -279,7 +295,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:29 GMT
+      - Thu, 18 Oct 2018 09:28:48 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       X-Goog-Upload-Command:
@@ -294,7 +310,7 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2UpIccCAXR9Hjj5gqc3Zg1HhIY2TFawJO6IzSp5cVOe7Lg07gQkY15wPc6W3OLewSxKmAIAEIPZvX2zkayGYLthfZyq-dQ
+      - AEnB2Upjsaq1o-HGrNpab42qMfcrrcfnH05cxeApASrMk6tNTPZN24rhrtuyokQmWK6oTG-V2rirAw8y0DGFT7vctErpA_J65IlkA_z0OLHSr8k9z3rH_2w
       X-Goog-Upload-Status:
       - final
       Vary:
@@ -309,28 +325,27 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:29 GMT
+      - Thu, 18 Oct 2018 09:28:49 GMT
       Content-Length:
       - '156'
       Server:
       - UploadServer
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: |
         {
          "kind": "drive#file",
-         "id": "127jZCX1YVVYzR0MTLXvuyuyb3REfbPQ0fTHlGa9hfrI",
+         "id": "10equOmHWFLgXU2xJPe2io6UBzavKCUZARcRmWxag1fo",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:29 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:49 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/127jZCX1YVVYzR0MTLXvuyuyb3REfbPQ0fTHlGa9hfrI
+    uri: https://www.googleapis.com/drive/v3/files/10equOmHWFLgXU2xJPe2io6UBzavKCUZARcRmWxag1fo
     body:
       encoding: UTF-8
       string: ''
@@ -342,7 +357,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:34 GMT
+      - Thu, 18 Oct 2018 09:28:54 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -359,23 +374,22 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:35 GMT
+      - Thu, 18 Oct 2018 09:28:54 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:35 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:54 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/127jZCX1YVVYzR0MTLXvuyuyb3REfbPQ0fTHlGa9hfrI?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/10equOmHWFLgXU2xJPe2io6UBzavKCUZARcRmWxag1fo?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -387,7 +401,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:35 GMT
+      - Thu, 18 Oct 2018 09:28:54 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -405,9 +419,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 20:41:35 GMT
+      - Thu, 18 Oct 2018 09:28:54 GMT
       Expires:
-      - Sun, 18 Mar 2018 20:41:35 GMT
+      - Thu, 18 Oct 2018 09:28:54 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -419,8 +433,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -432,20 +445,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 127jZCX1YVVYzR0MTLXvuyuyb3REfbPQ0fTHlGa9hfrI.",
+            "message": "File not found: 10equOmHWFLgXU2xJPe2io6UBzavKCUZARcRmWxag1fo.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 127jZCX1YVVYzR0MTLXvuyuyb3REfbPQ0fTHlGa9hfrI."
+          "message": "File not found: 10equOmHWFLgXU2xJPe2io6UBzavKCUZARcRmWxag1fo."
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:35 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:54 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1rVCGVkMAqYJlrzQWInbQer-HXXgqxyFF
+    uri: https://www.googleapis.com/drive/v3/files/1ovpgigwpcP_tO-PEDXKmp6SohFmQ6RoG
     body:
       encoding: UTF-8
       string: ''
@@ -457,7 +470,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:35 GMT
+      - Thu, 18 Oct 2018 09:28:54 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -474,18 +487,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:35 GMT
+      - Thu, 18 Oct 2018 09:28:55 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:35 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:55 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/FileResources_GoogleDrive/it_should_behave_like_including_syncable_integration/_fetch/when_file_is_trashed/1_3_1_2_1.yml
+++ b/spec/support/fixtures/vcr_cassettes/FileResources_GoogleDrive/it_should_behave_like_including_syncable_integration/_fetch/when_file_is_trashed/1_3_1_2_1.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,49 +21,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 20:41:36 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:28:55 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:36 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:55 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        20:41:36 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:28:55 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -72,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:36 GMT
+      - Thu, 18 Oct 2018 09:28:55 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -89,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:36 GMT
+      - Thu, 18 Oct 2018 09:28:55 GMT
       Vary:
       - Origin
       - X-Origin
@@ -106,31 +103,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1jTwuOD2h5w495j0z5V3hYjdj3_VN_3ZN",
-         "name": "Test @ 2018-03-18 20:41:36 UTC",
+         "id": "1ELaox2d6TO_QUtav5hf3aNLE3CnWY5N-",
+         "name": "Test @ 2018-10-18 09:28:55 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:36 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:55 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1jTwuOD2h5w495j0z5V3hYjdj3_VN_3ZN"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1ELaox2d6TO_QUtav5hf3aNLE3CnWY5N-"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -139,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:36 GMT
+      - Thu, 18 Oct 2018 09:28:55 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -156,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:37 GMT
+      - Thu, 18 Oct 2018 09:28:56 GMT
       Vary:
       - Origin
       - X-Origin
@@ -173,28 +180,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1GjcVGbJKiGuGymEM7RQnc-FjwtXL6SaHF7KjunB6YTQ",
+         "id": "1szi3IHcjdyylNrrIxCVy2flQQwGEksGPy4f7NHkHjwc",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1jTwuOD2h5w495j0z5V3hYjdj3_VN_3ZN"
+          "1ELaox2d6TO_QUtav5hf3aNLE3CnWY5N-"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:37 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:56 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/upload/drive/v3/files/1GjcVGbJKiGuGymEM7RQnc-FjwtXL6SaHF7KjunB6YTQ
+    uri: https://www.googleapis.com/upload/drive/v3/files/1szi3IHcjdyylNrrIxCVy2flQQwGEksGPy4f7NHkHjwc
     body:
       encoding: UTF-8
       string: ''
@@ -206,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:37 GMT
+      - Thu, 18 Oct 2018 09:28:56 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       X-Goog-Upload-Protocol:
@@ -225,22 +242,22 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2Upbt52hEUhpmID4HQTa3ABjqLc9_hp3K8VFCRaZqbr8hMge7yJzRxRTIyuuhEQQHGF4wWqjheV86iXtjKfhoC3_bIcM_Q
+      - AEnB2UrfFEZdPtZGmwy-7o7n0u99-blEL3Fkgm63eO3JjYTgP-m_X0XmH5UO711O-R3GgTce4ngPdtzX915hk8IiMLOpMgopqghu332VWK8kpvYq6YZd8UY
       X-Goog-Upload-Status:
       - active
       X-Goog-Upload-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1GjcVGbJKiGuGymEM7RQnc-FjwtXL6SaHF7KjunB6YTQ?upload_id=AEnB2Upbt52hEUhpmID4HQTa3ABjqLc9_hp3K8VFCRaZqbr8hMge7yJzRxRTIyuuhEQQHGF4wWqjheV86iXtjKfhoC3_bIcM_Q&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1szi3IHcjdyylNrrIxCVy2flQQwGEksGPy4f7NHkHjwc?upload_id=AEnB2UrfFEZdPtZGmwy-7o7n0u99-blEL3Fkgm63eO3JjYTgP-m_X0XmH5UO711O-R3GgTce4ngPdtzX915hk8IiMLOpMgopqghu332VWK8kpvYq6YZd8UY&upload_protocol=resumable
       X-Goog-Upload-Control-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1GjcVGbJKiGuGymEM7RQnc-FjwtXL6SaHF7KjunB6YTQ?upload_id=AEnB2Upbt52hEUhpmID4HQTa3ABjqLc9_hp3K8VFCRaZqbr8hMge7yJzRxRTIyuuhEQQHGF4wWqjheV86iXtjKfhoC3_bIcM_Q&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1szi3IHcjdyylNrrIxCVy2flQQwGEksGPy4f7NHkHjwc?upload_id=AEnB2UrfFEZdPtZGmwy-7o7n0u99-blEL3Fkgm63eO3JjYTgP-m_X0XmH5UO711O-R3GgTce4ngPdtzX915hk8IiMLOpMgopqghu332VWK8kpvYq6YZd8UY&upload_protocol=resumable
       X-Goog-Upload-Chunk-Granularity:
       - '262144'
       X-Goog-Upload-Header-Vary:
       - Origin
       - X-Origin
       X-Goog-Upload-Header-X-Google-Backends:
-      - ioew12:4831
+      - ioaf5:4402
       X-Goog-Upload-Header-X-Google-Session-Info:
-      - CLrLzJuGFRoCGAY6bwoPZHJpdmUtcm9zeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqYARKEAXlhMjkuR2wyQ0JiWElYOTFHeWp4aElqQWtrWDU1NmE2SU1KWW9uUWtXaTJnNzkxMkZFNGJwcm5idjhyb1VHVlZ1T2sySGNjNkR3elZxdGQ2ZmxQbHhIbWdWelo5TWZGRjkxX3d2NVNxdHZJT19xSjRLQldDajRrc05tT3NPQ0RqSVljZzAEOg0xLzdZYTRzRm02VnZ-
+      - CLrLzJuGFRoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqVARKBAXlhMjkuR2xzNkJ0eVNoeXR2dFlISTN5S25zblJKdG1wZldOTDZMckRjVmp5aHkxSzZOY0NHaUVXWi1Gb3FPRUlFTTRxdHgyNnc0SDRENjZLYldRd1Z5NHR0YW12SGlHeHByOHpCUkxWOHBCS013aU5JR0swenZYemhCLXNlT251eDAEOg0xLzJNM1JHd3dWbFp-
       X-Goog-Upload-Header-Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       X-Goog-Upload-Header-Pragma:
@@ -248,26 +265,25 @@ http_interactions:
       X-Goog-Upload-Header-Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       X-Goog-Upload-Header-Date:
-      - Sun, 18 Mar 2018 20:41:37 GMT
+      - Thu, 18 Oct 2018 09:28:56 GMT
       Content-Length:
       - '0'
       Date:
-      - Sun, 18 Mar 2018 20:41:37 GMT
+      - Thu, 18 Oct 2018 09:28:57 GMT
       Server:
       - UploadServer
       Content-Type:
       - text/html; charset=UTF-8
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:37 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:57 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/upload/drive/v3/files/1GjcVGbJKiGuGymEM7RQnc-FjwtXL6SaHF7KjunB6YTQ?upload_id=AEnB2Upbt52hEUhpmID4HQTa3ABjqLc9_hp3K8VFCRaZqbr8hMge7yJzRxRTIyuuhEQQHGF4wWqjheV86iXtjKfhoC3_bIcM_Q&upload_protocol=resumable
+    uri: https://www.googleapis.com/upload/drive/v3/files/1szi3IHcjdyylNrrIxCVy2flQQwGEksGPy4f7NHkHjwc?upload_id=AEnB2UrfFEZdPtZGmwy-7o7n0u99-blEL3Fkgm63eO3JjYTgP-m_X0XmH5UO711O-R3GgTce4ngPdtzX915hk8IiMLOpMgopqghu332VWK8kpvYq6YZd8UY&upload_protocol=resumable
     body:
       encoding: UTF-8
       string: new file content
@@ -279,7 +295,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:37 GMT
+      - Thu, 18 Oct 2018 09:28:57 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       X-Goog-Upload-Command:
@@ -294,7 +310,7 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2Upbt52hEUhpmID4HQTa3ABjqLc9_hp3K8VFCRaZqbr8hMge7yJzRxRTIyuuhEQQHGF4wWqjheV86iXtjKfhoC3_bIcM_Q
+      - AEnB2UrfFEZdPtZGmwy-7o7n0u99-blEL3Fkgm63eO3JjYTgP-m_X0XmH5UO711O-R3GgTce4ngPdtzX915hk8IiMLOpMgopqghu332VWK8kpvYq6YZd8UY
       X-Goog-Upload-Status:
       - final
       Vary:
@@ -309,28 +325,27 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:38 GMT
+      - Thu, 18 Oct 2018 09:28:57 GMT
       Content-Length:
       - '156'
       Server:
       - UploadServer
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: |
         {
          "kind": "drive#file",
-         "id": "1GjcVGbJKiGuGymEM7RQnc-FjwtXL6SaHF7KjunB6YTQ",
+         "id": "1szi3IHcjdyylNrrIxCVy2flQQwGEksGPy4f7NHkHjwc",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:38 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:58 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1GjcVGbJKiGuGymEM7RQnc-FjwtXL6SaHF7KjunB6YTQ?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1szi3IHcjdyylNrrIxCVy2flQQwGEksGPy4f7NHkHjwc?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"trashed":"true"}'
@@ -342,7 +357,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:43 GMT
+      - Thu, 18 Oct 2018 09:29:03 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -359,7 +374,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:43 GMT
+      - Thu, 18 Oct 2018 09:29:04 GMT
       Vary:
       - Origin
       - X-Origin
@@ -376,29 +391,39 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1GjcVGbJKiGuGymEM7RQnc-FjwtXL6SaHF7KjunB6YTQ",
+         "id": "1szi3IHcjdyylNrrIxCVy2flQQwGEksGPy4f7NHkHjwc",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": true,
          "parents": [
-          "1jTwuOD2h5w495j0z5V3hYjdj3_VN_3ZN"
+          "1ELaox2d6TO_QUtav5hf3aNLE3CnWY5N-"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1GjcVGbJKiGuGymEM7RQnc-FjwtXL6SaHF7KjunB6YTQ&v=1&s=AMedNnoAAAAAWq7rJ_wUtTUx9-cYIxb5OcEByBWHopS7&sz=s220",
-         "thumbnailVersion": "1"
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1szi3IHcjdyylNrrIxCVy2flQQwGEksGPy4f7NHkHjwc&v=1&s=AMedNnoAAAAAW8hugCMVHT5q93Z9eT9tvU56bqBY2t4w&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:44 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:04 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1GjcVGbJKiGuGymEM7RQnc-FjwtXL6SaHF7KjunB6YTQ?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1szi3IHcjdyylNrrIxCVy2flQQwGEksGPy4f7NHkHjwc?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -410,7 +435,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:44 GMT
+      - Thu, 18 Oct 2018 09:29:04 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -421,9 +446,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 20:41:44 GMT
+      - Thu, 18 Oct 2018 09:29:04 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:44 GMT
+      - Thu, 18 Oct 2018 09:29:04 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -442,29 +467,39 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1GjcVGbJKiGuGymEM7RQnc-FjwtXL6SaHF7KjunB6YTQ",
+         "id": "1szi3IHcjdyylNrrIxCVy2flQQwGEksGPy4f7NHkHjwc",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": true,
          "parents": [
-          "1jTwuOD2h5w495j0z5V3hYjdj3_VN_3ZN"
+          "1ELaox2d6TO_QUtav5hf3aNLE3CnWY5N-"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1GjcVGbJKiGuGymEM7RQnc-FjwtXL6SaHF7KjunB6YTQ&v=1&s=AMedNnoAAAAAWq7rKB6YGVVc6IodofHN4ZnagQdESq1y&sz=s220",
-         "thumbnailVersion": "1"
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1szi3IHcjdyylNrrIxCVy2flQQwGEksGPy4f7NHkHjwc&v=1&s=AMedNnoAAAAAW8hugCMVHT5q93Z9eT9tvU56bqBY2t4w&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:44 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:04 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1jTwuOD2h5w495j0z5V3hYjdj3_VN_3ZN
+    uri: https://www.googleapis.com/drive/v3/files/1ELaox2d6TO_QUtav5hf3aNLE3CnWY5N-
     body:
       encoding: UTF-8
       string: ''
@@ -476,7 +511,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:44 GMT
+      - Thu, 18 Oct 2018 09:29:04 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -493,18 +528,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:44 GMT
+      - Thu, 18 Oct 2018 09:29:04 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:44 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:04 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/FileResources_GoogleDrive/it_should_behave_like_including_syncable_integration/_pull/sets_correct_attributes.yml
+++ b/spec/support/fixtures/vcr_cassettes/FileResources_GoogleDrive/it_should_behave_like_including_syncable_integration/_pull/sets_correct_attributes.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,49 +21,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 20:40:51 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:28:10 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:40:51 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:10 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        20:40:51 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:28:10 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -72,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:40:51 GMT
+      - Thu, 18 Oct 2018 09:28:10 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -89,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:40:52 GMT
+      - Thu, 18 Oct 2018 09:28:10 GMT
       Vary:
       - Origin
       - X-Origin
@@ -106,31 +103,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1amkGtPuH7bz1RkfUfPzP1LWUCMGS4Qca",
-         "name": "Test @ 2018-03-18 20:40:51 UTC",
+         "id": "1sV-2I-R_BGKFjDbEcnmEJ7-2ePb5rrKm",
+         "name": "Test @ 2018-10-18 09:28:10 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:40:52 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:10 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1amkGtPuH7bz1RkfUfPzP1LWUCMGS4Qca"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1sV-2I-R_BGKFjDbEcnmEJ7-2ePb5rrKm"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -139,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:40:52 GMT
+      - Thu, 18 Oct 2018 09:28:10 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -156,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:40:52 GMT
+      - Thu, 18 Oct 2018 09:28:11 GMT
       Vary:
       - Origin
       - X-Origin
@@ -173,28 +180,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1Fp7L2zx6zxKUblVSPjjQlWJT3YztzGWvn0nwuBOPmDM",
+         "id": "185XJd13sLIPIEZ1kfQivk-mEtLPVfHSWGVVYdzvTw_4",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1amkGtPuH7bz1RkfUfPzP1LWUCMGS4Qca"
+          "1sV-2I-R_BGKFjDbEcnmEJ7-2ePb5rrKm"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:40:53 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:11 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/upload/drive/v3/files/1Fp7L2zx6zxKUblVSPjjQlWJT3YztzGWvn0nwuBOPmDM
+    uri: https://www.googleapis.com/upload/drive/v3/files/185XJd13sLIPIEZ1kfQivk-mEtLPVfHSWGVVYdzvTw_4
     body:
       encoding: UTF-8
       string: ''
@@ -206,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:40:53 GMT
+      - Thu, 18 Oct 2018 09:28:11 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       X-Goog-Upload-Protocol:
@@ -225,22 +242,22 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2UoKjBQlj5jCSls484hUpFDfGl31t0yeBjHruZEVm4fBYR2MoMbNoa0M9pBr9gJbQThMfmPwVu1FyaLY2AAVyzw6x8PT5Q
+      - AEnB2Up8HIPwANSJWIXntju359FZif3tbYUrXu0EQfX4cqquHvgtdE2egfWDGnBQztivs6rRYuYq6YNkbN7Ui6U1utm75Iw0OJkl4Cw_3tUHwAYizm7EnIY
       X-Goog-Upload-Status:
       - active
       X-Goog-Upload-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1Fp7L2zx6zxKUblVSPjjQlWJT3YztzGWvn0nwuBOPmDM?upload_id=AEnB2UoKjBQlj5jCSls484hUpFDfGl31t0yeBjHruZEVm4fBYR2MoMbNoa0M9pBr9gJbQThMfmPwVu1FyaLY2AAVyzw6x8PT5Q&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/185XJd13sLIPIEZ1kfQivk-mEtLPVfHSWGVVYdzvTw_4?upload_id=AEnB2Up8HIPwANSJWIXntju359FZif3tbYUrXu0EQfX4cqquHvgtdE2egfWDGnBQztivs6rRYuYq6YNkbN7Ui6U1utm75Iw0OJkl4Cw_3tUHwAYizm7EnIY&upload_protocol=resumable
       X-Goog-Upload-Control-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1Fp7L2zx6zxKUblVSPjjQlWJT3YztzGWvn0nwuBOPmDM?upload_id=AEnB2UoKjBQlj5jCSls484hUpFDfGl31t0yeBjHruZEVm4fBYR2MoMbNoa0M9pBr9gJbQThMfmPwVu1FyaLY2AAVyzw6x8PT5Q&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/185XJd13sLIPIEZ1kfQivk-mEtLPVfHSWGVVYdzvTw_4?upload_id=AEnB2Up8HIPwANSJWIXntju359FZif3tbYUrXu0EQfX4cqquHvgtdE2egfWDGnBQztivs6rRYuYq6YNkbN7Ui6U1utm75Iw0OJkl4Cw_3tUHwAYizm7EnIY&upload_protocol=resumable
       X-Goog-Upload-Chunk-Granularity:
       - '262144'
       X-Goog-Upload-Header-Vary:
       - Origin
       - X-Origin
       X-Goog-Upload-Header-X-Google-Backends:
-      - iodc22:4685
+      - ioqm7:4266
       X-Goog-Upload-Header-X-Google-Session-Info:
-      - CLrLzJuGFRoCGAY6bwoPZHJpdmUtcm9zeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqYARKEAXlhMjkuR2wyQ0JidFdRMk5IWUQtRFRmV2xNQnI1cUZrQ1dHZmJ3Z1I0VFRibzNDaDAwUlIyUEpNUWR1SE1CQ2lUc3BlemRjZ3g2RGViN05COXNFYTVpVWROTEZZa3gwOU5sZ251TlF5TkIxVE5YalRvVTdnbk0yMERmV2xmU1dodEl6UTAEOg0xLzdZYTRzRm02VnZ-
+      - CLrLzJuGFRoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqVARKBAXlhMjkuR2xzNkJyNDBVY1VOQk5yRDJfVlBsY0NKR2hvMnZDOUJBTkJXc09uOWVPbU9aOFRsZ3gyUTJFcFREbFhsWWh1d25CZ3p1ZzFETEZWV0lCWWJmT0xsbXdVWmphSHd6TDgyX2tuSXE3T1lCNnBrRlEzM0dYVDcxX1ZEN2NLZDAEOg0xLzJNM1JHd3dWbFp-
       X-Goog-Upload-Header-Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       X-Goog-Upload-Header-Pragma:
@@ -248,26 +265,25 @@ http_interactions:
       X-Goog-Upload-Header-Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       X-Goog-Upload-Header-Date:
-      - Sun, 18 Mar 2018 20:40:53 GMT
+      - Thu, 18 Oct 2018 09:28:11 GMT
       Content-Length:
       - '0'
       Date:
-      - Sun, 18 Mar 2018 20:40:53 GMT
+      - Thu, 18 Oct 2018 09:28:11 GMT
       Server:
       - UploadServer
       Content-Type:
       - text/html; charset=UTF-8
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:40:53 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:12 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/upload/drive/v3/files/1Fp7L2zx6zxKUblVSPjjQlWJT3YztzGWvn0nwuBOPmDM?upload_id=AEnB2UoKjBQlj5jCSls484hUpFDfGl31t0yeBjHruZEVm4fBYR2MoMbNoa0M9pBr9gJbQThMfmPwVu1FyaLY2AAVyzw6x8PT5Q&upload_protocol=resumable
+    uri: https://www.googleapis.com/upload/drive/v3/files/185XJd13sLIPIEZ1kfQivk-mEtLPVfHSWGVVYdzvTw_4?upload_id=AEnB2Up8HIPwANSJWIXntju359FZif3tbYUrXu0EQfX4cqquHvgtdE2egfWDGnBQztivs6rRYuYq6YNkbN7Ui6U1utm75Iw0OJkl4Cw_3tUHwAYizm7EnIY&upload_protocol=resumable
     body:
       encoding: UTF-8
       string: new file content
@@ -279,7 +295,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:40:53 GMT
+      - Thu, 18 Oct 2018 09:28:12 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       X-Goog-Upload-Command:
@@ -294,7 +310,7 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2UoKjBQlj5jCSls484hUpFDfGl31t0yeBjHruZEVm4fBYR2MoMbNoa0M9pBr9gJbQThMfmPwVu1FyaLY2AAVyzw6x8PT5Q
+      - AEnB2Up8HIPwANSJWIXntju359FZif3tbYUrXu0EQfX4cqquHvgtdE2egfWDGnBQztivs6rRYuYq6YNkbN7Ui6U1utm75Iw0OJkl4Cw_3tUHwAYizm7EnIY
       X-Goog-Upload-Status:
       - final
       Vary:
@@ -309,28 +325,27 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:40:54 GMT
+      - Thu, 18 Oct 2018 09:28:13 GMT
       Content-Length:
       - '156'
       Server:
       - UploadServer
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: |
         {
          "kind": "drive#file",
-         "id": "1Fp7L2zx6zxKUblVSPjjQlWJT3YztzGWvn0nwuBOPmDM",
+         "id": "185XJd13sLIPIEZ1kfQivk-mEtLPVfHSWGVVYdzvTw_4",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:40:54 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:13 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Fp7L2zx6zxKUblVSPjjQlWJT3YztzGWvn0nwuBOPmDM?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/185XJd13sLIPIEZ1kfQivk-mEtLPVfHSWGVVYdzvTw_4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -342,7 +357,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:40:59 GMT
+      - Thu, 18 Oct 2018 09:28:18 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -353,9 +368,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 20:40:59 GMT
+      - Thu, 18 Oct 2018 09:28:18 GMT
       Date:
-      - Sun, 18 Mar 2018 20:40:59 GMT
+      - Thu, 18 Oct 2018 09:28:18 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -374,29 +389,39 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1Fp7L2zx6zxKUblVSPjjQlWJT3YztzGWvn0nwuBOPmDM",
+         "id": "185XJd13sLIPIEZ1kfQivk-mEtLPVfHSWGVVYdzvTw_4",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1amkGtPuH7bz1RkfUfPzP1LWUCMGS4Qca"
+          "1sV-2I-R_BGKFjDbEcnmEJ7-2ePb5rrKm"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Fp7L2zx6zxKUblVSPjjQlWJT3YztzGWvn0nwuBOPmDM&v=1&s=AMedNnoAAAAAWq7q-1LCCSdkLwq2fNe8e_qKERcKmClm&sz=s220",
-         "thumbnailVersion": "1"
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=185XJd13sLIPIEZ1kfQivk-mEtLPVfHSWGVVYdzvTw_4&v=1&s=AMedNnoAAAAAW8huUtetmTDBH8_lvDD_a747p-_FEtaq&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:40:59 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:18 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Fp7L2zx6zxKUblVSPjjQlWJT3YztzGWvn0nwuBOPmDM/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/185XJd13sLIPIEZ1kfQivk-mEtLPVfHSWGVVYdzvTw_4/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -408,7 +433,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:40:59 GMT
+      - Thu, 18 Oct 2018 09:28:18 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -419,9 +444,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 20:40:59 GMT
+      - Thu, 18 Oct 2018 09:28:18 GMT
       Date:
-      - Sun, 18 Mar 2018 20:40:59 GMT
+      - Thu, 18 Oct 2018 09:28:18 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -440,8 +465,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -451,13 +475,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "3",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-03-18T20:40:53.778Z"
+         "modifiedTime": "2018-10-18T09:28:12.750Z"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:40:59 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:18 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1Fp7L2zx6zxKUblVSPjjQlWJT3YztzGWvn0nwuBOPmDM&s=AMedNnoAAAAAWq7q-1LCCSdkLwq2fNe8e_qKERcKmClm&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=185XJd13sLIPIEZ1kfQivk-mEtLPVfHSWGVVYdzvTw_4&s=AMedNnoAAAAAW8huUtetmTDBH8_lvDD_a747p-_FEtaq&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -469,7 +493,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:40:59 GMT
+      - Thu, 18 Oct 2018 09:28:18 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -500,7 +524,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Sun, 18 Mar 2018 20:41:00 GMT
+      - Thu, 18 Oct 2018 09:28:18 GMT
       Server:
       - fife
       Content-Length:
@@ -508,17 +532,16 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:00 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:18 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1amkGtPuH7bz1RkfUfPzP1LWUCMGS4Qca
+    uri: https://www.googleapis.com/drive/v3/files/1sV-2I-R_BGKFjDbEcnmEJ7-2ePb5rrKm
     body:
       encoding: UTF-8
       string: ''
@@ -530,7 +553,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:00 GMT
+      - Thu, 18 Oct 2018 09:28:18 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -547,18 +570,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:00 GMT
+      - Thu, 18 Oct 2018 09:28:19 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:00 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:19 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/FileResources_GoogleDrive/it_should_behave_like_including_syncable_integration/_pull/when_file_is_removed/1_3_2_3_1.yml
+++ b/spec/support/fixtures/vcr_cassettes/FileResources_GoogleDrive/it_should_behave_like_including_syncable_integration/_pull/when_file_is_removed/1_3_2_3_1.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,49 +21,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 20:41:09 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:28:28 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:09 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:28 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        20:41:09 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:28:28 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -72,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:09 GMT
+      - Thu, 18 Oct 2018 09:28:28 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -89,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:09 GMT
+      - Thu, 18 Oct 2018 09:28:28 GMT
       Vary:
       - Origin
       - X-Origin
@@ -106,31 +103,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "10RQGJnPG1Nbg7Sk7XME0fhwkqIKRqCQ2",
-         "name": "Test @ 2018-03-18 20:41:09 UTC",
+         "id": "1elUM6SbHXIEWbI5fOEYe_Ol_97Xzbnie",
+         "name": "Test @ 2018-10-18 09:28:28 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:09 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:28 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["10RQGJnPG1Nbg7Sk7XME0fhwkqIKRqCQ2"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1elUM6SbHXIEWbI5fOEYe_Ol_97Xzbnie"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -139,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:09 GMT
+      - Thu, 18 Oct 2018 09:28:28 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -156,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:10 GMT
+      - Thu, 18 Oct 2018 09:28:30 GMT
       Vary:
       - Origin
       - X-Origin
@@ -173,28 +180,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1n210rfifeep4UNmfFy4VfAk_XMMg212RIFn3Tj2geFw",
+         "id": "1qPe5ZlDSWYWmVaANwbsgWBTVhsQkTUMTNNd6Im-BLQk",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "10RQGJnPG1Nbg7Sk7XME0fhwkqIKRqCQ2"
+          "1elUM6SbHXIEWbI5fOEYe_Ol_97Xzbnie"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:10 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:30 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/upload/drive/v3/files/1n210rfifeep4UNmfFy4VfAk_XMMg212RIFn3Tj2geFw
+    uri: https://www.googleapis.com/upload/drive/v3/files/1qPe5ZlDSWYWmVaANwbsgWBTVhsQkTUMTNNd6Im-BLQk
     body:
       encoding: UTF-8
       string: ''
@@ -206,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:10 GMT
+      - Thu, 18 Oct 2018 09:28:30 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       X-Goog-Upload-Protocol:
@@ -225,22 +242,22 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2Uo6fejO_6PZYXr-zTcIsM0KdD9uQ88UOr6Ls_ygwLboN7avDyidT9ddC5bQOhGyR6TgN7mXkNsEQ2yLZI7yOG71p6TROg
+      - AEnB2UoBgxjQk6T2y-fYzF1DDbuz7UIwfoFe_gdjqHZiK4uawYI7I95Y8SPUu_ujEXeKPiw_7KLto2F7c_I6i3ELpn8hsC4iHcSiB6zTnpH0VYh1LB3Bmjc
       X-Goog-Upload-Status:
       - active
       X-Goog-Upload-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1n210rfifeep4UNmfFy4VfAk_XMMg212RIFn3Tj2geFw?upload_id=AEnB2Uo6fejO_6PZYXr-zTcIsM0KdD9uQ88UOr6Ls_ygwLboN7avDyidT9ddC5bQOhGyR6TgN7mXkNsEQ2yLZI7yOG71p6TROg&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1qPe5ZlDSWYWmVaANwbsgWBTVhsQkTUMTNNd6Im-BLQk?upload_id=AEnB2UoBgxjQk6T2y-fYzF1DDbuz7UIwfoFe_gdjqHZiK4uawYI7I95Y8SPUu_ujEXeKPiw_7KLto2F7c_I6i3ELpn8hsC4iHcSiB6zTnpH0VYh1LB3Bmjc&upload_protocol=resumable
       X-Goog-Upload-Control-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1n210rfifeep4UNmfFy4VfAk_XMMg212RIFn3Tj2geFw?upload_id=AEnB2Uo6fejO_6PZYXr-zTcIsM0KdD9uQ88UOr6Ls_ygwLboN7avDyidT9ddC5bQOhGyR6TgN7mXkNsEQ2yLZI7yOG71p6TROg&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1qPe5ZlDSWYWmVaANwbsgWBTVhsQkTUMTNNd6Im-BLQk?upload_id=AEnB2UoBgxjQk6T2y-fYzF1DDbuz7UIwfoFe_gdjqHZiK4uawYI7I95Y8SPUu_ujEXeKPiw_7KLto2F7c_I6i3ELpn8hsC4iHcSiB6zTnpH0VYh1LB3Bmjc&upload_protocol=resumable
       X-Goog-Upload-Chunk-Granularity:
       - '262144'
       X-Goog-Upload-Header-Vary:
       - Origin
       - X-Origin
       X-Goog-Upload-Header-X-Google-Backends:
-      - iogg14:4767
+      - iohg24:4013
       X-Goog-Upload-Header-X-Google-Session-Info:
-      - CLrLzJuGFRoCGAY6bwoPZHJpdmUtcm9zeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqYARKEAXlhMjkuR2wyQ0JRcnBtT2tqZEprU3FaVHhUM3JZMThHNzVLTXZ5bXVlTUgtWFFnakZIQ2JGQzNDMnNMRUdBX18xNW12OWd2UllwQ1BaUm5zcGQyb3hSTzBtOXRXd0ZqdXVwUGktT0htZ0VoWXJpbVFiQUVBUWZZbHFjUmFTampxZnhmYzAEOg0xLzdZYTRzRm02VnZ-
+      - CLrLzJuGFRoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqVARKBAXlhMjkuR2xzNkJrYzlEYVVvTHRsWkhUeXc5cnZ0TzJmNHNWbnhnNzZlVVJMSlhVTllrcFdkWHFVMlNLeFJVQVY1VnFzUWtIU0laeHB4empLdG9Ga1lxQUNlS0Q3c3BqbnhtRTVrYUpoWUJRVzNQRlBPS0x0UUJxRlF1QnNiSWxTXzAEOg0xLzJNM1JHd3dWbFp-
       X-Goog-Upload-Header-Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       X-Goog-Upload-Header-Pragma:
@@ -248,26 +265,25 @@ http_interactions:
       X-Goog-Upload-Header-Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       X-Goog-Upload-Header-Date:
-      - Sun, 18 Mar 2018 20:41:10 GMT
+      - Thu, 18 Oct 2018 09:28:30 GMT
       Content-Length:
       - '0'
       Date:
-      - Sun, 18 Mar 2018 20:41:10 GMT
+      - Thu, 18 Oct 2018 09:28:30 GMT
       Server:
       - UploadServer
       Content-Type:
       - text/html; charset=UTF-8
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:11 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:30 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/upload/drive/v3/files/1n210rfifeep4UNmfFy4VfAk_XMMg212RIFn3Tj2geFw?upload_id=AEnB2Uo6fejO_6PZYXr-zTcIsM0KdD9uQ88UOr6Ls_ygwLboN7avDyidT9ddC5bQOhGyR6TgN7mXkNsEQ2yLZI7yOG71p6TROg&upload_protocol=resumable
+    uri: https://www.googleapis.com/upload/drive/v3/files/1qPe5ZlDSWYWmVaANwbsgWBTVhsQkTUMTNNd6Im-BLQk?upload_id=AEnB2UoBgxjQk6T2y-fYzF1DDbuz7UIwfoFe_gdjqHZiK4uawYI7I95Y8SPUu_ujEXeKPiw_7KLto2F7c_I6i3ELpn8hsC4iHcSiB6zTnpH0VYh1LB3Bmjc&upload_protocol=resumable
     body:
       encoding: UTF-8
       string: new file content
@@ -279,7 +295,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:11 GMT
+      - Thu, 18 Oct 2018 09:28:30 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       X-Goog-Upload-Command:
@@ -294,7 +310,7 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2Uo6fejO_6PZYXr-zTcIsM0KdD9uQ88UOr6Ls_ygwLboN7avDyidT9ddC5bQOhGyR6TgN7mXkNsEQ2yLZI7yOG71p6TROg
+      - AEnB2UoBgxjQk6T2y-fYzF1DDbuz7UIwfoFe_gdjqHZiK4uawYI7I95Y8SPUu_ujEXeKPiw_7KLto2F7c_I6i3ELpn8hsC4iHcSiB6zTnpH0VYh1LB3Bmjc
       X-Goog-Upload-Status:
       - final
       Vary:
@@ -309,28 +325,27 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:11 GMT
+      - Thu, 18 Oct 2018 09:28:31 GMT
       Content-Length:
       - '156'
       Server:
       - UploadServer
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: |
         {
          "kind": "drive#file",
-         "id": "1n210rfifeep4UNmfFy4VfAk_XMMg212RIFn3Tj2geFw",
+         "id": "1qPe5ZlDSWYWmVaANwbsgWBTVhsQkTUMTNNd6Im-BLQk",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:11 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:31 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1n210rfifeep4UNmfFy4VfAk_XMMg212RIFn3Tj2geFw
+    uri: https://www.googleapis.com/drive/v3/files/1qPe5ZlDSWYWmVaANwbsgWBTVhsQkTUMTNNd6Im-BLQk
     body:
       encoding: UTF-8
       string: ''
@@ -342,7 +357,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:16 GMT
+      - Thu, 18 Oct 2018 09:28:36 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -359,23 +374,22 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:17 GMT
+      - Thu, 18 Oct 2018 09:28:37 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:17 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:37 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1n210rfifeep4UNmfFy4VfAk_XMMg212RIFn3Tj2geFw?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1qPe5ZlDSWYWmVaANwbsgWBTVhsQkTUMTNNd6Im-BLQk?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -387,7 +401,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:17 GMT
+      - Thu, 18 Oct 2018 09:28:37 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -405,9 +419,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 20:41:17 GMT
+      - Thu, 18 Oct 2018 09:28:37 GMT
       Expires:
-      - Sun, 18 Mar 2018 20:41:17 GMT
+      - Thu, 18 Oct 2018 09:28:37 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -419,8 +433,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -432,20 +445,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1n210rfifeep4UNmfFy4VfAk_XMMg212RIFn3Tj2geFw.",
+            "message": "File not found: 1qPe5ZlDSWYWmVaANwbsgWBTVhsQkTUMTNNd6Im-BLQk.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1n210rfifeep4UNmfFy4VfAk_XMMg212RIFn3Tj2geFw."
+          "message": "File not found: 1qPe5ZlDSWYWmVaANwbsgWBTVhsQkTUMTNNd6Im-BLQk."
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:17 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:37 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/10RQGJnPG1Nbg7Sk7XME0fhwkqIKRqCQ2
+    uri: https://www.googleapis.com/drive/v3/files/1elUM6SbHXIEWbI5fOEYe_Ol_97Xzbnie
     body:
       encoding: UTF-8
       string: ''
@@ -457,7 +470,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:17 GMT
+      - Thu, 18 Oct 2018 09:28:37 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -474,18 +487,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:17 GMT
+      - Thu, 18 Oct 2018 09:28:37 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:17 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:37 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/FileResources_GoogleDrive/it_should_behave_like_including_syncable_integration/_pull/when_file_is_trashed/1_3_2_2_1.yml
+++ b/spec/support/fixtures/vcr_cassettes/FileResources_GoogleDrive/it_should_behave_like_including_syncable_integration/_pull/when_file_is_trashed/1_3_2_2_1.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,49 +21,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 20:41:00 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:28:19 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:00 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:19 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        20:41:00 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:28:19 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -72,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:00 GMT
+      - Thu, 18 Oct 2018 09:28:19 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -89,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:01 GMT
+      - Thu, 18 Oct 2018 09:28:19 GMT
       Vary:
       - Origin
       - X-Origin
@@ -106,31 +103,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1pCPt1CdvkkH4eStCopFGjiH1r0MOPG-R",
-         "name": "Test @ 2018-03-18 20:41:00 UTC",
+         "id": "1ic06xGYMjyUpU3cmFT5FUQfWLn6YdIY1",
+         "name": "Test @ 2018-10-18 09:28:19 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:01 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:20 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1pCPt1CdvkkH4eStCopFGjiH1r0MOPG-R"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1ic06xGYMjyUpU3cmFT5FUQfWLn6YdIY1"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -139,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:01 GMT
+      - Thu, 18 Oct 2018 09:28:20 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -156,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:02 GMT
+      - Thu, 18 Oct 2018 09:28:20 GMT
       Vary:
       - Origin
       - X-Origin
@@ -173,28 +180,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1A90MwGttK_sBOUgTZwTmbs-VDYUvTkqQ1aQtUhX_uco",
+         "id": "1bD0yf-olGIaJ1HDps_YCYtDylYl_9oUJmCQJ3EFc0nE",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1pCPt1CdvkkH4eStCopFGjiH1r0MOPG-R"
+          "1ic06xGYMjyUpU3cmFT5FUQfWLn6YdIY1"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:02 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:20 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/upload/drive/v3/files/1A90MwGttK_sBOUgTZwTmbs-VDYUvTkqQ1aQtUhX_uco
+    uri: https://www.googleapis.com/upload/drive/v3/files/1bD0yf-olGIaJ1HDps_YCYtDylYl_9oUJmCQJ3EFc0nE
     body:
       encoding: UTF-8
       string: ''
@@ -206,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:02 GMT
+      - Thu, 18 Oct 2018 09:28:20 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       X-Goog-Upload-Protocol:
@@ -225,22 +242,22 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2UpbDDCqIEh9WNDQM9R0L7fNmyvqpH-hD3nvvTIBXYQ5yO9Jeg9r1S27e0Wkk9VMpM_DPUXz_9scvZ3qJoB6G0bD5hEEQg
+      - AEnB2Uq4DFOHjgX4mRuMGG8JJPWZnotEw_yakDJmqQRID-rTE2Nx6mlPBjjSy6wMdGClANxxLC3wKCHRwl_IAqpImCKREuqlxcNB4clnDWqg8So8Ipbf24M
       X-Goog-Upload-Status:
       - active
       X-Goog-Upload-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1A90MwGttK_sBOUgTZwTmbs-VDYUvTkqQ1aQtUhX_uco?upload_id=AEnB2UpbDDCqIEh9WNDQM9R0L7fNmyvqpH-hD3nvvTIBXYQ5yO9Jeg9r1S27e0Wkk9VMpM_DPUXz_9scvZ3qJoB6G0bD5hEEQg&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1bD0yf-olGIaJ1HDps_YCYtDylYl_9oUJmCQJ3EFc0nE?upload_id=AEnB2Uq4DFOHjgX4mRuMGG8JJPWZnotEw_yakDJmqQRID-rTE2Nx6mlPBjjSy6wMdGClANxxLC3wKCHRwl_IAqpImCKREuqlxcNB4clnDWqg8So8Ipbf24M&upload_protocol=resumable
       X-Goog-Upload-Control-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1A90MwGttK_sBOUgTZwTmbs-VDYUvTkqQ1aQtUhX_uco?upload_id=AEnB2UpbDDCqIEh9WNDQM9R0L7fNmyvqpH-hD3nvvTIBXYQ5yO9Jeg9r1S27e0Wkk9VMpM_DPUXz_9scvZ3qJoB6G0bD5hEEQg&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1bD0yf-olGIaJ1HDps_YCYtDylYl_9oUJmCQJ3EFc0nE?upload_id=AEnB2Uq4DFOHjgX4mRuMGG8JJPWZnotEw_yakDJmqQRID-rTE2Nx6mlPBjjSy6wMdGClANxxLC3wKCHRwl_IAqpImCKREuqlxcNB4clnDWqg8So8Ipbf24M&upload_protocol=resumable
       X-Goog-Upload-Chunk-Granularity:
       - '262144'
       X-Goog-Upload-Header-Vary:
       - Origin
       - X-Origin
       X-Goog-Upload-Header-X-Google-Backends:
-      - ioiw63:4500
+      - iob199:4453
       X-Goog-Upload-Header-X-Google-Session-Info:
-      - CLrLzJuGFRoCGAY6bwoPZHJpdmUtcm9zeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqYARKEAXlhMjkuR2wyQ0JXeUxTR21STDFDWHAxUXhENlB2VlFRV0dLbm9HaDNfUGNaNjdqZU1QVFF4VnZmQkZqZDhFeTRLdG1OUW8zREpMUUE0MURGbDZZckliNHlieVpiMkdFV01zUkJJNkd2UmNDVjRMeXFQYlQ1OVlPTGhuSldxTEtfQ0J3azAEOg0xLzdZYTRzRm02VnZ-
+      - CLrLzJuGFRoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqVARKBAXlhMjkuR2xzNkJscHAxOHplWmxwd3k2SmlCMS1jRnFzeXZyaVprTjJFeENnMU9jSmdZMktmbG56Y2tadWZYTGlmUm5CTl9kMGNlb0VmRFU3eTRWS09tVk5XVDhUVm90N0F2OGpCSzJMX2ZlUVkyUGRuZjluaWxnTjlJYUxQUC1DMDAEOg0xLzJNM1JHd3dWbFp-
       X-Goog-Upload-Header-Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       X-Goog-Upload-Header-Pragma:
@@ -248,26 +265,25 @@ http_interactions:
       X-Goog-Upload-Header-Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       X-Goog-Upload-Header-Date:
-      - Sun, 18 Mar 2018 20:41:02 GMT
+      - Thu, 18 Oct 2018 09:28:21 GMT
       Content-Length:
       - '0'
       Date:
-      - Sun, 18 Mar 2018 20:41:02 GMT
+      - Thu, 18 Oct 2018 09:28:21 GMT
       Server:
       - UploadServer
       Content-Type:
       - text/html; charset=UTF-8
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:02 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:21 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/upload/drive/v3/files/1A90MwGttK_sBOUgTZwTmbs-VDYUvTkqQ1aQtUhX_uco?upload_id=AEnB2UpbDDCqIEh9WNDQM9R0L7fNmyvqpH-hD3nvvTIBXYQ5yO9Jeg9r1S27e0Wkk9VMpM_DPUXz_9scvZ3qJoB6G0bD5hEEQg&upload_protocol=resumable
+    uri: https://www.googleapis.com/upload/drive/v3/files/1bD0yf-olGIaJ1HDps_YCYtDylYl_9oUJmCQJ3EFc0nE?upload_id=AEnB2Uq4DFOHjgX4mRuMGG8JJPWZnotEw_yakDJmqQRID-rTE2Nx6mlPBjjSy6wMdGClANxxLC3wKCHRwl_IAqpImCKREuqlxcNB4clnDWqg8So8Ipbf24M&upload_protocol=resumable
     body:
       encoding: UTF-8
       string: new file content
@@ -279,7 +295,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:02 GMT
+      - Thu, 18 Oct 2018 09:28:21 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       X-Goog-Upload-Command:
@@ -294,7 +310,7 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2UpbDDCqIEh9WNDQM9R0L7fNmyvqpH-hD3nvvTIBXYQ5yO9Jeg9r1S27e0Wkk9VMpM_DPUXz_9scvZ3qJoB6G0bD5hEEQg
+      - AEnB2Uq4DFOHjgX4mRuMGG8JJPWZnotEw_yakDJmqQRID-rTE2Nx6mlPBjjSy6wMdGClANxxLC3wKCHRwl_IAqpImCKREuqlxcNB4clnDWqg8So8Ipbf24M
       X-Goog-Upload-Status:
       - final
       Vary:
@@ -309,28 +325,27 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:03 GMT
+      - Thu, 18 Oct 2018 09:28:21 GMT
       Content-Length:
       - '156'
       Server:
       - UploadServer
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: |
         {
          "kind": "drive#file",
-         "id": "1A90MwGttK_sBOUgTZwTmbs-VDYUvTkqQ1aQtUhX_uco",
+         "id": "1bD0yf-olGIaJ1HDps_YCYtDylYl_9oUJmCQJ3EFc0nE",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:03 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:21 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1A90MwGttK_sBOUgTZwTmbs-VDYUvTkqQ1aQtUhX_uco?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1bD0yf-olGIaJ1HDps_YCYtDylYl_9oUJmCQJ3EFc0nE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"trashed":"true"}'
@@ -342,7 +357,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:08 GMT
+      - Thu, 18 Oct 2018 09:28:26 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -359,7 +374,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:08 GMT
+      - Thu, 18 Oct 2018 09:28:27 GMT
       Vary:
       - Origin
       - X-Origin
@@ -376,29 +391,39 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1A90MwGttK_sBOUgTZwTmbs-VDYUvTkqQ1aQtUhX_uco",
+         "id": "1bD0yf-olGIaJ1HDps_YCYtDylYl_9oUJmCQJ3EFc0nE",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": true,
          "parents": [
-          "1pCPt1CdvkkH4eStCopFGjiH1r0MOPG-R"
+          "1ic06xGYMjyUpU3cmFT5FUQfWLn6YdIY1"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1A90MwGttK_sBOUgTZwTmbs-VDYUvTkqQ1aQtUhX_uco&v=1&s=AMedNnoAAAAAWq7rBK1KBMiLOo9zGyoSw8Ofi7ABcfhc&sz=s220",
-         "thumbnailVersion": "1"
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1bD0yf-olGIaJ1HDps_YCYtDylYl_9oUJmCQJ3EFc0nE&v=1&s=AMedNnoAAAAAW8huW0REIUWQjYmQt6DCSeJdPDTPf76W&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:08 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:27 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1A90MwGttK_sBOUgTZwTmbs-VDYUvTkqQ1aQtUhX_uco?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1bD0yf-olGIaJ1HDps_YCYtDylYl_9oUJmCQJ3EFc0nE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -410,7 +435,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:08 GMT
+      - Thu, 18 Oct 2018 09:28:27 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -421,9 +446,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 20:41:08 GMT
+      - Thu, 18 Oct 2018 09:28:27 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:08 GMT
+      - Thu, 18 Oct 2018 09:28:27 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -442,29 +467,39 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1A90MwGttK_sBOUgTZwTmbs-VDYUvTkqQ1aQtUhX_uco",
+         "id": "1bD0yf-olGIaJ1HDps_YCYtDylYl_9oUJmCQJ3EFc0nE",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": true,
          "parents": [
-          "1pCPt1CdvkkH4eStCopFGjiH1r0MOPG-R"
+          "1ic06xGYMjyUpU3cmFT5FUQfWLn6YdIY1"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1A90MwGttK_sBOUgTZwTmbs-VDYUvTkqQ1aQtUhX_uco&v=1&s=AMedNnoAAAAAWq7rBK1KBMiLOo9zGyoSw8Ofi7ABcfhc&sz=s220",
-         "thumbnailVersion": "1"
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1bD0yf-olGIaJ1HDps_YCYtDylYl_9oUJmCQJ3EFc0nE&v=1&s=AMedNnoAAAAAW8huW0REIUWQjYmQt6DCSeJdPDTPf76W&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:08 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:27 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1pCPt1CdvkkH4eStCopFGjiH1r0MOPG-R
+    uri: https://www.googleapis.com/drive/v3/files/1ic06xGYMjyUpU3cmFT5FUQfWLn6YdIY1
     body:
       encoding: UTF-8
       string: ''
@@ -476,7 +511,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:08 GMT
+      - Thu, 18 Oct 2018 09:28:27 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -493,18 +528,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:09 GMT
+      - Thu, 18 Oct 2018 09:28:28 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:09 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:28 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/FileResources_GoogleDrive/it_should_behave_like_including_syncable_integration/_pull_children/has_children_subfile1_and_subfile2.yml
+++ b/spec/support/fixtures/vcr_cassettes/FileResources_GoogleDrive/it_should_behave_like_including_syncable_integration/_pull_children/has_children_subfile1_and_subfile2.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,49 +21,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 20:41:44 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:29:04 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:44 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:04 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        20:41:44 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:29:04 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -72,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:44 GMT
+      - Thu, 18 Oct 2018 09:29:04 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -89,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:44 GMT
+      - Thu, 18 Oct 2018 09:29:05 GMT
       Vary:
       - Origin
       - X-Origin
@@ -106,31 +103,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "19y8Twc_s3ZJSzz25i8hOgWikyijzq7G7",
-         "name": "Test @ 2018-03-18 20:41:44 UTC",
+         "id": "1Um3F4ayrkgAO3C4hztfvvYN9l-pEZ2BY",
+         "name": "Test @ 2018-10-18 09:29:04 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:45 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:05 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["19y8Twc_s3ZJSzz25i8hOgWikyijzq7G7"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["1Um3F4ayrkgAO3C4hztfvvYN9l-pEZ2BY"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -139,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:45 GMT
+      - Thu, 18 Oct 2018 09:29:05 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -156,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:45 GMT
+      - Thu, 18 Oct 2018 09:29:05 GMT
       Vary:
       - Origin
       - X-Origin
@@ -173,31 +180,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1jNlK7gr_TlaiWDghoFiulQYQQdQxZo7-",
+         "id": "1OBxZSn8rcgqfDhUGjmJOnNR2N3ZYlq2l",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "19y8Twc_s3ZJSzz25i8hOgWikyijzq7G7"
+          "1Um3F4ayrkgAO3C4hztfvvYN9l-pEZ2BY"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:45 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:05 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"sub1","parents":["1jNlK7gr_TlaiWDghoFiulQYQQdQxZo7-"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"sub1","parents":["1OBxZSn8rcgqfDhUGjmJOnNR2N3ZYlq2l"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -206,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:45 GMT
+      - Thu, 18 Oct 2018 09:29:05 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -223,7 +240,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:46 GMT
+      - Thu, 18 Oct 2018 09:29:06 GMT
       Vary:
       - Origin
       - X-Origin
@@ -240,31 +257,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1z9F5S1TUl_jwI0i6GM7-nXMm1bS1AeKP",
+         "id": "1tCKPcDNmEGSH8u7zL36N5xTJDEetjVvx",
          "name": "sub1",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1jNlK7gr_TlaiWDghoFiulQYQQdQxZo7-"
+          "1OBxZSn8rcgqfDhUGjmJOnNR2N3ZYlq2l"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:46 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:06 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"sub2","parents":["1jNlK7gr_TlaiWDghoFiulQYQQdQxZo7-"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"sub2","parents":["1OBxZSn8rcgqfDhUGjmJOnNR2N3ZYlq2l"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -273,7 +300,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:46 GMT
+      - Thu, 18 Oct 2018 09:29:06 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -290,7 +317,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:46 GMT
+      - Thu, 18 Oct 2018 09:29:06 GMT
       Vary:
       - Origin
       - X-Origin
@@ -307,28 +334,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1SAhi14j1fRJiNcKYCGJ2qWk0QuLixqUs",
+         "id": "1bLNyBUdCiSljLz0xinoXV9nhyDLLOW3Z",
          "name": "sub2",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1jNlK7gr_TlaiWDghoFiulQYQQdQxZo7-"
+          "1OBxZSn8rcgqfDhUGjmJOnNR2N3ZYlq2l"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:46 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:06 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1jNlK7gr_TlaiWDghoFiulQYQQdQxZo7-?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1OBxZSn8rcgqfDhUGjmJOnNR2N3ZYlq2l?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -340,7 +377,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:46 GMT
+      - Thu, 18 Oct 2018 09:29:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -351,9 +388,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 20:41:46 GMT
+      - Thu, 18 Oct 2018 09:29:06 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:46 GMT
+      - Thu, 18 Oct 2018 09:29:06 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -372,28 +409,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1jNlK7gr_TlaiWDghoFiulQYQQdQxZo7-",
+         "id": "1OBxZSn8rcgqfDhUGjmJOnNR2N3ZYlq2l",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "19y8Twc_s3ZJSzz25i8hOgWikyijzq7G7"
+          "1Um3F4ayrkgAO3C4hztfvvYN9l-pEZ2BY"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:46 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:06 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1jNlK7gr_TlaiWDghoFiulQYQQdQxZo7-/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1OBxZSn8rcgqfDhUGjmJOnNR2N3ZYlq2l/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -405,7 +452,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:46 GMT
+      - Thu, 18 Oct 2018 09:29:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -423,9 +470,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 20:41:46 GMT
+      - Thu, 18 Oct 2018 09:29:06 GMT
       Expires:
-      - Sun, 18 Mar 2018 20:41:46 GMT
+      - Thu, 18 Oct 2018 09:29:06 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -437,8 +484,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -458,10 +504,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:46 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:06 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271jNlK7gr_TlaiWDghoFiulQYQQdQxZo7-%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271OBxZSn8rcgqfDhUGjmJOnNR2N3ZYlq2l%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -473,7 +519,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:46 GMT
+      - Thu, 18 Oct 2018 09:29:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -484,9 +530,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 20:41:47 GMT
+      - Thu, 18 Oct 2018 09:29:07 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:47 GMT
+      - Thu, 18 Oct 2018 09:29:07 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -505,8 +551,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -515,32 +560,54 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1SAhi14j1fRJiNcKYCGJ2qWk0QuLixqUs",
+           "id": "1bLNyBUdCiSljLz0xinoXV9nhyDLLOW3Z",
            "name": "sub2",
            "mimeType": "application/vnd.google-apps.folder",
            "trashed": false,
            "parents": [
-            "1jNlK7gr_TlaiWDghoFiulQYQQdQxZo7-"
+            "1OBxZSn8rcgqfDhUGjmJOnNR2N3ZYlq2l"
            ],
-           "thumbnailVersion": "0"
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "owner",
+             "displayName": "Upshift One",
+             "deleted": false
+            }
+           ]
           },
           {
-           "id": "1z9F5S1TUl_jwI0i6GM7-nXMm1bS1AeKP",
+           "id": "1tCKPcDNmEGSH8u7zL36N5xTJDEetjVvx",
            "name": "sub1",
            "mimeType": "application/vnd.google-apps.folder",
            "trashed": false,
            "parents": [
-            "1jNlK7gr_TlaiWDghoFiulQYQQdQxZo7-"
+            "1OBxZSn8rcgqfDhUGjmJOnNR2N3ZYlq2l"
            ],
-           "thumbnailVersion": "0"
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "owner",
+             "displayName": "Upshift One",
+             "deleted": false
+            }
+           ]
           }
          ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:47 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:07 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1SAhi14j1fRJiNcKYCGJ2qWk0QuLixqUs/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1bLNyBUdCiSljLz0xinoXV9nhyDLLOW3Z/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -552,7 +619,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:47 GMT
+      - Thu, 18 Oct 2018 09:29:07 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -570,9 +637,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 20:41:47 GMT
+      - Thu, 18 Oct 2018 09:29:07 GMT
       Expires:
-      - Sun, 18 Mar 2018 20:41:47 GMT
+      - Thu, 18 Oct 2018 09:29:07 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -584,8 +651,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -605,10 +671,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:47 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:07 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1z9F5S1TUl_jwI0i6GM7-nXMm1bS1AeKP/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1tCKPcDNmEGSH8u7zL36N5xTJDEetjVvx/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -620,7 +686,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:47 GMT
+      - Thu, 18 Oct 2018 09:29:07 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -638,9 +704,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 20:41:47 GMT
+      - Thu, 18 Oct 2018 09:29:07 GMT
       Expires:
-      - Sun, 18 Mar 2018 20:41:47 GMT
+      - Thu, 18 Oct 2018 09:29:07 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -652,8 +718,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -673,10 +738,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:47 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:07 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/19y8Twc_s3ZJSzz25i8hOgWikyijzq7G7
+    uri: https://www.googleapis.com/drive/v3/files/1Um3F4ayrkgAO3C4hztfvvYN9l-pEZ2BY
     body:
       encoding: UTF-8
       string: ''
@@ -688,7 +753,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:47 GMT
+      - Thu, 18 Oct 2018 09:29:07 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -705,18 +770,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:47 GMT
+      - Thu, 18 Oct 2018 09:29:07 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:47 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:07 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/FileResources_GoogleDrive/it_should_behave_like_including_syncable_integration/_pull_children/when_subfile1_is_deleted_and_subfile3_is_added/updates_children_to_subfile2_and_subfile3.yml
+++ b/spec/support/fixtures/vcr_cassettes/FileResources_GoogleDrive/it_should_behave_like_including_syncable_integration/_pull_children/when_subfile1_is_deleted_and_subfile3_is_added/updates_children_to_subfile2_and_subfile3.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,49 +21,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 20:41:48 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:29:07 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:48 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:08 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        20:41:48 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:29:08 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -72,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:48 GMT
+      - Thu, 18 Oct 2018 09:29:08 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -89,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:48 GMT
+      - Thu, 18 Oct 2018 09:29:08 GMT
       Vary:
       - Origin
       - X-Origin
@@ -106,31 +103,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1TWV88AJMS5zJWHTGEF_yIOF8VD4dTFWW",
-         "name": "Test @ 2018-03-18 20:41:48 UTC",
+         "id": "1s1YTCPy9FkyaPgaZ6k5pcFrmiKmnVBup",
+         "name": "Test @ 2018-10-18 09:29:08 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:48 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:08 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["1TWV88AJMS5zJWHTGEF_yIOF8VD4dTFWW"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["1s1YTCPy9FkyaPgaZ6k5pcFrmiKmnVBup"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -139,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:48 GMT
+      - Thu, 18 Oct 2018 09:29:08 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -156,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:49 GMT
+      - Thu, 18 Oct 2018 09:29:08 GMT
       Vary:
       - Origin
       - X-Origin
@@ -173,31 +180,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1FAWGUbBrcPANGSiPy-5esUXrybWghfWr",
+         "id": "1vlXBvh1B2yCOXaP8kuW09p7G3fTvmA7m",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1TWV88AJMS5zJWHTGEF_yIOF8VD4dTFWW"
+          "1s1YTCPy9FkyaPgaZ6k5pcFrmiKmnVBup"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:49 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:08 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"sub1","parents":["1FAWGUbBrcPANGSiPy-5esUXrybWghfWr"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"sub1","parents":["1vlXBvh1B2yCOXaP8kuW09p7G3fTvmA7m"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -206,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:49 GMT
+      - Thu, 18 Oct 2018 09:29:08 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -223,7 +240,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:49 GMT
+      - Thu, 18 Oct 2018 09:29:09 GMT
       Vary:
       - Origin
       - X-Origin
@@ -240,31 +257,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1_NwGbDCzbenEEUWusDCAJ8IW3C9QS7Qx",
+         "id": "1htwIX-2iKM9D8KofGXUnbVrXaonn7h7v",
          "name": "sub1",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1FAWGUbBrcPANGSiPy-5esUXrybWghfWr"
+          "1vlXBvh1B2yCOXaP8kuW09p7G3fTvmA7m"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:49 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:09 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"sub2","parents":["1FAWGUbBrcPANGSiPy-5esUXrybWghfWr"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"sub2","parents":["1vlXBvh1B2yCOXaP8kuW09p7G3fTvmA7m"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -273,7 +300,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:49 GMT
+      - Thu, 18 Oct 2018 09:29:09 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -290,7 +317,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:50 GMT
+      - Thu, 18 Oct 2018 09:29:09 GMT
       Vary:
       - Origin
       - X-Origin
@@ -307,28 +334,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1MyeP6J0--i1k3rUF3Vsvb5gGlLggS6k3",
+         "id": "1ffzJX3Acy_at3rYNW7ZYWwW-dKrUczSH",
          "name": "sub2",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1FAWGUbBrcPANGSiPy-5esUXrybWghfWr"
+          "1vlXBvh1B2yCOXaP8kuW09p7G3fTvmA7m"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:50 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:09 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1FAWGUbBrcPANGSiPy-5esUXrybWghfWr?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1vlXBvh1B2yCOXaP8kuW09p7G3fTvmA7m?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -340,7 +377,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:50 GMT
+      - Thu, 18 Oct 2018 09:29:09 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -351,9 +388,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 20:41:50 GMT
+      - Thu, 18 Oct 2018 09:29:09 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:50 GMT
+      - Thu, 18 Oct 2018 09:29:09 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -372,28 +409,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1FAWGUbBrcPANGSiPy-5esUXrybWghfWr",
+         "id": "1vlXBvh1B2yCOXaP8kuW09p7G3fTvmA7m",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1TWV88AJMS5zJWHTGEF_yIOF8VD4dTFWW"
+          "1s1YTCPy9FkyaPgaZ6k5pcFrmiKmnVBup"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:50 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:10 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1FAWGUbBrcPANGSiPy-5esUXrybWghfWr/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1vlXBvh1B2yCOXaP8kuW09p7G3fTvmA7m/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -405,7 +452,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:50 GMT
+      - Thu, 18 Oct 2018 09:29:10 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -423,9 +470,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 20:41:50 GMT
+      - Thu, 18 Oct 2018 09:29:10 GMT
       Expires:
-      - Sun, 18 Mar 2018 20:41:50 GMT
+      - Thu, 18 Oct 2018 09:29:10 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -437,8 +484,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -458,10 +504,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:50 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:10 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271FAWGUbBrcPANGSiPy-5esUXrybWghfWr%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271vlXBvh1B2yCOXaP8kuW09p7G3fTvmA7m%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -473,7 +519,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:50 GMT
+      - Thu, 18 Oct 2018 09:29:10 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -484,9 +530,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 20:41:50 GMT
+      - Thu, 18 Oct 2018 09:29:10 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:50 GMT
+      - Thu, 18 Oct 2018 09:29:10 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -505,8 +551,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -515,32 +560,54 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1MyeP6J0--i1k3rUF3Vsvb5gGlLggS6k3",
+           "id": "1ffzJX3Acy_at3rYNW7ZYWwW-dKrUczSH",
            "name": "sub2",
            "mimeType": "application/vnd.google-apps.folder",
            "trashed": false,
            "parents": [
-            "1FAWGUbBrcPANGSiPy-5esUXrybWghfWr"
+            "1vlXBvh1B2yCOXaP8kuW09p7G3fTvmA7m"
            ],
-           "thumbnailVersion": "0"
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "owner",
+             "displayName": "Upshift One",
+             "deleted": false
+            }
+           ]
           },
           {
-           "id": "1_NwGbDCzbenEEUWusDCAJ8IW3C9QS7Qx",
+           "id": "1htwIX-2iKM9D8KofGXUnbVrXaonn7h7v",
            "name": "sub1",
            "mimeType": "application/vnd.google-apps.folder",
            "trashed": false,
            "parents": [
-            "1FAWGUbBrcPANGSiPy-5esUXrybWghfWr"
+            "1vlXBvh1B2yCOXaP8kuW09p7G3fTvmA7m"
            ],
-           "thumbnailVersion": "0"
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "owner",
+             "displayName": "Upshift One",
+             "deleted": false
+            }
+           ]
           }
          ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:50 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:10 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1MyeP6J0--i1k3rUF3Vsvb5gGlLggS6k3/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1ffzJX3Acy_at3rYNW7ZYWwW-dKrUczSH/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -552,7 +619,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:50 GMT
+      - Thu, 18 Oct 2018 09:29:10 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -570,9 +637,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 20:41:50 GMT
+      - Thu, 18 Oct 2018 09:29:10 GMT
       Expires:
-      - Sun, 18 Mar 2018 20:41:50 GMT
+      - Thu, 18 Oct 2018 09:29:10 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -584,8 +651,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -605,10 +671,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:50 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:10 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1_NwGbDCzbenEEUWusDCAJ8IW3C9QS7Qx/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1htwIX-2iKM9D8KofGXUnbVrXaonn7h7v/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -620,7 +686,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:50 GMT
+      - Thu, 18 Oct 2018 09:29:10 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -638,9 +704,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 20:41:50 GMT
+      - Thu, 18 Oct 2018 09:29:10 GMT
       Expires:
-      - Sun, 18 Mar 2018 20:41:50 GMT
+      - Thu, 18 Oct 2018 09:29:10 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -652,8 +718,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -673,10 +738,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:50 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:10 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1_NwGbDCzbenEEUWusDCAJ8IW3C9QS7Qx
+    uri: https://www.googleapis.com/drive/v3/files/1htwIX-2iKM9D8KofGXUnbVrXaonn7h7v
     body:
       encoding: UTF-8
       string: ''
@@ -688,7 +753,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:50 GMT
+      - Thu, 18 Oct 2018 09:29:10 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -705,26 +770,25 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:51 GMT
+      - Thu, 18 Oct 2018 09:29:11 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:51 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:11 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"sub3","parents":["1FAWGUbBrcPANGSiPy-5esUXrybWghfWr"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"sub3","parents":["1vlXBvh1B2yCOXaP8kuW09p7G3fTvmA7m"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -733,7 +797,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:51 GMT
+      - Thu, 18 Oct 2018 09:29:11 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -750,7 +814,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:51 GMT
+      - Thu, 18 Oct 2018 09:29:11 GMT
       Vary:
       - Origin
       - X-Origin
@@ -767,28 +831,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1-DdmPjL3ToYDQ1s0sJgWgO1AqE70GwZs",
+         "id": "1E01sTfPINVPUiYc8xLWeQStAnVbiZYUw",
          "name": "sub3",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1FAWGUbBrcPANGSiPy-5esUXrybWghfWr"
+          "1vlXBvh1B2yCOXaP8kuW09p7G3fTvmA7m"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:51 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:12 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271FAWGUbBrcPANGSiPy-5esUXrybWghfWr%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271vlXBvh1B2yCOXaP8kuW09p7G3fTvmA7m%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -800,7 +874,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:51 GMT
+      - Thu, 18 Oct 2018 09:29:12 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -811,9 +885,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 20:41:51 GMT
+      - Thu, 18 Oct 2018 09:29:12 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:51 GMT
+      - Thu, 18 Oct 2018 09:29:12 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -832,8 +906,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -842,32 +915,54 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1-DdmPjL3ToYDQ1s0sJgWgO1AqE70GwZs",
+           "id": "1E01sTfPINVPUiYc8xLWeQStAnVbiZYUw",
            "name": "sub3",
            "mimeType": "application/vnd.google-apps.folder",
            "trashed": false,
            "parents": [
-            "1FAWGUbBrcPANGSiPy-5esUXrybWghfWr"
+            "1vlXBvh1B2yCOXaP8kuW09p7G3fTvmA7m"
            ],
-           "thumbnailVersion": "0"
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "owner",
+             "displayName": "Upshift One",
+             "deleted": false
+            }
+           ]
           },
           {
-           "id": "1MyeP6J0--i1k3rUF3Vsvb5gGlLggS6k3",
+           "id": "1ffzJX3Acy_at3rYNW7ZYWwW-dKrUczSH",
            "name": "sub2",
            "mimeType": "application/vnd.google-apps.folder",
            "trashed": false,
            "parents": [
-            "1FAWGUbBrcPANGSiPy-5esUXrybWghfWr"
+            "1vlXBvh1B2yCOXaP8kuW09p7G3fTvmA7m"
            ],
-           "thumbnailVersion": "0"
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "owner",
+             "displayName": "Upshift One",
+             "deleted": false
+            }
+           ]
           }
          ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:51 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:12 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1-DdmPjL3ToYDQ1s0sJgWgO1AqE70GwZs/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1E01sTfPINVPUiYc8xLWeQStAnVbiZYUw/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -879,7 +974,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:51 GMT
+      - Thu, 18 Oct 2018 09:29:12 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -897,9 +992,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 20:41:52 GMT
+      - Thu, 18 Oct 2018 09:29:12 GMT
       Expires:
-      - Sun, 18 Mar 2018 20:41:52 GMT
+      - Thu, 18 Oct 2018 09:29:12 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -911,8 +1006,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -932,10 +1026,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:52 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:12 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1TWV88AJMS5zJWHTGEF_yIOF8VD4dTFWW
+    uri: https://www.googleapis.com/drive/v3/files/1s1YTCPy9FkyaPgaZ6k5pcFrmiKmnVBup
     body:
       encoding: UTF-8
       string: ''
@@ -947,7 +1041,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 20:41:52 GMT
+      - Thu, 18 Oct 2018 09:29:12 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -964,18 +1058,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 20:41:52 GMT
+      - Thu, 18 Oct 2018 09:29:12 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 20:41:52 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:12 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/FileResources_GoogleDrive/snapshotable_stageable_syncable/can_pull_a_snapshot_of_a_new_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/FileResources_GoogleDrive/snapshotable_stageable_syncable/can_pull_a_snapshot_of_a_new_file.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,49 +21,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 22:29:08 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:29:28 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:08 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:28 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        22:29:08 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:29:28 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -72,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:08 GMT
+      - Thu, 18 Oct 2018 09:29:28 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -89,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 22:29:08 GMT
+      - Thu, 18 Oct 2018 09:29:29 GMT
       Vary:
       - Origin
       - X-Origin
@@ -106,31 +103,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1wxyOVzWy7L89I-UW3H6cMqarrP9lhOup",
-         "name": "Test @ 2018-03-18 22:29:08 UTC",
+         "id": "1DTyEmIeCzA233Bgk0R1aSkaM9-oL6Qy_",
+         "name": "Test @ 2018-10-18 09:29:28 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:08 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:29 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1wxyOVzWy7L89I-UW3H6cMqarrP9lhOup"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1DTyEmIeCzA233Bgk0R1aSkaM9-oL6Qy_"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -139,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:08 GMT
+      - Thu, 18 Oct 2018 09:29:29 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -156,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 22:29:09 GMT
+      - Thu, 18 Oct 2018 09:29:30 GMT
       Vary:
       - Origin
       - X-Origin
@@ -173,28 +180,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1DvUNgMQUBqeXzr-VVE4t0qkOFzy5LaPM4WAnl0-h13U",
+         "id": "1ARbehrsIws9_PpcRQsbB4mZmAzN2ZfxJ0yDzYAEOeCQ",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1wxyOVzWy7L89I-UW3H6cMqarrP9lhOup"
+          "1DTyEmIeCzA233Bgk0R1aSkaM9-oL6Qy_"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:09 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:30 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1wxyOVzWy7L89I-UW3H6cMqarrP9lhOup?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1DTyEmIeCzA233Bgk0R1aSkaM9-oL6Qy_?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -206,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:09 GMT
+      - Thu, 18 Oct 2018 09:29:30 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -217,9 +234,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 22:29:09 GMT
+      - Thu, 18 Oct 2018 09:29:30 GMT
       Date:
-      - Sun, 18 Mar 2018 22:29:09 GMT
+      - Thu, 18 Oct 2018 09:29:30 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -238,28 +255,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1wxyOVzWy7L89I-UW3H6cMqarrP9lhOup",
-         "name": "Test @ 2018-03-18 22:29:08 UTC",
+         "id": "1DTyEmIeCzA233Bgk0R1aSkaM9-oL6Qy_",
+         "name": "Test @ 2018-10-18 09:29:28 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:09 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:30 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1wxyOVzWy7L89I-UW3H6cMqarrP9lhOup/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1DTyEmIeCzA233Bgk0R1aSkaM9-oL6Qy_/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -271,7 +298,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:09 GMT
+      - Thu, 18 Oct 2018 09:29:30 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -289,9 +316,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 22:29:09 GMT
+      - Thu, 18 Oct 2018 09:29:30 GMT
       Expires:
-      - Sun, 18 Mar 2018 22:29:09 GMT
+      - Thu, 18 Oct 2018 09:29:30 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -303,8 +330,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -324,10 +350,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:09 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:30 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1DvUNgMQUBqeXzr-VVE4t0qkOFzy5LaPM4WAnl0-h13U?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ARbehrsIws9_PpcRQsbB4mZmAzN2ZfxJ0yDzYAEOeCQ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -339,7 +365,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:09 GMT
+      - Thu, 18 Oct 2018 09:29:30 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -350,9 +376,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 22:29:09 GMT
+      - Thu, 18 Oct 2018 09:29:30 GMT
       Date:
-      - Sun, 18 Mar 2018 22:29:09 GMT
+      - Thu, 18 Oct 2018 09:29:30 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -371,28 +397,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1DvUNgMQUBqeXzr-VVE4t0qkOFzy5LaPM4WAnl0-h13U",
+         "id": "1ARbehrsIws9_PpcRQsbB4mZmAzN2ZfxJ0yDzYAEOeCQ",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1wxyOVzWy7L89I-UW3H6cMqarrP9lhOup"
+          "1DTyEmIeCzA233Bgk0R1aSkaM9-oL6Qy_"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:10 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:30 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1DvUNgMQUBqeXzr-VVE4t0qkOFzy5LaPM4WAnl0-h13U/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1ARbehrsIws9_PpcRQsbB4mZmAzN2ZfxJ0yDzYAEOeCQ/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -404,7 +440,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:10 GMT
+      - Thu, 18 Oct 2018 09:29:30 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -415,9 +451,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 22:29:10 GMT
+      - Thu, 18 Oct 2018 09:29:31 GMT
       Date:
-      - Sun, 18 Mar 2018 22:29:10 GMT
+      - Thu, 18 Oct 2018 09:29:31 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -436,8 +472,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -447,13 +482,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-03-18T22:29:08.709Z"
+         "modifiedTime": "2018-10-18T09:29:29.476Z"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:10 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:31 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1wxyOVzWy7L89I-UW3H6cMqarrP9lhOup
+    uri: https://www.googleapis.com/drive/v3/files/1DTyEmIeCzA233Bgk0R1aSkaM9-oL6Qy_
     body:
       encoding: UTF-8
       string: ''
@@ -465,7 +500,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:10 GMT
+      - Thu, 18 Oct 2018 09:29:31 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -482,18 +517,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 22:29:10 GMT
+      - Thu, 18 Oct 2018 09:29:31 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:10 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:31 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/FileResources_GoogleDrive/snapshotable_stageable_syncable/can_pull_a_snapshot_of_a_removed_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/FileResources_GoogleDrive/snapshotable_stageable_syncable/can_pull_a_snapshot_of_a_removed_file.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,49 +21,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 22:29:03 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:29:24 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:03 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:24 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        22:29:03 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:29:24 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -72,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:03 GMT
+      - Thu, 18 Oct 2018 09:29:24 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -89,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 22:29:04 GMT
+      - Thu, 18 Oct 2018 09:29:25 GMT
       Vary:
       - Origin
       - X-Origin
@@ -106,31 +103,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1fNUF2dEuKsH8j-ySMCZNhXbY63Bmlzlp",
-         "name": "Test @ 2018-03-18 22:29:03 UTC",
+         "id": "1NGzEzrW3b8Fz5PFiZ46Gw3ewvy4WkW03",
+         "name": "Test @ 2018-10-18 09:29:24 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:04 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:25 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1fNUF2dEuKsH8j-ySMCZNhXbY63Bmlzlp"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1NGzEzrW3b8Fz5PFiZ46Gw3ewvy4WkW03"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -139,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:04 GMT
+      - Thu, 18 Oct 2018 09:29:25 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -156,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 22:29:05 GMT
+      - Thu, 18 Oct 2018 09:29:26 GMT
       Vary:
       - Origin
       - X-Origin
@@ -173,28 +180,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1EsQ1BykAMF_pMWlHUnC8qEiylX9HO88BoP4OELeppgk",
+         "id": "1GBsIaK94ifWLTSjsECQSKnkyutLebV1RypNYmE2S5gg",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1fNUF2dEuKsH8j-ySMCZNhXbY63Bmlzlp"
+          "1NGzEzrW3b8Fz5PFiZ46Gw3ewvy4WkW03"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:05 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:26 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1fNUF2dEuKsH8j-ySMCZNhXbY63Bmlzlp?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1NGzEzrW3b8Fz5PFiZ46Gw3ewvy4WkW03?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -206,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:05 GMT
+      - Thu, 18 Oct 2018 09:29:26 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -217,9 +234,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 22:29:05 GMT
+      - Thu, 18 Oct 2018 09:29:26 GMT
       Date:
-      - Sun, 18 Mar 2018 22:29:05 GMT
+      - Thu, 18 Oct 2018 09:29:26 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -238,28 +255,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1fNUF2dEuKsH8j-ySMCZNhXbY63Bmlzlp",
-         "name": "Test @ 2018-03-18 22:29:03 UTC",
+         "id": "1NGzEzrW3b8Fz5PFiZ46Gw3ewvy4WkW03",
+         "name": "Test @ 2018-10-18 09:29:24 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:05 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:26 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1fNUF2dEuKsH8j-ySMCZNhXbY63Bmlzlp/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1NGzEzrW3b8Fz5PFiZ46Gw3ewvy4WkW03/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -271,7 +298,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:05 GMT
+      - Thu, 18 Oct 2018 09:29:26 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -289,9 +316,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 22:29:05 GMT
+      - Thu, 18 Oct 2018 09:29:26 GMT
       Expires:
-      - Sun, 18 Mar 2018 22:29:05 GMT
+      - Thu, 18 Oct 2018 09:29:26 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -303,8 +330,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -324,10 +350,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:05 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:27 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1EsQ1BykAMF_pMWlHUnC8qEiylX9HO88BoP4OELeppgk?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1GBsIaK94ifWLTSjsECQSKnkyutLebV1RypNYmE2S5gg?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -339,7 +365,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:06 GMT
+      - Thu, 18 Oct 2018 09:29:27 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -350,9 +376,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 22:29:06 GMT
+      - Thu, 18 Oct 2018 09:29:27 GMT
       Date:
-      - Sun, 18 Mar 2018 22:29:06 GMT
+      - Thu, 18 Oct 2018 09:29:27 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -371,28 +397,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1EsQ1BykAMF_pMWlHUnC8qEiylX9HO88BoP4OELeppgk",
+         "id": "1GBsIaK94ifWLTSjsECQSKnkyutLebV1RypNYmE2S5gg",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1fNUF2dEuKsH8j-ySMCZNhXbY63Bmlzlp"
+          "1NGzEzrW3b8Fz5PFiZ46Gw3ewvy4WkW03"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:06 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:27 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1EsQ1BykAMF_pMWlHUnC8qEiylX9HO88BoP4OELeppgk/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1GBsIaK94ifWLTSjsECQSKnkyutLebV1RypNYmE2S5gg/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -404,7 +440,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:06 GMT
+      - Thu, 18 Oct 2018 09:29:27 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -415,9 +451,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 22:29:06 GMT
+      - Thu, 18 Oct 2018 09:29:27 GMT
       Date:
-      - Sun, 18 Mar 2018 22:29:06 GMT
+      - Thu, 18 Oct 2018 09:29:27 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -436,8 +472,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -447,13 +482,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-03-18T22:29:04.823Z"
+         "modifiedTime": "2018-10-18T09:29:25.900Z"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:06 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:27 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1EsQ1BykAMF_pMWlHUnC8qEiylX9HO88BoP4OELeppgk
+    uri: https://www.googleapis.com/drive/v3/files/1GBsIaK94ifWLTSjsECQSKnkyutLebV1RypNYmE2S5gg
     body:
       encoding: UTF-8
       string: ''
@@ -465,7 +500,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:06 GMT
+      - Thu, 18 Oct 2018 09:29:27 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -482,23 +517,22 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 22:29:07 GMT
+      - Thu, 18 Oct 2018 09:29:27 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:07 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:28 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1EsQ1BykAMF_pMWlHUnC8qEiylX9HO88BoP4OELeppgk?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1GBsIaK94ifWLTSjsECQSKnkyutLebV1RypNYmE2S5gg?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -510,7 +544,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:07 GMT
+      - Thu, 18 Oct 2018 09:29:28 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -528,9 +562,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 22:29:07 GMT
+      - Thu, 18 Oct 2018 09:29:28 GMT
       Expires:
-      - Sun, 18 Mar 2018 22:29:07 GMT
+      - Thu, 18 Oct 2018 09:29:28 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -542,8 +576,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -555,20 +588,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1EsQ1BykAMF_pMWlHUnC8qEiylX9HO88BoP4OELeppgk.",
+            "message": "File not found: 1GBsIaK94ifWLTSjsECQSKnkyutLebV1RypNYmE2S5gg.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1EsQ1BykAMF_pMWlHUnC8qEiylX9HO88BoP4OELeppgk."
+          "message": "File not found: 1GBsIaK94ifWLTSjsECQSKnkyutLebV1RypNYmE2S5gg."
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:07 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:28 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1fNUF2dEuKsH8j-ySMCZNhXbY63Bmlzlp
+    uri: https://www.googleapis.com/drive/v3/files/1NGzEzrW3b8Fz5PFiZ46Gw3ewvy4WkW03
     body:
       encoding: UTF-8
       string: ''
@@ -580,7 +613,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:07 GMT
+      - Thu, 18 Oct 2018 09:29:28 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -597,18 +630,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 22:29:07 GMT
+      - Thu, 18 Oct 2018 09:29:28 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:07 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:28 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/FileResources_GoogleDrive/snapshotable_stageable_syncable/can_pull_a_snapshot_of_an_existing_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/FileResources_GoogleDrive/snapshotable_stageable_syncable/can_pull_a_snapshot_of_an_existing_file.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,49 +21,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 22:29:10 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:29:13 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:10 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:13 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        22:29:10 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:29:13 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -72,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:10 GMT
+      - Thu, 18 Oct 2018 09:29:13 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -89,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 22:29:11 GMT
+      - Thu, 18 Oct 2018 09:29:13 GMT
       Vary:
       - Origin
       - X-Origin
@@ -106,31 +103,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1muu-toZNrF0iSP799QTeLaf2jGbvFpEv",
-         "name": "Test @ 2018-03-18 22:29:10 UTC",
+         "id": "1siE7nN1he2ZC2DyRVzndljesbt3VzENz",
+         "name": "Test @ 2018-10-18 09:29:13 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:11 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:13 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1muu-toZNrF0iSP799QTeLaf2jGbvFpEv"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1siE7nN1he2ZC2DyRVzndljesbt3VzENz"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -139,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:11 GMT
+      - Thu, 18 Oct 2018 09:29:13 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -156,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 22:29:12 GMT
+      - Thu, 18 Oct 2018 09:29:14 GMT
       Vary:
       - Origin
       - X-Origin
@@ -173,28 +180,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1Yo2a4HRbhLv7R1zjMsvxy-SxMYYztGjq2SPN9viK1YM",
+         "id": "1nt2S8N9ho3mX5Qeh-fRfYwR4Lu4vuIVXdWZLagjSkf0",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1muu-toZNrF0iSP799QTeLaf2jGbvFpEv"
+          "1siE7nN1he2ZC2DyRVzndljesbt3VzENz"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:12 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:14 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1muu-toZNrF0iSP799QTeLaf2jGbvFpEv?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1siE7nN1he2ZC2DyRVzndljesbt3VzENz?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -206,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:12 GMT
+      - Thu, 18 Oct 2018 09:29:14 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -217,9 +234,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 22:29:12 GMT
+      - Thu, 18 Oct 2018 09:29:14 GMT
       Date:
-      - Sun, 18 Mar 2018 22:29:12 GMT
+      - Thu, 18 Oct 2018 09:29:14 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -238,28 +255,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1muu-toZNrF0iSP799QTeLaf2jGbvFpEv",
-         "name": "Test @ 2018-03-18 22:29:10 UTC",
+         "id": "1siE7nN1he2ZC2DyRVzndljesbt3VzENz",
+         "name": "Test @ 2018-10-18 09:29:13 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:12 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:14 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1muu-toZNrF0iSP799QTeLaf2jGbvFpEv/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1siE7nN1he2ZC2DyRVzndljesbt3VzENz/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -271,7 +298,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:12 GMT
+      - Thu, 18 Oct 2018 09:29:14 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -289,9 +316,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 22:29:12 GMT
+      - Thu, 18 Oct 2018 09:29:14 GMT
       Expires:
-      - Sun, 18 Mar 2018 22:29:12 GMT
+      - Thu, 18 Oct 2018 09:29:14 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -303,8 +330,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -324,10 +350,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:12 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:14 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Yo2a4HRbhLv7R1zjMsvxy-SxMYYztGjq2SPN9viK1YM?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1nt2S8N9ho3mX5Qeh-fRfYwR4Lu4vuIVXdWZLagjSkf0?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -339,7 +365,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:12 GMT
+      - Thu, 18 Oct 2018 09:29:15 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -350,9 +376,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 22:29:12 GMT
+      - Thu, 18 Oct 2018 09:29:15 GMT
       Date:
-      - Sun, 18 Mar 2018 22:29:12 GMT
+      - Thu, 18 Oct 2018 09:29:15 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -371,28 +397,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1Yo2a4HRbhLv7R1zjMsvxy-SxMYYztGjq2SPN9viK1YM",
+         "id": "1nt2S8N9ho3mX5Qeh-fRfYwR4Lu4vuIVXdWZLagjSkf0",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1muu-toZNrF0iSP799QTeLaf2jGbvFpEv"
+          "1siE7nN1he2ZC2DyRVzndljesbt3VzENz"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:12 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:15 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Yo2a4HRbhLv7R1zjMsvxy-SxMYYztGjq2SPN9viK1YM/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1nt2S8N9ho3mX5Qeh-fRfYwR4Lu4vuIVXdWZLagjSkf0/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -404,7 +440,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:12 GMT
+      - Thu, 18 Oct 2018 09:29:15 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -415,9 +451,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 22:29:12 GMT
+      - Thu, 18 Oct 2018 09:29:15 GMT
       Date:
-      - Sun, 18 Mar 2018 22:29:12 GMT
+      - Thu, 18 Oct 2018 09:29:15 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -436,8 +472,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -447,13 +482,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-03-18T22:29:11.408Z"
+         "modifiedTime": "2018-10-18T09:29:13.816Z"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:12 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:15 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1Yo2a4HRbhLv7R1zjMsvxy-SxMYYztGjq2SPN9viK1YM?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1nt2S8N9ho3mX5Qeh-fRfYwR4Lu4vuIVXdWZLagjSkf0?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"name":"my new file name"}'
@@ -465,7 +500,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:12 GMT
+      - Thu, 18 Oct 2018 09:29:15 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -482,7 +517,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 22:29:13 GMT
+      - Thu, 18 Oct 2018 09:29:15 GMT
       Vary:
       - Origin
       - X-Origin
@@ -499,28 +534,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1Yo2a4HRbhLv7R1zjMsvxy-SxMYYztGjq2SPN9viK1YM",
+         "id": "1nt2S8N9ho3mX5Qeh-fRfYwR4Lu4vuIVXdWZLagjSkf0",
          "name": "my new file name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1muu-toZNrF0iSP799QTeLaf2jGbvFpEv"
+          "1siE7nN1he2ZC2DyRVzndljesbt3VzENz"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:13 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:16 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/upload/drive/v3/files/1Yo2a4HRbhLv7R1zjMsvxy-SxMYYztGjq2SPN9viK1YM
+    uri: https://www.googleapis.com/upload/drive/v3/files/1nt2S8N9ho3mX5Qeh-fRfYwR4Lu4vuIVXdWZLagjSkf0
     body:
       encoding: UTF-8
       string: ''
@@ -532,7 +577,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:13 GMT
+      - Thu, 18 Oct 2018 09:29:16 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       X-Goog-Upload-Protocol:
@@ -551,22 +596,22 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2UpUFrBJpjSYQcEdilREEf8yP5FiTd0rg96DuCfvfkiG8v1XKOd-Uja77RnEvvqt-aX--ML1HRc_8BlQytyZjjjGqQxXEg
+      - AEnB2UqEawUqpcikzHUGq2ChIrOUFF5hkIMa9zhMtmwN6kJZu3G5b-kWz44zxmnB9yp_6bTeOmGDRZy7mfZHI-hZqcUueowGlgnbEJIzKJiVTF1Per4aPC4
       X-Goog-Upload-Status:
       - active
       X-Goog-Upload-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1Yo2a4HRbhLv7R1zjMsvxy-SxMYYztGjq2SPN9viK1YM?upload_id=AEnB2UpUFrBJpjSYQcEdilREEf8yP5FiTd0rg96DuCfvfkiG8v1XKOd-Uja77RnEvvqt-aX--ML1HRc_8BlQytyZjjjGqQxXEg&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1nt2S8N9ho3mX5Qeh-fRfYwR4Lu4vuIVXdWZLagjSkf0?upload_id=AEnB2UqEawUqpcikzHUGq2ChIrOUFF5hkIMa9zhMtmwN6kJZu3G5b-kWz44zxmnB9yp_6bTeOmGDRZy7mfZHI-hZqcUueowGlgnbEJIzKJiVTF1Per4aPC4&upload_protocol=resumable
       X-Goog-Upload-Control-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1Yo2a4HRbhLv7R1zjMsvxy-SxMYYztGjq2SPN9viK1YM?upload_id=AEnB2UpUFrBJpjSYQcEdilREEf8yP5FiTd0rg96DuCfvfkiG8v1XKOd-Uja77RnEvvqt-aX--ML1HRc_8BlQytyZjjjGqQxXEg&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1nt2S8N9ho3mX5Qeh-fRfYwR4Lu4vuIVXdWZLagjSkf0?upload_id=AEnB2UqEawUqpcikzHUGq2ChIrOUFF5hkIMa9zhMtmwN6kJZu3G5b-kWz44zxmnB9yp_6bTeOmGDRZy7mfZHI-hZqcUueowGlgnbEJIzKJiVTF1Per4aPC4&upload_protocol=resumable
       X-Goog-Upload-Chunk-Granularity:
       - '262144'
       X-Goog-Upload-Header-Vary:
       - Origin
       - X-Origin
       X-Goog-Upload-Header-X-Google-Backends:
-      - ioag189:4776
+      - iojl19:4300
       X-Goog-Upload-Header-X-Google-Session-Info:
-      - CLrLzJuGFRoCGAY6bwoPZHJpdmUtcm9zeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqYARKEAXlhMjkuR2wyQ0JVWVJZZElkTFZWZnRZYVB5SEVHa3E3ZnNtZzJNQ0V1dmN4LWF2cXZERm1fTTMwLWl4VG4zQmJTb01QSmEtTjU1aG1BNk1GcjExQ0ZlRGFBS1hCS0g3Z2FNWm5PdWJIWnhmT3E1U2RNVktDV2YzRTZ5X05tek15dGRRWTAEOg0xLzdZYTRzRm02VnZ-
+      - CLrLzJuGFRoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqVARKBAXlhMjkuR2xzNkJsM0haR29FcTgyVUg1X0ZzTXVtT0JfRW5ROTN0RU05TURpQ1EwaVFLaGtCQUxTTU1KckVwT1dGMUhoTldXblNSakFHT1BDbVd1VXA0R2tsR2s4S0F4cnY0MnhWNFVXMTRYLW5NVVZUVUJDVk96NXRzRW4xQ3FGNDAEOg0xLzJNM1JHd3dWbFp-
       X-Goog-Upload-Header-Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       X-Goog-Upload-Header-Pragma:
@@ -574,26 +619,25 @@ http_interactions:
       X-Goog-Upload-Header-Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       X-Goog-Upload-Header-Date:
-      - Sun, 18 Mar 2018 22:29:13 GMT
+      - Thu, 18 Oct 2018 09:29:16 GMT
       Content-Length:
       - '0'
       Date:
-      - Sun, 18 Mar 2018 22:29:13 GMT
+      - Thu, 18 Oct 2018 09:29:16 GMT
       Server:
       - UploadServer
       Content-Type:
       - text/html; charset=UTF-8
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:13 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:16 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/upload/drive/v3/files/1Yo2a4HRbhLv7R1zjMsvxy-SxMYYztGjq2SPN9viK1YM?upload_id=AEnB2UpUFrBJpjSYQcEdilREEf8yP5FiTd0rg96DuCfvfkiG8v1XKOd-Uja77RnEvvqt-aX--ML1HRc_8BlQytyZjjjGqQxXEg&upload_protocol=resumable
+    uri: https://www.googleapis.com/upload/drive/v3/files/1nt2S8N9ho3mX5Qeh-fRfYwR4Lu4vuIVXdWZLagjSkf0?upload_id=AEnB2UqEawUqpcikzHUGq2ChIrOUFF5hkIMa9zhMtmwN6kJZu3G5b-kWz44zxmnB9yp_6bTeOmGDRZy7mfZHI-hZqcUueowGlgnbEJIzKJiVTF1Per4aPC4&upload_protocol=resumable
     body:
       encoding: UTF-8
       string: new file content
@@ -605,7 +649,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:13 GMT
+      - Thu, 18 Oct 2018 09:29:16 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       X-Goog-Upload-Command:
@@ -620,7 +664,7 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2UpUFrBJpjSYQcEdilREEf8yP5FiTd0rg96DuCfvfkiG8v1XKOd-Uja77RnEvvqt-aX--ML1HRc_8BlQytyZjjjGqQxXEg
+      - AEnB2UqEawUqpcikzHUGq2ChIrOUFF5hkIMa9zhMtmwN6kJZu3G5b-kWz44zxmnB9yp_6bTeOmGDRZy7mfZHI-hZqcUueowGlgnbEJIzKJiVTF1Per4aPC4
       X-Goog-Upload-Status:
       - final
       Vary:
@@ -635,28 +679,27 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 22:29:14 GMT
+      - Thu, 18 Oct 2018 09:29:17 GMT
       Content-Length:
       - '163'
       Server:
       - UploadServer
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: |
         {
          "kind": "drive#file",
-         "id": "1Yo2a4HRbhLv7R1zjMsvxy-SxMYYztGjq2SPN9viK1YM",
+         "id": "1nt2S8N9ho3mX5Qeh-fRfYwR4Lu4vuIVXdWZLagjSkf0",
          "name": "my new file name",
          "mimeType": "application/vnd.google-apps.document"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:14 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:17 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Yo2a4HRbhLv7R1zjMsvxy-SxMYYztGjq2SPN9viK1YM?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1nt2S8N9ho3mX5Qeh-fRfYwR4Lu4vuIVXdWZLagjSkf0?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -668,7 +711,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:19 GMT
+      - Thu, 18 Oct 2018 09:29:22 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -679,9 +722,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 22:29:19 GMT
+      - Thu, 18 Oct 2018 09:29:22 GMT
       Date:
-      - Sun, 18 Mar 2018 22:29:19 GMT
+      - Thu, 18 Oct 2018 09:29:22 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -700,29 +743,39 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1Yo2a4HRbhLv7R1zjMsvxy-SxMYYztGjq2SPN9viK1YM",
+         "id": "1nt2S8N9ho3mX5Qeh-fRfYwR4Lu4vuIVXdWZLagjSkf0",
          "name": "my new file name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1muu-toZNrF0iSP799QTeLaf2jGbvFpEv"
+          "1siE7nN1he2ZC2DyRVzndljesbt3VzENz"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Yo2a4HRbhLv7R1zjMsvxy-SxMYYztGjq2SPN9viK1YM&v=1&s=AMedNnoAAAAAWq8EXyb-teveBAVp7OTngszMq_NpZYl1&sz=s220",
-         "thumbnailVersion": "1"
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1nt2S8N9ho3mX5Qeh-fRfYwR4Lu4vuIVXdWZLagjSkf0&v=1&s=AMedNnoAAAAAW8huksEk0le_sICUEwnCf7hrNfmZOiEj&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:19 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:22 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Yo2a4HRbhLv7R1zjMsvxy-SxMYYztGjq2SPN9viK1YM/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1nt2S8N9ho3mX5Qeh-fRfYwR4Lu4vuIVXdWZLagjSkf0/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -734,7 +787,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:19 GMT
+      - Thu, 18 Oct 2018 09:29:22 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -745,9 +798,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 22:29:19 GMT
+      - Thu, 18 Oct 2018 09:29:22 GMT
       Date:
-      - Sun, 18 Mar 2018 22:29:19 GMT
+      - Thu, 18 Oct 2018 09:29:22 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -766,8 +819,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -777,13 +829,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "3",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-03-18T22:29:14.217Z"
+         "modifiedTime": "2018-10-18T09:29:16.846Z"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:19 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:22 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1Yo2a4HRbhLv7R1zjMsvxy-SxMYYztGjq2SPN9viK1YM&s=AMedNnoAAAAAWq8EXyb-teveBAVp7OTngszMq_NpZYl1&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1nt2S8N9ho3mX5Qeh-fRfYwR4Lu4vuIVXdWZLagjSkf0&s=AMedNnoAAAAAW8huksEk0le_sICUEwnCf7hrNfmZOiEj&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -795,7 +847,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:19 GMT
+      - Thu, 18 Oct 2018 09:29:22 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -826,7 +878,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Sun, 18 Mar 2018 22:29:20 GMT
+      - Thu, 18 Oct 2018 09:29:23 GMT
       Server:
       - fife
       Content-Length:
@@ -834,17 +886,16 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:20 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:23 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1muu-toZNrF0iSP799QTeLaf2jGbvFpEv
+    uri: https://www.googleapis.com/drive/v3/files/1siE7nN1he2ZC2DyRVzndljesbt3VzENz
     body:
       encoding: UTF-8
       string: ''
@@ -856,7 +907,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 22:29:20 GMT
+      - Thu, 18 Oct 2018 09:29:23 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -873,18 +924,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 22:29:20 GMT
+      - Thu, 18 Oct 2018 09:29:24 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 22:29:20 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:24 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_creates_file_within_project_folder.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_creates_file_within_project_folder.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,42 +21,39 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:36:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:35:16 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:36:17 GMT
+  recorded_at: Thu, 18 Oct 2018 09:35:16 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -66,7 +63,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -78,49 +75,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:36:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:35:16 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:36:17 GMT
+  recorded_at: Thu, 18 Oct 2018 09:35:16 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        21:36:17 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:35:16 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -129,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:36:17 GMT
+      - Thu, 18 Oct 2018 09:35:16 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -146,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:36:18 GMT
+      - Thu, 18 Oct 2018 09:35:17 GMT
       Vary:
       - Origin
       - X-Origin
@@ -163,28 +157,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1J4_GfYrOXxJ-TcmsF15VmZD_xZ9DDs8D",
-         "name": "Test @ 2018-03-18 21:36:17 UTC",
+         "id": "1eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr",
+         "name": "Test @ 2018-10-18 09:35:16 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AEIi2L68pCuiUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:36:18 GMT
+  recorded_at: Thu, 18 Oct 2018 09:35:17 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1J4_GfYrOXxJ-TcmsF15VmZD_xZ9DDs8D/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -196,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:36:18 GMT
+      - Thu, 18 Oct 2018 09:35:17 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -213,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:36:18 GMT
+      - Thu, 18 Oct 2018 09:35:18 GMT
       Vary:
       - Origin
       - X-Origin
@@ -230,8 +234,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -244,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:36:18 GMT
+  recorded_at: Thu, 18 Oct 2018 09:35:18 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -259,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:36:18 GMT
+      - Thu, 18 Oct 2018 09:35:18 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -270,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:36:18 GMT
+      - Thu, 18 Oct 2018 09:35:18 GMT
       Date:
-      - Sun, 18 Mar 2018 21:36:18 GMT
+      - Thu, 18 Oct 2018 09:35:18 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -291,8 +294,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -300,13 +302,13 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "7191"
+         "startPageToken": "9351"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:36:18 GMT
+  recorded_at: Thu, 18 Oct 2018 09:35:18 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1J4_GfYrOXxJ-TcmsF15VmZD_xZ9DDs8D?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -318,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:36:19 GMT
+      - Thu, 18 Oct 2018 09:35:18 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -329,9 +331,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:36:19 GMT
+      - Thu, 18 Oct 2018 09:35:18 GMT
       Date:
-      - Sun, 18 Mar 2018 21:36:19 GMT
+      - Thu, 18 Oct 2018 09:35:18 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -350,25 +352,44 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1J4_GfYrOXxJ-TcmsF15VmZD_xZ9DDs8D",
-         "name": "Test @ 2018-03-18 21:36:17 UTC",
+         "id": "1eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr",
+         "name": "Test @ 2018-10-18 09:35:16 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:36:19 GMT
+  recorded_at: Thu, 18 Oct 2018 09:35:18 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1J4_GfYrOXxJ-TcmsF15VmZD_xZ9DDs8D/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -380,7 +401,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:36:19 GMT
+      - Thu, 18 Oct 2018 09:35:18 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -398,9 +419,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:36:19 GMT
+      - Thu, 18 Oct 2018 09:35:18 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:36:19 GMT
+      - Thu, 18 Oct 2018 09:35:18 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -412,8 +433,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -433,10 +453,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:36:19 GMT
+  recorded_at: Thu, 18 Oct 2018 09:35:18 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271J4_GfYrOXxJ-TcmsF15VmZD_xZ9DDs8D%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -448,7 +468,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:36:19 GMT
+      - Thu, 18 Oct 2018 09:35:18 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -459,9 +479,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:36:19 GMT
+      - Thu, 18 Oct 2018 09:35:19 GMT
       Date:
-      - Sun, 18 Mar 2018 21:36:19 GMT
+      - Thu, 18 Oct 2018 09:35:19 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -480,8 +500,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -491,13 +510,13 @@ http_interactions:
          "files": []
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:36:19 GMT
+  recorded_at: Thu, 18 Oct 2018 09:35:19 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"My New File","parents":["1J4_GfYrOXxJ-TcmsF15VmZD_xZ9DDs8D"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"My New File","parents":["1eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -506,7 +525,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:36:19 GMT
+      - Thu, 18 Oct 2018 09:35:19 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -523,7 +542,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:36:20 GMT
+      - Thu, 18 Oct 2018 09:35:20 GMT
       Vary:
       - Origin
       - X-Origin
@@ -540,94 +559,47 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1aphYh0oWixQA_olnJOqJwJyf9M_EAOT6fNC4x0Ikk6k",
+         "id": "1iB2qfWA_iDp8FYz9jYFRRzFfTTRLERrw7mFQheUbF4Q",
          "name": "My New File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1J4_GfYrOXxJ-TcmsF15VmZD_xZ9DDs8D"
+          "1eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr"
          ],
-         "thumbnailVersion": "0"
-        }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:36:20 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=7191
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sun, 18 Mar 2018 21:37:20 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sun, 18 Mar 2018 21:37:20 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:37:20 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "newStartPageToken": "7193",
-         "changes": [
+         "thumbnailVersion": "0",
+         "permissions": [
           {
-           "fileId": "1J4_GfYrOXxJ-TcmsF15VmZD_xZ9DDs8D"
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
           },
           {
-           "fileId": "1aphYh0oWixQA_olnJOqJwJyf9M_EAOT6fNC4x0Ikk6k"
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:37:20 GMT
+  recorded_at: Thu, 18 Oct 2018 09:35:20 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1J4_GfYrOXxJ-TcmsF15VmZD_xZ9DDs8D?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9351
     body:
       encoding: UTF-8
       string: ''
@@ -639,7 +611,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:37:20 GMT
+      - Thu, 18 Oct 2018 09:36:20 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -650,9 +622,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:37:21 GMT
+      - Thu, 18 Oct 2018 09:36:20 GMT
       Date:
-      - Sun, 18 Mar 2018 21:37:21 GMT
+      - Thu, 18 Oct 2018 09:36:20 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -671,25 +643,31 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1J4_GfYrOXxJ-TcmsF15VmZD_xZ9DDs8D",
-         "name": "Test @ 2018-03-18 21:36:17 UTC",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "thumbnailVersion": "0"
+         "newStartPageToken": "9354",
+         "changes": [
+          {
+           "fileId": "1eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr"
+          },
+          {
+           "fileId": "193gJcpGvFfo0qBL-BRF09lGKYZ7-Arfj_cdxusnWsLQ"
+          },
+          {
+           "fileId": "1iB2qfWA_iDp8FYz9jYFRRzFfTTRLERrw7mFQheUbF4Q"
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:37:21 GMT
+  recorded_at: Thu, 18 Oct 2018 09:36:20 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1J4_GfYrOXxJ-TcmsF15VmZD_xZ9DDs8D/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -701,7 +679,88 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:37:21 GMT
+      - Thu, 18 Oct 2018 09:36:20 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 09:36:20 GMT
+      Date:
+      - Thu, 18 Oct 2018 09:36:20 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr",
+         "name": "Test @ 2018-10-18 09:35:16 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 09:36:21 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 09:36:21 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -719,9 +778,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:37:21 GMT
+      - Thu, 18 Oct 2018 09:36:21 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:37:21 GMT
+      - Thu, 18 Oct 2018 09:36:21 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -733,8 +792,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -754,10 +812,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:37:21 GMT
+  recorded_at: Thu, 18 Oct 2018 09:36:21 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1aphYh0oWixQA_olnJOqJwJyf9M_EAOT6fNC4x0Ikk6k?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/193gJcpGvFfo0qBL-BRF09lGKYZ7-Arfj_cdxusnWsLQ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -769,22 +827,16 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:37:21 GMT
+      - Thu, 18 Oct 2018 09:36:21 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
       - application/x-www-form-urlencoded
   response:
     status:
-      code: 200
-      message: OK
+      code: 404
+      message: Not Found
     headers:
-      Expires:
-      - Sun, 18 Mar 2018 21:37:21 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:37:21 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
       Vary:
       - Origin
       - X-Origin
@@ -792,6 +844,12 @@ http_interactions:
       - application/json; charset=UTF-8
       Content-Encoding:
       - gzip
+      Date:
+      - Thu, 18 Oct 2018 09:36:21 GMT
+      Expires:
+      - Thu, 18 Oct 2018 09:36:21 GMT
+      Cache-Control:
+      - private, max-age=0
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -801,29 +859,32 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1aphYh0oWixQA_olnJOqJwJyf9M_EAOT6fNC4x0Ikk6k",
-         "name": "My New File",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1J4_GfYrOXxJ-TcmsF15VmZD_xZ9DDs8D"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1aphYh0oWixQA_olnJOqJwJyf9M_EAOT6fNC4x0Ikk6k&v=1&s=AMedNnoAAAAAWq74MTRZ_N_tMr0R3ZlF4_L6bhsdEJrU&sz=s220",
-         "thumbnailVersion": "1"
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "notFound",
+            "message": "File not found: 193gJcpGvFfo0qBL-BRF09lGKYZ7-Arfj_cdxusnWsLQ.",
+            "locationType": "parameter",
+            "location": "fileId"
+           }
+          ],
+          "code": 404,
+          "message": "File not found: 193gJcpGvFfo0qBL-BRF09lGKYZ7-Arfj_cdxusnWsLQ."
+         }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:37:21 GMT
+  recorded_at: Thu, 18 Oct 2018 09:36:21 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1aphYh0oWixQA_olnJOqJwJyf9M_EAOT6fNC4x0Ikk6k/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1iB2qfWA_iDp8FYz9jYFRRzFfTTRLERrw7mFQheUbF4Q?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -835,7 +896,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:37:21 GMT
+      - Thu, 18 Oct 2018 09:36:21 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -846,9 +907,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:37:21 GMT
+      - Thu, 18 Oct 2018 09:36:21 GMT
       Date:
-      - Sun, 18 Mar 2018 21:37:21 GMT
+      - Thu, 18 Oct 2018 09:36:21 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -867,8 +928,92 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1iB2qfWA_iDp8FYz9jYFRRzFfTTRLERrw7mFQheUbF4Q",
+         "name": "My New File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1iB2qfWA_iDp8FYz9jYFRRzFfTTRLERrw7mFQheUbF4Q&v=1&s=AMedNnoAAAAAW8hwNZ3PnqHjGDDliaJmNdT4JhAW8mrX&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 09:36:21 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1iB2qfWA_iDp8FYz9jYFRRzFfTTRLERrw7mFQheUbF4Q/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 09:36:21 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 09:36:21 GMT
+      Date:
+      - Thu, 18 Oct 2018 09:36:21 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -878,13 +1023,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-03-18T21:36:19.885Z"
+         "modifiedTime": "2018-10-18T09:35:19.277Z"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:37:21 GMT
+  recorded_at: Thu, 18 Oct 2018 09:36:21 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1aphYh0oWixQA_olnJOqJwJyf9M_EAOT6fNC4x0Ikk6k&s=AMedNnoAAAAAWq74MTRZ_N_tMr0R3ZlF4_L6bhsdEJrU&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1iB2qfWA_iDp8FYz9jYFRRzFfTTRLERrw7mFQheUbF4Q&s=AMedNnoAAAAAW8hwNZ3PnqHjGDDliaJmNdT4JhAW8mrX&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -896,7 +1041,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:37:21 GMT
+      - Thu, 18 Oct 2018 09:36:21 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -927,7 +1072,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Sun, 18 Mar 2018 21:37:22 GMT
+      - Thu, 18 Oct 2018 09:36:21 GMT
       Server:
       - fife
       Content-Length:
@@ -935,17 +1080,16 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:37:22 GMT
+  recorded_at: Thu, 18 Oct 2018 09:36:21 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1J4_GfYrOXxJ-TcmsF15VmZD_xZ9DDs8D
+    uri: https://www.googleapis.com/drive/v3/files/1eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr
     body:
       encoding: UTF-8
       string: ''
@@ -957,7 +1101,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:37:22 GMT
+      - Thu, 18 Oct 2018 09:36:22 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -974,18 +1118,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:37:23 GMT
+      - Thu, 18 Oct 2018 09:36:22 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:37:23 GMT
+  recorded_at: Thu, 18 Oct 2018 09:36:22 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_creates_file_within_project_folder.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_creates_file_within_project_folder.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:35:16 GMT
+      - Thu, 18 Oct 2018 11:13:03 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:35:16 GMT
+  recorded_at: Thu, 18 Oct 2018 11:13:03 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:35:16 GMT
+      - Thu, 18 Oct 2018 11:13:03 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:35:16 GMT
+  recorded_at: Thu, 18 Oct 2018 11:13:03 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        09:35:16 UTC","parents":["root"]}'
+        11:13:03 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:35:16 GMT
+      - Thu, 18 Oct 2018 11:13:03 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:35:17 GMT
+      - Thu, 18 Oct 2018 11:13:04 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr",
-         "name": "Test @ 2018-10-18 09:35:16 UTC",
+         "id": "1y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR",
+         "name": "Test @ 2018-10-18 11:13:03 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:35:17 GMT
+  recorded_at: Thu, 18 Oct 2018 11:13:04 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:35:17 GMT
+      - Thu, 18 Oct 2018 11:13:04 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:35:18 GMT
+      - Thu, 18 Oct 2018 11:13:04 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:35:18 GMT
+  recorded_at: Thu, 18 Oct 2018 11:13:04 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:35:18 GMT
+      - Thu, 18 Oct 2018 11:13:04 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:35:18 GMT
+      - Thu, 18 Oct 2018 11:13:04 GMT
       Date:
-      - Thu, 18 Oct 2018 09:35:18 GMT
+      - Thu, 18 Oct 2018 11:13:04 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,13 +302,153 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "9351"
+         "startPageToken": "9564"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:35:18 GMT
+  recorded_at: Thu, 18 Oct 2018 11:13:04 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"10 Golgafrinchan
+        Ark Fleet Ship B (Archive)","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:13:05 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:13:05 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1bSuEDdPTVC6OEiq_2JL_BvJiqGvoJnr-",
+         "name": "10 Golgafrinchan Ark Fleet Ship B (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:13:05 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1bSuEDdPTVC6OEiq_2JL_BvJiqGvoJnr-/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:13:05 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:13:06 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "13193959451567607887",
+         "type": "user",
+         "role": "reader"
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:13:06 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1bSuEDdPTVC6OEiq_2JL_BvJiqGvoJnr-?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -320,7 +460,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:35:18 GMT
+      - Thu, 18 Oct 2018 11:13:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -331,9 +471,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:35:18 GMT
+      - Thu, 18 Oct 2018 11:13:06 GMT
       Date:
-      - Thu, 18 Oct 2018 09:35:18 GMT
+      - Thu, 18 Oct 2018 11:13:06 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -359,37 +499,40 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr",
-         "name": "Test @ 2018-10-18 09:35:16 UTC",
+         "id": "1bSuEDdPTVC6OEiq_2JL_BvJiqGvoJnr-",
+         "name": "10 Golgafrinchan Ark Fleet Ship B (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
          "thumbnailVersion": "0",
          "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
           {
            "kind": "drive#permission",
            "id": "13193959451567607887",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
+           "role": "reader",
            "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
            "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:35:18 GMT
+  recorded_at: Thu, 18 Oct 2018 11:13:06 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1bSuEDdPTVC6OEiq_2JL_BvJiqGvoJnr-/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -401,7 +544,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:35:18 GMT
+      - Thu, 18 Oct 2018 11:13:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -419,9 +562,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:35:18 GMT
+      - Thu, 18 Oct 2018 11:13:06 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:35:18 GMT
+      - Thu, 18 Oct 2018 11:13:06 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -453,10 +596,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:35:18 GMT
+  recorded_at: Thu, 18 Oct 2018 11:13:06 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files/1y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -468,7 +611,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:35:18 GMT
+      - Thu, 18 Oct 2018 11:13:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -479,9 +622,157 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:35:19 GMT
+      - Thu, 18 Oct 2018 11:13:06 GMT
       Date:
-      - Thu, 18 Oct 2018 09:35:19 GMT
+      - Thu, 18 Oct 2018 11:13:06 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR",
+         "name": "Test @ 2018-10-18 11:13:03 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:13:06 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:13:06 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:13:07 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:13:07 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:13:07 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:13:07 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:13:07 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:13:07 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -510,13 +801,13 @@ http_interactions:
          "files": []
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:35:19 GMT
+  recorded_at: Thu, 18 Oct 2018 11:13:07 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"My New File","parents":["1eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"My New File","parents":["1y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -525,7 +816,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:35:19 GMT
+      - Thu, 18 Oct 2018 11:13:07 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -542,7 +833,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:35:20 GMT
+      - Thu, 18 Oct 2018 11:13:08 GMT
       Vary:
       - Origin
       - X-Origin
@@ -566,12 +857,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1iB2qfWA_iDp8FYz9jYFRRzFfTTRLERrw7mFQheUbF4Q",
+         "id": "1yL-c0dQhtsTTZfZ-Oc3Pzb6ak1wYveGM3AOgVIH75XE",
          "name": "My New File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr"
+          "1y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -596,10 +887,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:35:20 GMT
+  recorded_at: Thu, 18 Oct 2018 11:13:08 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9351
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9564
     body:
       encoding: UTF-8
       string: ''
@@ -611,7 +902,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:36:20 GMT
+      - Thu, 18 Oct 2018 11:14:08 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -622,9 +913,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:36:20 GMT
+      - Thu, 18 Oct 2018 11:14:08 GMT
       Date:
-      - Thu, 18 Oct 2018 09:36:20 GMT
+      - Thu, 18 Oct 2018 11:14:08 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -650,24 +941,30 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "9354",
+         "newStartPageToken": "9571",
          "changes": [
           {
-           "fileId": "1eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr"
+           "fileId": "1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM"
           },
           {
-           "fileId": "193gJcpGvFfo0qBL-BRF09lGKYZ7-Arfj_cdxusnWsLQ"
+           "fileId": "1bSuEDdPTVC6OEiq_2JL_BvJiqGvoJnr-"
           },
           {
-           "fileId": "1iB2qfWA_iDp8FYz9jYFRRzFfTTRLERrw7mFQheUbF4Q"
+           "fileId": "1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu"
+          },
+          {
+           "fileId": "1yL-c0dQhtsTTZfZ-Oc3Pzb6ak1wYveGM3AOgVIH75XE"
+          },
+          {
+           "fileId": "1y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR"
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:36:20 GMT
+  recorded_at: Thu, 18 Oct 2018 11:14:08 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -679,7 +976,76 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:36:20 GMT
+      - Thu, 18 Oct 2018 11:14:08 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:14:08 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:14:08 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "notFound",
+            "message": "File not found: 1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM.",
+            "locationType": "parameter",
+            "location": "fileId"
+           }
+          ],
+          "code": 404,
+          "message": "File not found: 1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:14:08 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1bSuEDdPTVC6OEiq_2JL_BvJiqGvoJnr-?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:14:08 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -690,9 +1056,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:36:20 GMT
+      - Thu, 18 Oct 2018 11:14:09 GMT
       Date:
-      - Thu, 18 Oct 2018 09:36:20 GMT
+      - Thu, 18 Oct 2018 11:14:09 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -718,37 +1084,40 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr",
-         "name": "Test @ 2018-10-18 09:35:16 UTC",
+         "id": "1bSuEDdPTVC6OEiq_2JL_BvJiqGvoJnr-",
+         "name": "10 Golgafrinchan Ark Fleet Ship B (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
          "thumbnailVersion": "0",
          "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
           {
            "kind": "drive#permission",
            "id": "13193959451567607887",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
+           "role": "reader",
            "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
            "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:36:21 GMT
+  recorded_at: Thu, 18 Oct 2018 11:14:09 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1bSuEDdPTVC6OEiq_2JL_BvJiqGvoJnr-/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -760,7 +1129,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:36:21 GMT
+      - Thu, 18 Oct 2018 11:14:09 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -778,9 +1147,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:36:21 GMT
+      - Thu, 18 Oct 2018 11:14:09 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:36:21 GMT
+      - Thu, 18 Oct 2018 11:14:09 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -812,10 +1181,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:36:21 GMT
+  recorded_at: Thu, 18 Oct 2018 11:14:09 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/193gJcpGvFfo0qBL-BRF09lGKYZ7-Arfj_cdxusnWsLQ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -827,7 +1196,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:36:21 GMT
+      - Thu, 18 Oct 2018 11:14:09 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -845,9 +1214,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:36:21 GMT
+      - Thu, 18 Oct 2018 11:14:09 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:36:21 GMT
+      - Thu, 18 Oct 2018 11:14:09 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -871,20 +1240,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 193gJcpGvFfo0qBL-BRF09lGKYZ7-Arfj_cdxusnWsLQ.",
+            "message": "File not found: 1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 193gJcpGvFfo0qBL-BRF09lGKYZ7-Arfj_cdxusnWsLQ."
+          "message": "File not found: 1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu."
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:36:21 GMT
+  recorded_at: Thu, 18 Oct 2018 11:14:09 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1iB2qfWA_iDp8FYz9jYFRRzFfTTRLERrw7mFQheUbF4Q?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1yL-c0dQhtsTTZfZ-Oc3Pzb6ak1wYveGM3AOgVIH75XE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -896,7 +1265,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:36:21 GMT
+      - Thu, 18 Oct 2018 11:14:09 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -907,9 +1276,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:36:21 GMT
+      - Thu, 18 Oct 2018 11:14:09 GMT
       Date:
-      - Thu, 18 Oct 2018 09:36:21 GMT
+      - Thu, 18 Oct 2018 11:14:09 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -935,14 +1304,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1iB2qfWA_iDp8FYz9jYFRRzFfTTRLERrw7mFQheUbF4Q",
+         "id": "1yL-c0dQhtsTTZfZ-Oc3Pzb6ak1wYveGM3AOgVIH75XE",
          "name": "My New File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr"
+          "1y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1iB2qfWA_iDp8FYz9jYFRRzFfTTRLERrw7mFQheUbF4Q&v=1&s=AMedNnoAAAAAW8hwNZ3PnqHjGDDliaJmNdT4JhAW8mrX&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1yL-c0dQhtsTTZfZ-Oc3Pzb6ak1wYveGM3AOgVIH75XE&v=1&s=AMedNnoAAAAAW8iHIfvJ7PI6wGuo04ndtYmRsjiBUHfd&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -966,10 +1335,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:36:21 GMT
+  recorded_at: Thu, 18 Oct 2018 11:14:09 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1iB2qfWA_iDp8FYz9jYFRRzFfTTRLERrw7mFQheUbF4Q/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1yL-c0dQhtsTTZfZ-Oc3Pzb6ak1wYveGM3AOgVIH75XE/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -981,7 +1350,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:36:21 GMT
+      - Thu, 18 Oct 2018 11:14:09 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -992,9 +1361,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:36:21 GMT
+      - Thu, 18 Oct 2018 11:14:09 GMT
       Date:
-      - Thu, 18 Oct 2018 09:36:21 GMT
+      - Thu, 18 Oct 2018 11:14:09 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1023,13 +1392,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T09:35:19.277Z"
+         "modifiedTime": "2018-10-18T11:13:07.718Z"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:36:21 GMT
+  recorded_at: Thu, 18 Oct 2018 11:14:09 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1iB2qfWA_iDp8FYz9jYFRRzFfTTRLERrw7mFQheUbF4Q&s=AMedNnoAAAAAW8hwNZ3PnqHjGDDliaJmNdT4JhAW8mrX&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1yL-c0dQhtsTTZfZ-Oc3Pzb6ak1wYveGM3AOgVIH75XE&s=AMedNnoAAAAAW8iHIfvJ7PI6wGuo04ndtYmRsjiBUHfd&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1041,7 +1410,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:36:21 GMT
+      - Thu, 18 Oct 2018 11:14:09 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1072,7 +1441,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 18 Oct 2018 09:36:21 GMT
+      - Thu, 18 Oct 2018 11:14:10 GMT
       Server:
       - fife
       Content-Length:
@@ -1086,10 +1455,10 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:36:21 GMT
+  recorded_at: Thu, 18 Oct 2018 11:14:10 GMT
 - request:
-    method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1eeIuMONCvr4ViZo7nLDUbdJYLPktvsDr
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1101,7 +1470,155 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:36:22 GMT
+      - Thu, 18 Oct 2018 11:14:10 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:14:10 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:14:10 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR",
+         "name": "Test @ 2018-10-18 11:13:03 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:14:10 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:14:10 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:14:10 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:14:10 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:14:10 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:14:10 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1118,7 +1635,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:36:22 GMT
+      - Thu, 18 Oct 2018 11:14:11 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1130,5 +1647,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:36:22 GMT
+  recorded_at: Thu, 18 Oct 2018 11:14:11 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_creates_file_within_project_folder.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_creates_file_within_project_folder.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 11:13:03 GMT
+      - Sat, 20 Oct 2018 20:17:01 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:13:03 GMT
+  recorded_at: Sat, 20 Oct 2018 20:17:01 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 11:13:03 GMT
+      - Sat, 20 Oct 2018 20:17:01 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:13:03 GMT
+  recorded_at: Sat, 20 Oct 2018 20:17:01 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        11:13:03 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-20
+        20:17:01 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:13:03 GMT
+      - Sat, 20 Oct 2018 20:17:01 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:13:04 GMT
+      - Sat, 20 Oct 2018 20:17:01 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR",
-         "name": "Test @ 2018-10-18 11:13:03 UTC",
+         "id": "1AhvFiNcRXYnGbkRZ22j8YaZhT4JyYb2_",
+         "name": "Test @ 2018-10-20 20:17:01 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:13:04 GMT
+  recorded_at: Sat, 20 Oct 2018 20:17:01 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1AhvFiNcRXYnGbkRZ22j8YaZhT4JyYb2_/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:13:04 GMT
+      - Sat, 20 Oct 2018 20:17:01 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:13:04 GMT
+      - Sat, 20 Oct 2018 20:17:02 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:13:04 GMT
+  recorded_at: Sat, 20 Oct 2018 20:17:02 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:13:04 GMT
+      - Sat, 20 Oct 2018 20:17:02 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:13:04 GMT
+      - Sat, 20 Oct 2018 20:17:02 GMT
       Date:
-      - Thu, 18 Oct 2018 11:13:04 GMT
+      - Sat, 20 Oct 2018 20:17:02 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,17 +302,17 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "9564"
+         "startPageToken": "10557"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:13:04 GMT
+  recorded_at: Sat, 20 Oct 2018 20:17:02 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"10 Golgafrinchan
-        Ark Fleet Ship B (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"3 Tanngrisnir
+        (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -321,7 +321,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:13:05 GMT
+      - Sat, 20 Oct 2018 20:17:02 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -338,7 +338,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:13:05 GMT
+      - Sat, 20 Oct 2018 20:17:03 GMT
       Vary:
       - Origin
       - X-Origin
@@ -362,8 +362,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1bSuEDdPTVC6OEiq_2JL_BvJiqGvoJnr-",
-         "name": "10 Golgafrinchan Ark Fleet Ship B (Archive)",
+         "id": "10MxUqzaMmABhiVP51g1Eg7t8eXVFKg5H",
+         "name": "3 Tanngrisnir (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -383,10 +383,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:13:05 GMT
+  recorded_at: Sat, 20 Oct 2018 20:17:03 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1bSuEDdPTVC6OEiq_2JL_BvJiqGvoJnr-/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/10MxUqzaMmABhiVP51g1Eg7t8eXVFKg5H/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -398,7 +398,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:13:05 GMT
+      - Sat, 20 Oct 2018 20:17:03 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -415,7 +415,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:13:06 GMT
+      - Sat, 20 Oct 2018 20:17:04 GMT
       Vary:
       - Origin
       - X-Origin
@@ -445,10 +445,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:13:06 GMT
+  recorded_at: Sat, 20 Oct 2018 20:17:04 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1bSuEDdPTVC6OEiq_2JL_BvJiqGvoJnr-?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/10MxUqzaMmABhiVP51g1Eg7t8eXVFKg5H?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -460,7 +460,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:13:06 GMT
+      - Sat, 20 Oct 2018 20:17:04 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -471,9 +471,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:13:06 GMT
+      - Sat, 20 Oct 2018 20:17:04 GMT
       Date:
-      - Thu, 18 Oct 2018 11:13:06 GMT
+      - Sat, 20 Oct 2018 20:17:04 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -499,8 +499,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1bSuEDdPTVC6OEiq_2JL_BvJiqGvoJnr-",
-         "name": "10 Golgafrinchan Ark Fleet Ship B (Archive)",
+         "id": "10MxUqzaMmABhiVP51g1Eg7t8eXVFKg5H",
+         "name": "3 Tanngrisnir (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -529,10 +529,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:13:06 GMT
+  recorded_at: Sat, 20 Oct 2018 20:17:04 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1bSuEDdPTVC6OEiq_2JL_BvJiqGvoJnr-/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/10MxUqzaMmABhiVP51g1Eg7t8eXVFKg5H/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -544,7 +544,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:13:06 GMT
+      - Sat, 20 Oct 2018 20:17:04 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -562,9 +562,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:13:06 GMT
+      - Sat, 20 Oct 2018 20:17:04 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:13:06 GMT
+      - Sat, 20 Oct 2018 20:17:04 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -596,10 +596,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:13:06 GMT
+  recorded_at: Sat, 20 Oct 2018 20:17:04 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1AhvFiNcRXYnGbkRZ22j8YaZhT4JyYb2_?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -611,7 +611,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:13:06 GMT
+      - Sat, 20 Oct 2018 20:17:04 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -622,9 +622,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:13:06 GMT
+      - Sat, 20 Oct 2018 20:17:04 GMT
       Date:
-      - Thu, 18 Oct 2018 11:13:06 GMT
+      - Sat, 20 Oct 2018 20:17:04 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -650,8 +650,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR",
-         "name": "Test @ 2018-10-18 11:13:03 UTC",
+         "id": "1AhvFiNcRXYnGbkRZ22j8YaZhT4JyYb2_",
+         "name": "Test @ 2018-10-20 20:17:01 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -677,10 +677,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:13:06 GMT
+  recorded_at: Sat, 20 Oct 2018 20:17:04 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1AhvFiNcRXYnGbkRZ22j8YaZhT4JyYb2_/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -692,7 +692,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:13:06 GMT
+      - Sat, 20 Oct 2018 20:17:04 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -710,9 +710,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:13:07 GMT
+      - Sat, 20 Oct 2018 20:17:04 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:13:07 GMT
+      - Sat, 20 Oct 2018 20:17:04 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -744,10 +744,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:13:07 GMT
+  recorded_at: Sat, 20 Oct 2018 20:17:04 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271AhvFiNcRXYnGbkRZ22j8YaZhT4JyYb2_%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -759,7 +759,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:13:07 GMT
+      - Sat, 20 Oct 2018 20:17:04 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -770,9 +770,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:13:07 GMT
+      - Sat, 20 Oct 2018 20:17:04 GMT
       Date:
-      - Thu, 18 Oct 2018 11:13:07 GMT
+      - Sat, 20 Oct 2018 20:17:04 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -801,13 +801,13 @@ http_interactions:
          "files": []
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:13:07 GMT
+  recorded_at: Sat, 20 Oct 2018 20:17:04 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"My New File","parents":["1y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"My New File","parents":["1AhvFiNcRXYnGbkRZ22j8YaZhT4JyYb2_"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -816,7 +816,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:13:07 GMT
+      - Sat, 20 Oct 2018 20:17:05 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -833,7 +833,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:13:08 GMT
+      - Sat, 20 Oct 2018 20:17:05 GMT
       Vary:
       - Origin
       - X-Origin
@@ -857,12 +857,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1yL-c0dQhtsTTZfZ-Oc3Pzb6ak1wYveGM3AOgVIH75XE",
+         "id": "16ePkF143Mo5V1u_qXYzvsvXtzl0GAx_50LsOu6mHbIY",
          "name": "My New File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR"
+          "1AhvFiNcRXYnGbkRZ22j8YaZhT4JyYb2_"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -887,10 +887,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:13:08 GMT
+  recorded_at: Sat, 20 Oct 2018 20:17:06 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9564
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=10557
     body:
       encoding: UTF-8
       string: ''
@@ -902,7 +902,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:14:08 GMT
+      - Sat, 20 Oct 2018 20:18:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -913,9 +913,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:14:08 GMT
+      - Sat, 20 Oct 2018 20:18:06 GMT
       Date:
-      - Thu, 18 Oct 2018 11:14:08 GMT
+      - Sat, 20 Oct 2018 20:18:06 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -941,30 +941,27 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "9571",
+         "newStartPageToken": "10562",
          "changes": [
           {
-           "fileId": "1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM"
+           "fileId": "10MxUqzaMmABhiVP51g1Eg7t8eXVFKg5H"
           },
           {
-           "fileId": "1bSuEDdPTVC6OEiq_2JL_BvJiqGvoJnr-"
+           "fileId": "16cEqt2OVZYu-bmAqwG0_GTQQkkxQpGJlSPg-pKSwPqA"
           },
           {
-           "fileId": "1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu"
+           "fileId": "16ePkF143Mo5V1u_qXYzvsvXtzl0GAx_50LsOu6mHbIY"
           },
           {
-           "fileId": "1yL-c0dQhtsTTZfZ-Oc3Pzb6ak1wYveGM3AOgVIH75XE"
-          },
-          {
-           "fileId": "1y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR"
+           "fileId": "1AhvFiNcRXYnGbkRZ22j8YaZhT4JyYb2_"
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:14:08 GMT
+  recorded_at: Sat, 20 Oct 2018 20:18:06 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/10MxUqzaMmABhiVP51g1Eg7t8eXVFKg5H?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -976,76 +973,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:14:08 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 18 Oct 2018 11:14:08 GMT
-      Expires:
-      - Thu, 18 Oct 2018 11:14:08 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "notFound",
-            "message": "File not found: 1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM.",
-            "locationType": "parameter",
-            "location": "fileId"
-           }
-          ],
-          "code": 404,
-          "message": "File not found: 1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM."
-         }
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:14:08 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1bSuEDdPTVC6OEiq_2JL_BvJiqGvoJnr-?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:14:08 GMT
+      - Sat, 20 Oct 2018 20:18:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1056,9 +984,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:14:09 GMT
+      - Sat, 20 Oct 2018 20:18:06 GMT
       Date:
-      - Thu, 18 Oct 2018 11:14:09 GMT
+      - Sat, 20 Oct 2018 20:18:06 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1084,8 +1012,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1bSuEDdPTVC6OEiq_2JL_BvJiqGvoJnr-",
-         "name": "10 Golgafrinchan Ark Fleet Ship B (Archive)",
+         "id": "10MxUqzaMmABhiVP51g1Eg7t8eXVFKg5H",
+         "name": "3 Tanngrisnir (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -1114,10 +1042,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:14:09 GMT
+  recorded_at: Sat, 20 Oct 2018 20:18:06 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1bSuEDdPTVC6OEiq_2JL_BvJiqGvoJnr-/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/10MxUqzaMmABhiVP51g1Eg7t8eXVFKg5H/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1129,7 +1057,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:14:09 GMT
+      - Sat, 20 Oct 2018 20:18:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1147,9 +1075,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:14:09 GMT
+      - Sat, 20 Oct 2018 20:18:06 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:14:09 GMT
+      - Sat, 20 Oct 2018 20:18:06 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1181,10 +1109,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:14:09 GMT
+  recorded_at: Sat, 20 Oct 2018 20:18:06 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/16cEqt2OVZYu-bmAqwG0_GTQQkkxQpGJlSPg-pKSwPqA?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1196,7 +1124,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:14:09 GMT
+      - Sat, 20 Oct 2018 20:18:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1214,9 +1142,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:14:09 GMT
+      - Sat, 20 Oct 2018 20:18:06 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:14:09 GMT
+      - Sat, 20 Oct 2018 20:18:06 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1240,20 +1168,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu.",
+            "message": "File not found: 16cEqt2OVZYu-bmAqwG0_GTQQkkxQpGJlSPg-pKSwPqA.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu."
+          "message": "File not found: 16cEqt2OVZYu-bmAqwG0_GTQQkkxQpGJlSPg-pKSwPqA."
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:14:09 GMT
+  recorded_at: Sat, 20 Oct 2018 20:18:06 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1yL-c0dQhtsTTZfZ-Oc3Pzb6ak1wYveGM3AOgVIH75XE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/16ePkF143Mo5V1u_qXYzvsvXtzl0GAx_50LsOu6mHbIY?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1265,7 +1193,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:14:09 GMT
+      - Sat, 20 Oct 2018 20:18:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1276,9 +1204,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:14:09 GMT
+      - Sat, 20 Oct 2018 20:18:07 GMT
       Date:
-      - Thu, 18 Oct 2018 11:14:09 GMT
+      - Sat, 20 Oct 2018 20:18:07 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1304,14 +1232,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1yL-c0dQhtsTTZfZ-Oc3Pzb6ak1wYveGM3AOgVIH75XE",
+         "id": "16ePkF143Mo5V1u_qXYzvsvXtzl0GAx_50LsOu6mHbIY",
          "name": "My New File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR"
+          "1AhvFiNcRXYnGbkRZ22j8YaZhT4JyYb2_"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1yL-c0dQhtsTTZfZ-Oc3Pzb6ak1wYveGM3AOgVIH75XE&v=1&s=AMedNnoAAAAAW8iHIfvJ7PI6wGuo04ndtYmRsjiBUHfd&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=16ePkF143Mo5V1u_qXYzvsvXtzl0GAx_50LsOu6mHbIY&v=1&s=AMedNnoAAAAAW8upnzkeYzuEs-ySfpz8VQ1KT9FV5X_o&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -1335,10 +1263,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:14:09 GMT
+  recorded_at: Sat, 20 Oct 2018 20:18:07 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1yL-c0dQhtsTTZfZ-Oc3Pzb6ak1wYveGM3AOgVIH75XE/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/16ePkF143Mo5V1u_qXYzvsvXtzl0GAx_50LsOu6mHbIY/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1350,7 +1278,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:14:09 GMT
+      - Sat, 20 Oct 2018 20:18:07 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1361,9 +1289,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:14:09 GMT
+      - Sat, 20 Oct 2018 20:18:07 GMT
       Date:
-      - Thu, 18 Oct 2018 11:14:09 GMT
+      - Sat, 20 Oct 2018 20:18:07 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1392,13 +1320,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T11:13:07.718Z"
+         "modifiedTime": "2018-10-20T20:17:05.216Z"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:14:09 GMT
+  recorded_at: Sat, 20 Oct 2018 20:18:07 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1yL-c0dQhtsTTZfZ-Oc3Pzb6ak1wYveGM3AOgVIH75XE&s=AMedNnoAAAAAW8iHIfvJ7PI6wGuo04ndtYmRsjiBUHfd&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=16ePkF143Mo5V1u_qXYzvsvXtzl0GAx_50LsOu6mHbIY&s=AMedNnoAAAAAW8upnzkeYzuEs-ySfpz8VQ1KT9FV5X_o&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1410,7 +1338,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:14:09 GMT
+      - Sat, 20 Oct 2018 20:18:07 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1441,7 +1369,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 18 Oct 2018 11:14:10 GMT
+      - Sat, 20 Oct 2018 20:18:07 GMT
       Server:
       - fife
       Content-Length:
@@ -1455,10 +1383,96 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:14:10 GMT
+  recorded_at: Sat, 20 Oct 2018 20:18:07 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/16ePkF143Mo5V1u_qXYzvsvXtzl0GAx_50LsOu6mHbIY/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"My New File","parents":["10MxUqzaMmABhiVP51g1Eg7t8eXVFKg5H"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:18:07 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:18:09 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1zkw03wmd5XIFORK8BaCComM6ZQfqru6_iDJUfk2bUas",
+         "name": "My New File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "10MxUqzaMmABhiVP51g1Eg7t8eXVFKg5H"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:18:09 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1AhvFiNcRXYnGbkRZ22j8YaZhT4JyYb2_?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1470,7 +1484,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:14:10 GMT
+      - Sat, 20 Oct 2018 20:18:09 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1481,9 +1495,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:14:10 GMT
+      - Sat, 20 Oct 2018 20:18:09 GMT
       Date:
-      - Thu, 18 Oct 2018 11:14:10 GMT
+      - Sat, 20 Oct 2018 20:18:09 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1509,8 +1523,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR",
-         "name": "Test @ 2018-10-18 11:13:03 UTC",
+         "id": "1AhvFiNcRXYnGbkRZ22j8YaZhT4JyYb2_",
+         "name": "Test @ 2018-10-20 20:17:01 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -1536,10 +1550,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:14:10 GMT
+  recorded_at: Sat, 20 Oct 2018 20:18:09 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1AhvFiNcRXYnGbkRZ22j8YaZhT4JyYb2_/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1551,7 +1565,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:14:10 GMT
+      - Sat, 20 Oct 2018 20:18:09 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1569,9 +1583,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:14:10 GMT
+      - Sat, 20 Oct 2018 20:18:09 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:14:10 GMT
+      - Sat, 20 Oct 2018 20:18:09 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1603,10 +1617,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:14:10 GMT
+  recorded_at: Sat, 20 Oct 2018 20:18:09 GMT
 - request:
-    method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1y_v2rbuWuMVrakHVGh0eSNE1PRnmugwR
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1zkw03wmd5XIFORK8BaCComM6ZQfqru6_iDJUfk2bUas?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1618,7 +1632,91 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:14:10 GMT
+      - Sat, 20 Oct 2018 20:18:09 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:18:09 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:18:09 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1zkw03wmd5XIFORK8BaCComM6ZQfqru6_iDJUfk2bUas",
+         "name": "My New File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "10MxUqzaMmABhiVP51g1Eg7t8eXVFKg5H"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:18:09 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1AhvFiNcRXYnGbkRZ22j8YaZhT4JyYb2_
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:18:09 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1635,7 +1733,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:14:11 GMT
+      - Sat, 20 Oct 2018 20:18:10 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1647,5 +1745,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:14:11 GMT
+  recorded_at: Sat, 20 Oct 2018 20:18:10 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_deletes_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_deletes_file.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,42 +21,39 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:30:36 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:37:28 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:30:36 GMT
+  recorded_at: Thu, 18 Oct 2018 09:37:28 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -66,7 +63,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -78,49 +75,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:30:36 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:37:29 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:30:36 GMT
+  recorded_at: Thu, 18 Oct 2018 09:37:29 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        21:30:36 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:37:29 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -129,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:30:36 GMT
+      - Thu, 18 Oct 2018 09:37:29 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -146,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:30:37 GMT
+      - Thu, 18 Oct 2018 09:37:29 GMT
       Vary:
       - Origin
       - X-Origin
@@ -163,28 +157,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1AlwdCh--vTgpa8yJgM7t2H-eflC6KqwV",
-         "name": "Test @ 2018-03-18 21:30:36 UTC",
+         "id": "1MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb",
+         "name": "Test @ 2018-10-18 09:37:29 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AEIi2L68pCuiUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:30:37 GMT
+  recorded_at: Thu, 18 Oct 2018 09:37:29 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1AlwdCh--vTgpa8yJgM7t2H-eflC6KqwV/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -196,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:30:37 GMT
+      - Thu, 18 Oct 2018 09:37:29 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -213,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:30:38 GMT
+      - Thu, 18 Oct 2018 09:37:30 GMT
       Vary:
       - Origin
       - X-Origin
@@ -230,8 +234,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -244,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:30:38 GMT
+  recorded_at: Thu, 18 Oct 2018 09:37:30 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -259,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:30:38 GMT
+      - Thu, 18 Oct 2018 09:37:30 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -270,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:30:38 GMT
+      - Thu, 18 Oct 2018 09:37:30 GMT
       Date:
-      - Sun, 18 Mar 2018 21:30:38 GMT
+      - Thu, 18 Oct 2018 09:37:30 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -291,8 +294,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -300,17 +302,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "7163"
+         "startPageToken": "9364"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:30:38 GMT
+  recorded_at: Thu, 18 Oct 2018 09:37:30 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File To
-        Delete","parents":["1AlwdCh--vTgpa8yJgM7t2H-eflC6KqwV"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"To Delete","parents":["1MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -319,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:30:38 GMT
+      - Thu, 18 Oct 2018 09:37:30 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -336,7 +337,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:30:39 GMT
+      - Thu, 18 Oct 2018 09:37:32 GMT
       Vary:
       - Origin
       - X-Origin
@@ -353,28 +354,47 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1IX3SSW5i-872XDuLjdsJ7HY8qJh_A2iuFnHUWkPiY2I",
-         "name": "File To Delete",
+         "id": "1MwMz3H5ioKJ3innEHFAWGfVfU7Adx-Pr5VxiUpTYdfE",
+         "name": "To Delete",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1AlwdCh--vTgpa8yJgM7t2H-eflC6KqwV"
+          "1MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:30:39 GMT
+  recorded_at: Thu, 18 Oct 2018 09:37:32 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1AlwdCh--vTgpa8yJgM7t2H-eflC6KqwV?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -386,7 +406,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:30:39 GMT
+      - Thu, 18 Oct 2018 09:37:32 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -397,9 +417,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:30:40 GMT
+      - Thu, 18 Oct 2018 09:37:32 GMT
       Date:
-      - Sun, 18 Mar 2018 21:30:40 GMT
+      - Thu, 18 Oct 2018 09:37:32 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -418,25 +438,44 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1AlwdCh--vTgpa8yJgM7t2H-eflC6KqwV",
-         "name": "Test @ 2018-03-18 21:30:36 UTC",
+         "id": "1MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb",
+         "name": "Test @ 2018-10-18 09:37:29 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:30:40 GMT
+  recorded_at: Thu, 18 Oct 2018 09:37:32 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1AlwdCh--vTgpa8yJgM7t2H-eflC6KqwV/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -448,7 +487,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:30:40 GMT
+      - Thu, 18 Oct 2018 09:37:32 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -466,9 +505,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:30:40 GMT
+      - Thu, 18 Oct 2018 09:37:32 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:30:40 GMT
+      - Thu, 18 Oct 2018 09:37:32 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -480,8 +519,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -501,10 +539,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:30:40 GMT
+  recorded_at: Thu, 18 Oct 2018 09:37:33 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271AlwdCh--vTgpa8yJgM7t2H-eflC6KqwV%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -516,7 +554,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:30:40 GMT
+      - Thu, 18 Oct 2018 09:37:33 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -527,9 +565,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:30:40 GMT
+      - Thu, 18 Oct 2018 09:37:33 GMT
       Date:
-      - Sun, 18 Mar 2018 21:30:40 GMT
+      - Thu, 18 Oct 2018 09:37:33 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -548,8 +586,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -558,22 +595,42 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1IX3SSW5i-872XDuLjdsJ7HY8qJh_A2iuFnHUWkPiY2I",
-           "name": "File To Delete",
+           "id": "1MwMz3H5ioKJ3innEHFAWGfVfU7Adx-Pr5VxiUpTYdfE",
+           "name": "To Delete",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1AlwdCh--vTgpa8yJgM7t2H-eflC6KqwV"
+            "1MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb"
            ],
-           "thumbnailVersion": "0"
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "writer",
+             "displayName": "Upshift One",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "13193959451567607887",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+             "role": "owner",
+             "displayName": "Testuser Upshift One",
+             "deleted": false
+            }
+           ]
           }
          ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:30:40 GMT
+  recorded_at: Thu, 18 Oct 2018 09:37:33 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1IX3SSW5i-872XDuLjdsJ7HY8qJh_A2iuFnHUWkPiY2I/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1MwMz3H5ioKJ3innEHFAWGfVfU7Adx-Pr5VxiUpTYdfE/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -585,16 +642,22 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:30:40 GMT
+      - Thu, 18 Oct 2018 09:37:33 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
       - application/x-www-form-urlencoded
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 200
+      message: OK
     headers:
+      Expires:
+      - Thu, 18 Oct 2018 09:37:33 GMT
+      Date:
+      - Thu, 18 Oct 2018 09:37:33 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
       Vary:
       - Origin
       - X-Origin
@@ -602,12 +665,6 @@ http_interactions:
       - application/json; charset=UTF-8
       Content-Encoding:
       - gzip
-      Date:
-      - Sun, 18 Mar 2018 21:30:40 GMT
-      Expires:
-      - Sun, 18 Mar 2018 21:30:40 GMT
-      Cache-Control:
-      - private, max-age=0
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -617,33 +674,23 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "notFound",
-            "message": "Revision not found: head.",
-            "locationType": "parameter",
-            "location": "revisionId"
-           }
-          ],
-          "code": 404,
-          "message": "Revision not found: head."
-         }
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-18T09:37:31.551Z"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:30:40 GMT
+  recorded_at: Thu, 18 Oct 2018 09:37:33 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1IX3SSW5i-872XDuLjdsJ7HY8qJh_A2iuFnHUWkPiY2I
+    uri: https://www.googleapis.com/drive/v3/files/1MwMz3H5ioKJ3innEHFAWGfVfU7Adx-Pr5VxiUpTYdfE
     body:
       encoding: UTF-8
       string: ''
@@ -655,7 +702,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:30:40 GMT
+      - Thu, 18 Oct 2018 09:37:33 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -672,23 +719,22 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:30:41 GMT
+      - Thu, 18 Oct 2018 09:37:34 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:30:41 GMT
+  recorded_at: Thu, 18 Oct 2018 09:37:34 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=7163
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9364
     body:
       encoding: UTF-8
       string: ''
@@ -700,7 +746,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:31:41 GMT
+      - Thu, 18 Oct 2018 09:38:34 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -711,9 +757,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:31:41 GMT
+      - Thu, 18 Oct 2018 09:38:34 GMT
       Date:
-      - Sun, 18 Mar 2018 21:31:41 GMT
+      - Thu, 18 Oct 2018 09:38:34 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -732,32 +778,31 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "7168",
+         "newStartPageToken": "9368",
          "changes": [
           {
-           "fileId": "1r2PdAoVVnogkIrwstIlcvYqzrbX_f0VaNNuZdn62soQ"
+           "fileId": "1u9EVYrOHeQaLt0YC6uXhApTnsx5KxTgnKPzQUp_bvlw"
           },
           {
-           "fileId": "1IX3SSW5i-872XDuLjdsJ7HY8qJh_A2iuFnHUWkPiY2I"
+           "fileId": "1MwMz3H5ioKJ3innEHFAWGfVfU7Adx-Pr5VxiUpTYdfE"
           },
           {
-           "fileId": "1AlwdCh--vTgpa8yJgM7t2H-eflC6KqwV"
+           "fileId": "1MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb"
           }
          ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:31:41 GMT
+  recorded_at: Thu, 18 Oct 2018 09:38:34 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1r2PdAoVVnogkIrwstIlcvYqzrbX_f0VaNNuZdn62soQ?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1u9EVYrOHeQaLt0YC6uXhApTnsx5KxTgnKPzQUp_bvlw?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -769,7 +814,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:31:41 GMT
+      - Thu, 18 Oct 2018 09:38:34 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -787,9 +832,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:31:41 GMT
+      - Thu, 18 Oct 2018 09:38:34 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:31:41 GMT
+      - Thu, 18 Oct 2018 09:38:34 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -801,8 +846,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -814,20 +858,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1r2PdAoVVnogkIrwstIlcvYqzrbX_f0VaNNuZdn62soQ.",
+            "message": "File not found: 1u9EVYrOHeQaLt0YC6uXhApTnsx5KxTgnKPzQUp_bvlw.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1r2PdAoVVnogkIrwstIlcvYqzrbX_f0VaNNuZdn62soQ."
+          "message": "File not found: 1u9EVYrOHeQaLt0YC6uXhApTnsx5KxTgnKPzQUp_bvlw."
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:31:41 GMT
+  recorded_at: Thu, 18 Oct 2018 09:38:34 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1IX3SSW5i-872XDuLjdsJ7HY8qJh_A2iuFnHUWkPiY2I?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1MwMz3H5ioKJ3innEHFAWGfVfU7Adx-Pr5VxiUpTYdfE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -839,7 +883,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:31:41 GMT
+      - Thu, 18 Oct 2018 09:38:34 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -857,9 +901,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:31:42 GMT
+      - Thu, 18 Oct 2018 09:38:34 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:31:42 GMT
+      - Thu, 18 Oct 2018 09:38:34 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -871,8 +915,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -884,20 +927,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1IX3SSW5i-872XDuLjdsJ7HY8qJh_A2iuFnHUWkPiY2I.",
+            "message": "File not found: 1MwMz3H5ioKJ3innEHFAWGfVfU7Adx-Pr5VxiUpTYdfE.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1IX3SSW5i-872XDuLjdsJ7HY8qJh_A2iuFnHUWkPiY2I."
+          "message": "File not found: 1MwMz3H5ioKJ3innEHFAWGfVfU7Adx-Pr5VxiUpTYdfE."
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:31:42 GMT
+  recorded_at: Thu, 18 Oct 2018 09:38:34 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1AlwdCh--vTgpa8yJgM7t2H-eflC6KqwV?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -909,7 +952,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:31:42 GMT
+      - Thu, 18 Oct 2018 09:38:34 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -920,9 +963,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:31:42 GMT
+      - Thu, 18 Oct 2018 09:38:34 GMT
       Date:
-      - Sun, 18 Mar 2018 21:31:42 GMT
+      - Thu, 18 Oct 2018 09:38:34 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -941,25 +984,44 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1AlwdCh--vTgpa8yJgM7t2H-eflC6KqwV",
-         "name": "Test @ 2018-03-18 21:30:36 UTC",
+         "id": "1MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb",
+         "name": "Test @ 2018-10-18 09:37:29 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:31:42 GMT
+  recorded_at: Thu, 18 Oct 2018 09:38:34 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1AlwdCh--vTgpa8yJgM7t2H-eflC6KqwV/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -971,7 +1033,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:31:42 GMT
+      - Thu, 18 Oct 2018 09:38:34 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -989,9 +1051,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:31:42 GMT
+      - Thu, 18 Oct 2018 09:38:35 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:31:42 GMT
+      - Thu, 18 Oct 2018 09:38:35 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1003,8 +1065,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -1024,10 +1085,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:31:42 GMT
+  recorded_at: Thu, 18 Oct 2018 09:38:35 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1AlwdCh--vTgpa8yJgM7t2H-eflC6KqwV
+    uri: https://www.googleapis.com/drive/v3/files/1MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb
     body:
       encoding: UTF-8
       string: ''
@@ -1039,7 +1100,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:31:42 GMT
+      - Thu, 18 Oct 2018 09:38:35 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1056,18 +1117,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:31:43 GMT
+      - Thu, 18 Oct 2018 09:38:35 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:31:43 GMT
+  recorded_at: Thu, 18 Oct 2018 09:38:35 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_deletes_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_deletes_file.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 11:10:41 GMT
+      - Sat, 20 Oct 2018 20:24:27 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:10:41 GMT
+  recorded_at: Sat, 20 Oct 2018 20:24:27 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 11:10:41 GMT
+      - Sat, 20 Oct 2018 20:24:27 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:10:41 GMT
+  recorded_at: Sat, 20 Oct 2018 20:24:27 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        11:10:41 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-20
+        20:24:27 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:10:41 GMT
+      - Sat, 20 Oct 2018 20:24:27 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:10:42 GMT
+      - Sat, 20 Oct 2018 20:24:28 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB",
-         "name": "Test @ 2018-10-18 11:10:41 UTC",
+         "id": "1RnN-T5B3nfVamBQEXtfiE3BXJ4dECcBs",
+         "name": "Test @ 2018-10-20 20:24:27 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:10:42 GMT
+  recorded_at: Sat, 20 Oct 2018 20:24:28 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1RnN-T5B3nfVamBQEXtfiE3BXJ4dECcBs/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:10:42 GMT
+      - Sat, 20 Oct 2018 20:24:28 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:10:43 GMT
+      - Sat, 20 Oct 2018 20:24:28 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:10:43 GMT
+  recorded_at: Sat, 20 Oct 2018 20:24:28 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:10:43 GMT
+      - Sat, 20 Oct 2018 20:24:28 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:10:43 GMT
+      - Sat, 20 Oct 2018 20:24:29 GMT
       Date:
-      - Thu, 18 Oct 2018 11:10:43 GMT
+      - Sat, 20 Oct 2018 20:24:29 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,16 +302,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "9549"
+         "startPageToken": "10665"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:10:43 GMT
+  recorded_at: Sat, 20 Oct 2018 20:24:29 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"To Delete","parents":["1JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"To Delete","parents":["1RnN-T5B3nfVamBQEXtfiE3BXJ4dECcBs"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -320,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:10:43 GMT
+      - Sat, 20 Oct 2018 20:24:29 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -337,7 +337,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:10:44 GMT
+      - Sat, 20 Oct 2018 20:24:30 GMT
       Vary:
       - Origin
       - X-Origin
@@ -361,12 +361,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "13MNgTr1qFXNUnVyfd0OutNF6n-klwB6bxWgX2g-1sqU",
+         "id": "1uDO9y10NJXPa5lI6BGN5EjayHT5vZTc-SB6HqS1CCJQ",
          "name": "To Delete",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB"
+          "1RnN-T5B3nfVamBQEXtfiE3BXJ4dECcBs"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -391,14 +391,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:10:44 GMT
+  recorded_at: Sat, 20 Oct 2018 20:24:30 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"8 Billion
-        Year Bunker (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"9 RW6 (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -407,7 +406,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:10:44 GMT
+      - Sat, 20 Oct 2018 20:24:30 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -424,7 +423,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:10:45 GMT
+      - Sat, 20 Oct 2018 20:24:30 GMT
       Vary:
       - Origin
       - X-Origin
@@ -448,8 +447,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1gYjfy6-_aC-4iJVpWMLkAfewF4P4hqwG",
-         "name": "8 Billion Year Bunker (Archive)",
+         "id": "16ISLD3J_Kwq0RBRuH34pthE_LB8f2KHd",
+         "name": "9 RW6 (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -469,10 +468,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:10:45 GMT
+  recorded_at: Sat, 20 Oct 2018 20:24:30 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1gYjfy6-_aC-4iJVpWMLkAfewF4P4hqwG/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/16ISLD3J_Kwq0RBRuH34pthE_LB8f2KHd/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -484,7 +483,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:10:45 GMT
+      - Sat, 20 Oct 2018 20:24:30 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -501,7 +500,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:10:45 GMT
+      - Sat, 20 Oct 2018 20:24:31 GMT
       Vary:
       - Origin
       - X-Origin
@@ -531,10 +530,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:10:45 GMT
+  recorded_at: Sat, 20 Oct 2018 20:24:31 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1gYjfy6-_aC-4iJVpWMLkAfewF4P4hqwG?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/16ISLD3J_Kwq0RBRuH34pthE_LB8f2KHd?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -546,7 +545,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:10:45 GMT
+      - Sat, 20 Oct 2018 20:24:31 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -557,9 +556,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:10:46 GMT
+      - Sat, 20 Oct 2018 20:24:31 GMT
       Date:
-      - Thu, 18 Oct 2018 11:10:46 GMT
+      - Sat, 20 Oct 2018 20:24:31 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -585,8 +584,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1gYjfy6-_aC-4iJVpWMLkAfewF4P4hqwG",
-         "name": "8 Billion Year Bunker (Archive)",
+         "id": "16ISLD3J_Kwq0RBRuH34pthE_LB8f2KHd",
+         "name": "9 RW6 (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -615,10 +614,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:10:46 GMT
+  recorded_at: Sat, 20 Oct 2018 20:24:31 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1gYjfy6-_aC-4iJVpWMLkAfewF4P4hqwG/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/16ISLD3J_Kwq0RBRuH34pthE_LB8f2KHd/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -630,7 +629,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:10:46 GMT
+      - Sat, 20 Oct 2018 20:24:31 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -648,9 +647,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:10:46 GMT
+      - Sat, 20 Oct 2018 20:24:31 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:10:46 GMT
+      - Sat, 20 Oct 2018 20:24:31 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -682,10 +681,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:10:46 GMT
+  recorded_at: Sat, 20 Oct 2018 20:24:31 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1RnN-T5B3nfVamBQEXtfiE3BXJ4dECcBs?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -697,7 +696,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:10:46 GMT
+      - Sat, 20 Oct 2018 20:24:31 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -708,9 +707,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:10:46 GMT
+      - Sat, 20 Oct 2018 20:24:31 GMT
       Date:
-      - Thu, 18 Oct 2018 11:10:46 GMT
+      - Sat, 20 Oct 2018 20:24:31 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -736,8 +735,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB",
-         "name": "Test @ 2018-10-18 11:10:41 UTC",
+         "id": "1RnN-T5B3nfVamBQEXtfiE3BXJ4dECcBs",
+         "name": "Test @ 2018-10-20 20:24:27 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -763,10 +762,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:10:46 GMT
+  recorded_at: Sat, 20 Oct 2018 20:24:31 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1RnN-T5B3nfVamBQEXtfiE3BXJ4dECcBs/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -778,7 +777,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:10:46 GMT
+      - Sat, 20 Oct 2018 20:24:31 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -796,9 +795,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:10:46 GMT
+      - Sat, 20 Oct 2018 20:24:32 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:10:46 GMT
+      - Sat, 20 Oct 2018 20:24:32 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -830,10 +829,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:10:46 GMT
+  recorded_at: Sat, 20 Oct 2018 20:24:32 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271RnN-T5B3nfVamBQEXtfiE3BXJ4dECcBs%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -845,7 +844,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:10:46 GMT
+      - Sat, 20 Oct 2018 20:24:32 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -856,9 +855,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:10:46 GMT
+      - Sat, 20 Oct 2018 20:24:32 GMT
       Date:
-      - Thu, 18 Oct 2018 11:10:46 GMT
+      - Sat, 20 Oct 2018 20:24:32 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -886,12 +885,12 @@ http_interactions:
         {
          "files": [
           {
-           "id": "13MNgTr1qFXNUnVyfd0OutNF6n-klwB6bxWgX2g-1sqU",
+           "id": "1uDO9y10NJXPa5lI6BGN5EjayHT5vZTc-SB6HqS1CCJQ",
            "name": "To Delete",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB"
+            "1RnN-T5B3nfVamBQEXtfiE3BXJ4dECcBs"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -918,10 +917,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:10:46 GMT
+  recorded_at: Sat, 20 Oct 2018 20:24:32 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/13MNgTr1qFXNUnVyfd0OutNF6n-klwB6bxWgX2g-1sqU/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1uDO9y10NJXPa5lI6BGN5EjayHT5vZTc-SB6HqS1CCJQ/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -933,7 +932,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:10:46 GMT
+      - Sat, 20 Oct 2018 20:24:32 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -944,9 +943,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:10:46 GMT
+      - Sat, 20 Oct 2018 20:24:32 GMT
       Date:
-      - Thu, 18 Oct 2018 11:10:46 GMT
+      - Sat, 20 Oct 2018 20:24:32 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -975,13 +974,185 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T11:10:43.889Z"
+         "modifiedTime": "2018-10-20T20:24:29.345Z"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:10:46 GMT
+  recorded_at: Sat, 20 Oct 2018 20:24:32 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1uDO9y10NJXPa5lI6BGN5EjayHT5vZTc-SB6HqS1CCJQ/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"To Delete","parents":["16ISLD3J_Kwq0RBRuH34pthE_LB8f2KHd"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:24:32 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:24:34 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1UDNXpoFyNrLliVtU8lLw_R8FlAYJwujW-efm7FIq8A4",
+         "name": "To Delete",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "16ISLD3J_Kwq0RBRuH34pthE_LB8f2KHd"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:24:34 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1uDO9y10NJXPa5lI6BGN5EjayHT5vZTc-SB6HqS1CCJQ/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"To Delete","parents":["16ISLD3J_Kwq0RBRuH34pthE_LB8f2KHd"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:24:34 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:24:36 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1LLnbZxn9J9g4CgiX_aMBD9QzC076DZ5UVGsjbeJ3-eU",
+         "name": "To Delete",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "16ISLD3J_Kwq0RBRuH34pthE_LB8f2KHd"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:24:36 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/13MNgTr1qFXNUnVyfd0OutNF6n-klwB6bxWgX2g-1sqU
+    uri: https://www.googleapis.com/drive/v3/files/1uDO9y10NJXPa5lI6BGN5EjayHT5vZTc-SB6HqS1CCJQ
     body:
       encoding: UTF-8
       string: ''
@@ -993,7 +1164,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:10:47 GMT
+      - Sat, 20 Oct 2018 20:24:36 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1010,7 +1181,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:10:47 GMT
+      - Sat, 20 Oct 2018 20:24:37 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1022,10 +1193,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:10:47 GMT
+  recorded_at: Sat, 20 Oct 2018 20:24:37 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9549
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=10665
     body:
       encoding: UTF-8
       string: ''
@@ -1037,7 +1208,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:11:47 GMT
+      - Sat, 20 Oct 2018 20:25:37 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1048,9 +1219,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:11:47 GMT
+      - Sat, 20 Oct 2018 20:25:37 GMT
       Date:
-      - Thu, 18 Oct 2018 11:11:47 GMT
+      - Sat, 20 Oct 2018 20:25:37 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1076,24 +1247,42 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "9554",
+         "newStartPageToken": "10683",
          "changes": [
           {
-           "fileId": "1gYjfy6-_aC-4iJVpWMLkAfewF4P4hqwG"
+           "fileId": "1BYvs0yGsEJY_h1TP8mklJxZKN3rfP4KqmpEs-VFBphI"
           },
           {
-           "fileId": "13MNgTr1qFXNUnVyfd0OutNF6n-klwB6bxWgX2g-1sqU"
+           "fileId": "16ISLD3J_Kwq0RBRuH34pthE_LB8f2KHd"
           },
           {
-           "fileId": "1JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB"
+           "fileId": "1VyXNSI5ViJTOpNdRClWsTYBEoHyB51Z_SoUt6bExxy4"
+          },
+          {
+           "fileId": "1UDNXpoFyNrLliVtU8lLw_R8FlAYJwujW-efm7FIq8A4"
+          },
+          {
+           "fileId": "1uDO9y10NJXPa5lI6BGN5EjayHT5vZTc-SB6HqS1CCJQ"
+          },
+          {
+           "fileId": "1LLnbZxn9J9g4CgiX_aMBD9QzC076DZ5UVGsjbeJ3-eU"
+          },
+          {
+           "fileId": "1a6237Bi0oPueUP3e1YD4WYguwuBwFZ-vO1VC35IMI3s"
+          },
+          {
+           "fileId": "15hBELdmp_4c0xvS3orQ0z6SqlRztqqghYewDhdCMmEQ"
+          },
+          {
+           "fileId": "1RnN-T5B3nfVamBQEXtfiE3BXJ4dECcBs"
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:11:47 GMT
+  recorded_at: Sat, 20 Oct 2018 20:25:37 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1gYjfy6-_aC-4iJVpWMLkAfewF4P4hqwG?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1BYvs0yGsEJY_h1TP8mklJxZKN3rfP4KqmpEs-VFBphI?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1105,7 +1294,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:11:47 GMT
+      - Sat, 20 Oct 2018 20:25:37 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1116,9 +1305,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:11:47 GMT
+      - Sat, 20 Oct 2018 20:25:37 GMT
       Date:
-      - Thu, 18 Oct 2018 11:11:47 GMT
+      - Sat, 20 Oct 2018 20:25:37 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1144,8 +1333,213 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1gYjfy6-_aC-4iJVpWMLkAfewF4P4hqwG",
-         "name": "8 Billion Year Bunker (Archive)",
+         "id": "1BYvs0yGsEJY_h1TP8mklJxZKN3rfP4KqmpEs-VFBphI",
+         "name": "File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1jVG7eDE9Iw2HKO6QS6bePnT6iKH8SIeN"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1BYvs0yGsEJY_h1TP8mklJxZKN3rfP4KqmpEs-VFBphI&v=1&s=AMedNnoAAAAAW8urYeWFF8h-DlnJfNHm0IN27k4glQSh&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:25:37 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1BYvs0yGsEJY_h1TP8mklJxZKN3rfP4KqmpEs-VFBphI/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:25:37 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:25:38 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:25:38 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-20T20:24:25.490Z"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:25:38 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1BYvs0yGsEJY_h1TP8mklJxZKN3rfP4KqmpEs-VFBphI&s=AMedNnoAAAAAW8urYeWFF8h-DlnJfNHm0IN27k4glQSh&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:25:38 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 20 Oct 2018 20:25:38 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1533'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAAFtUlEQVR4nO3du2pV3RqA4RnxEJSARwhRwRixEAmoSNTOi7H3LrwGewVrLb0CjYUQRRQSImKjuEBhZZnDIrv4Ybf7baL8m+fpRjEm4yteBoxmzuzv7w9AcOhvHwD+NdQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBaq/X8toNNrd3d3b2/vbB4H/4cBrmUwmP378GIZhPB5PJpPfv3/v7+9Pp9PJZDIMw/Pnz1++fLm6uvrq1avt7e3xePzfXb9+/RqG4du3b/8sR6PRZDJ59uzZMAz/fPDXr19bW1vv37//8OHDQU8BwzDMHPS/wR49erS0tLS8vPzixYujR48eP3782rVrP3/+/Pr164MHDx4/fnzx4sWtra2TJ0++fft2Z2fn4cOHhw8ffvr06cLCwmg0On/+/Hg8fvPmzZUrV5aWll6/fj0zM3PixIn5+fm1tbVhGFZWVo4cOXL37t0DnQKGP3C3LC4u3r9/f2Nj49ChQ2fPnl1eXn7y5Mm7d+9u3rw5DMO5c+fm5uZ2dnZGo9F0Op2fn9/b2xuPx/Pz8zdu3Njc3Lx3797nz58vXbp079696XR6+vTptbW1Cxcu/P79e2VlZXFx8dixY2fOnDnoKWD4A3fLp0+fzp8/P5lM1tfXp9PpysrKx48fh2G4fPny7Ozs+vr67OzseDyem5v78uXLdDq9c+fOzMzM6urq7u7u1atXV1dXb9++/f3794WFhclksrGxMT8/v7m5ef369e3t7e3t7VOnTm1ubt66detAp4DhD9QC/zf+/psY/FuoBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoHqP+q3665OEUZRAAAAAElFTkSuQmCC
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:25:38 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/16ISLD3J_Kwq0RBRuH34pthE_LB8f2KHd?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:25:38 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:25:38 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:25:38 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "16ISLD3J_Kwq0RBRuH34pthE_LB8f2KHd",
+         "name": "9 RW6 (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -1174,10 +1568,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:11:47 GMT
+  recorded_at: Sat, 20 Oct 2018 20:25:38 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1gYjfy6-_aC-4iJVpWMLkAfewF4P4hqwG/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/16ISLD3J_Kwq0RBRuH34pthE_LB8f2KHd/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1189,7 +1583,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:11:47 GMT
+      - Sat, 20 Oct 2018 20:25:38 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1207,9 +1601,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:11:48 GMT
+      - Sat, 20 Oct 2018 20:25:38 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:11:48 GMT
+      - Sat, 20 Oct 2018 20:25:38 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1241,10 +1635,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:11:48 GMT
+  recorded_at: Sat, 20 Oct 2018 20:25:38 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/13MNgTr1qFXNUnVyfd0OutNF6n-klwB6bxWgX2g-1sqU?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1VyXNSI5ViJTOpNdRClWsTYBEoHyB51Z_SoUt6bExxy4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1256,7 +1650,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:11:48 GMT
+      - Sat, 20 Oct 2018 20:25:38 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1274,9 +1668,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:11:48 GMT
+      - Sat, 20 Oct 2018 20:25:38 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:11:48 GMT
+      - Sat, 20 Oct 2018 20:25:38 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1300,20 +1694,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 13MNgTr1qFXNUnVyfd0OutNF6n-klwB6bxWgX2g-1sqU.",
+            "message": "File not found: 1VyXNSI5ViJTOpNdRClWsTYBEoHyB51Z_SoUt6bExxy4.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 13MNgTr1qFXNUnVyfd0OutNF6n-klwB6bxWgX2g-1sqU."
+          "message": "File not found: 1VyXNSI5ViJTOpNdRClWsTYBEoHyB51Z_SoUt6bExxy4."
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:11:48 GMT
+  recorded_at: Sat, 20 Oct 2018 20:25:38 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1UDNXpoFyNrLliVtU8lLw_R8FlAYJwujW-efm7FIq8A4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1325,7 +1719,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:11:48 GMT
+      - Sat, 20 Oct 2018 20:25:38 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1336,9 +1730,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:11:48 GMT
+      - Sat, 20 Oct 2018 20:25:38 GMT
       Date:
-      - Thu, 18 Oct 2018 11:11:48 GMT
+      - Sat, 20 Oct 2018 20:25:38 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1364,8 +1758,897 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB",
-         "name": "Test @ 2018-10-18 11:10:41 UTC",
+         "id": "1UDNXpoFyNrLliVtU8lLw_R8FlAYJwujW-efm7FIq8A4",
+         "name": "To Delete",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "16ISLD3J_Kwq0RBRuH34pthE_LB8f2KHd"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1UDNXpoFyNrLliVtU8lLw_R8FlAYJwujW-efm7FIq8A4&v=1&s=AMedNnoAAAAAW8urYglLBdiCK3nIV6XTtVgmy946hnXS&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:25:38 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1UDNXpoFyNrLliVtU8lLw_R8FlAYJwujW-efm7FIq8A4/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:25:38 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:25:39 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:25:39 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-20T20:24:33.508Z"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:25:39 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1UDNXpoFyNrLliVtU8lLw_R8FlAYJwujW-efm7FIq8A4&s=AMedNnoAAAAAW8urYglLBdiCK3nIV6XTtVgmy946hnXS&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:25:39 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 20 Oct 2018 20:25:39 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:25:39 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1uDO9y10NJXPa5lI6BGN5EjayHT5vZTc-SB6HqS1CCJQ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:25:39 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Sat, 20 Oct 2018 20:25:39 GMT
+      Expires:
+      - Sat, 20 Oct 2018 20:25:39 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "notFound",
+            "message": "File not found: 1uDO9y10NJXPa5lI6BGN5EjayHT5vZTc-SB6HqS1CCJQ.",
+            "locationType": "parameter",
+            "location": "fileId"
+           }
+          ],
+          "code": 404,
+          "message": "File not found: 1uDO9y10NJXPa5lI6BGN5EjayHT5vZTc-SB6HqS1CCJQ."
+         }
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:25:39 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1LLnbZxn9J9g4CgiX_aMBD9QzC076DZ5UVGsjbeJ3-eU?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:25:39 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:25:39 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:25:39 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1LLnbZxn9J9g4CgiX_aMBD9QzC076DZ5UVGsjbeJ3-eU",
+         "name": "To Delete",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "16ISLD3J_Kwq0RBRuH34pthE_LB8f2KHd"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1LLnbZxn9J9g4CgiX_aMBD9QzC076DZ5UVGsjbeJ3-eU&v=1&s=AMedNnoAAAAAW8urY7YSKdHvVEz2cVDn7B5qQ_u_UNdB&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:25:39 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1LLnbZxn9J9g4CgiX_aMBD9QzC076DZ5UVGsjbeJ3-eU/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:25:39 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:25:40 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:25:40 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-20T20:24:35.811Z"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:25:40 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1LLnbZxn9J9g4CgiX_aMBD9QzC076DZ5UVGsjbeJ3-eU&s=AMedNnoAAAAAW8urY7YSKdHvVEz2cVDn7B5qQ_u_UNdB&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:25:40 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 20 Oct 2018 20:25:40 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:25:40 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1a6237Bi0oPueUP3e1YD4WYguwuBwFZ-vO1VC35IMI3s?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:25:40 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:25:40 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:25:40 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1a6237Bi0oPueUP3e1YD4WYguwuBwFZ-vO1VC35IMI3s",
+         "name": "File To Move",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1Qrv2gg2ZuGOyWIdUa6aC2oXsq2_aKi3B"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1a6237Bi0oPueUP3e1YD4WYguwuBwFZ-vO1VC35IMI3s&v=1&s=AMedNnoAAAAAW8urZGJKITzd4xHMVZ1iLiDTCN3ptjgo&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:25:40 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1a6237Bi0oPueUP3e1YD4WYguwuBwFZ-vO1VC35IMI3s/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:25:40 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:25:40 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:25:40 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-20T20:22:02.817Z"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:25:40 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1a6237Bi0oPueUP3e1YD4WYguwuBwFZ-vO1VC35IMI3s&s=AMedNnoAAAAAW8urZGJKITzd4xHMVZ1iLiDTCN3ptjgo&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:25:40 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 20 Oct 2018 20:25:40 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:25:40 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/15hBELdmp_4c0xvS3orQ0z6SqlRztqqghYewDhdCMmEQ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:25:41 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:25:41 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:25:41 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "15hBELdmp_4c0xvS3orQ0z6SqlRztqqghYewDhdCMmEQ",
+         "name": "File To Move",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1Qrv2gg2ZuGOyWIdUa6aC2oXsq2_aKi3B"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=15hBELdmp_4c0xvS3orQ0z6SqlRztqqghYewDhdCMmEQ&v=1&s=AMedNnoAAAAAW8urZXs4wCsG7Sr-e-QyV82R_CGSDwgS&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:25:41 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/15hBELdmp_4c0xvS3orQ0z6SqlRztqqghYewDhdCMmEQ/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:25:41 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:25:41 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:25:41 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-20T20:22:01.273Z"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:25:41 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=15hBELdmp_4c0xvS3orQ0z6SqlRztqqghYewDhdCMmEQ&s=AMedNnoAAAAAW8urZXs4wCsG7Sr-e-QyV82R_CGSDwgS&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:25:41 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 20 Oct 2018 20:25:41 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:25:41 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1RnN-T5B3nfVamBQEXtfiE3BXJ4dECcBs?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:25:41 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:25:41 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:25:41 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1RnN-T5B3nfVamBQEXtfiE3BXJ4dECcBs",
+         "name": "Test @ 2018-10-20 20:24:27 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -1391,10 +2674,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:11:48 GMT
+  recorded_at: Sat, 20 Oct 2018 20:25:41 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1RnN-T5B3nfVamBQEXtfiE3BXJ4dECcBs/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1406,7 +2689,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:11:48 GMT
+      - Sat, 20 Oct 2018 20:25:41 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1424,9 +2707,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:11:48 GMT
+      - Sat, 20 Oct 2018 20:25:41 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:11:48 GMT
+      - Sat, 20 Oct 2018 20:25:41 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1458,10 +2741,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:11:48 GMT
+  recorded_at: Sat, 20 Oct 2018 20:25:41 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB
+    uri: https://www.googleapis.com/drive/v3/files/1RnN-T5B3nfVamBQEXtfiE3BXJ4dECcBs
     body:
       encoding: UTF-8
       string: ''
@@ -1473,7 +2756,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:11:48 GMT
+      - Sat, 20 Oct 2018 20:25:42 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1490,7 +2773,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:11:49 GMT
+      - Sat, 20 Oct 2018 20:25:42 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1502,5 +2785,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:11:49 GMT
+  recorded_at: Sat, 20 Oct 2018 20:25:42 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_deletes_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_deletes_file.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:37:28 GMT
+      - Thu, 18 Oct 2018 11:10:41 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:37:28 GMT
+  recorded_at: Thu, 18 Oct 2018 11:10:41 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:37:29 GMT
+      - Thu, 18 Oct 2018 11:10:41 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:37:29 GMT
+  recorded_at: Thu, 18 Oct 2018 11:10:41 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        09:37:29 UTC","parents":["root"]}'
+        11:10:41 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:37:29 GMT
+      - Thu, 18 Oct 2018 11:10:41 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:37:29 GMT
+      - Thu, 18 Oct 2018 11:10:42 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb",
-         "name": "Test @ 2018-10-18 09:37:29 UTC",
+         "id": "1JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB",
+         "name": "Test @ 2018-10-18 11:10:41 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:37:29 GMT
+  recorded_at: Thu, 18 Oct 2018 11:10:42 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:37:29 GMT
+      - Thu, 18 Oct 2018 11:10:42 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:37:30 GMT
+      - Thu, 18 Oct 2018 11:10:43 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:37:30 GMT
+  recorded_at: Thu, 18 Oct 2018 11:10:43 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:37:30 GMT
+      - Thu, 18 Oct 2018 11:10:43 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:37:30 GMT
+      - Thu, 18 Oct 2018 11:10:43 GMT
       Date:
-      - Thu, 18 Oct 2018 09:37:30 GMT
+      - Thu, 18 Oct 2018 11:10:43 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,16 +302,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "9364"
+         "startPageToken": "9549"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:37:30 GMT
+  recorded_at: Thu, 18 Oct 2018 11:10:43 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"To Delete","parents":["1MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"To Delete","parents":["1JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -320,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:37:30 GMT
+      - Thu, 18 Oct 2018 11:10:43 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -337,7 +337,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:37:32 GMT
+      - Thu, 18 Oct 2018 11:10:44 GMT
       Vary:
       - Origin
       - X-Origin
@@ -361,12 +361,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1MwMz3H5ioKJ3innEHFAWGfVfU7Adx-Pr5VxiUpTYdfE",
+         "id": "13MNgTr1qFXNUnVyfd0OutNF6n-klwB6bxWgX2g-1sqU",
          "name": "To Delete",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb"
+          "1JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -391,10 +391,150 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:37:32 GMT
+  recorded_at: Thu, 18 Oct 2018 11:10:44 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"8 Billion
+        Year Bunker (Archive)","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:10:44 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:10:45 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1gYjfy6-_aC-4iJVpWMLkAfewF4P4hqwG",
+         "name": "8 Billion Year Bunker (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:10:45 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1gYjfy6-_aC-4iJVpWMLkAfewF4P4hqwG/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:10:45 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:10:45 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "13193959451567607887",
+         "type": "user",
+         "role": "reader"
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:10:45 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1gYjfy6-_aC-4iJVpWMLkAfewF4P4hqwG?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -406,7 +546,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:37:32 GMT
+      - Thu, 18 Oct 2018 11:10:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -417,9 +557,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:37:32 GMT
+      - Thu, 18 Oct 2018 11:10:46 GMT
       Date:
-      - Thu, 18 Oct 2018 09:37:32 GMT
+      - Thu, 18 Oct 2018 11:10:46 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -445,37 +585,40 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb",
-         "name": "Test @ 2018-10-18 09:37:29 UTC",
+         "id": "1gYjfy6-_aC-4iJVpWMLkAfewF4P4hqwG",
+         "name": "8 Billion Year Bunker (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
          "thumbnailVersion": "0",
          "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
           {
            "kind": "drive#permission",
            "id": "13193959451567607887",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
+           "role": "reader",
            "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
            "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:37:32 GMT
+  recorded_at: Thu, 18 Oct 2018 11:10:46 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1gYjfy6-_aC-4iJVpWMLkAfewF4P4hqwG/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -487,7 +630,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:37:32 GMT
+      - Thu, 18 Oct 2018 11:10:46 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -505,9 +648,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:37:32 GMT
+      - Thu, 18 Oct 2018 11:10:46 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:37:32 GMT
+      - Thu, 18 Oct 2018 11:10:46 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -539,10 +682,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:37:33 GMT
+  recorded_at: Thu, 18 Oct 2018 11:10:46 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files/1JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -554,7 +697,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:37:33 GMT
+      - Thu, 18 Oct 2018 11:10:46 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -565,9 +708,157 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:37:33 GMT
+      - Thu, 18 Oct 2018 11:10:46 GMT
       Date:
-      - Thu, 18 Oct 2018 09:37:33 GMT
+      - Thu, 18 Oct 2018 11:10:46 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB",
+         "name": "Test @ 2018-10-18 11:10:41 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:10:46 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:10:46 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:10:46 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:10:46 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:10:46 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:10:46 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:10:46 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:10:46 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -595,12 +886,12 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1MwMz3H5ioKJ3innEHFAWGfVfU7Adx-Pr5VxiUpTYdfE",
+           "id": "13MNgTr1qFXNUnVyfd0OutNF6n-klwB6bxWgX2g-1sqU",
            "name": "To Delete",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb"
+            "1JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -627,10 +918,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:37:33 GMT
+  recorded_at: Thu, 18 Oct 2018 11:10:46 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1MwMz3H5ioKJ3innEHFAWGfVfU7Adx-Pr5VxiUpTYdfE/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/13MNgTr1qFXNUnVyfd0OutNF6n-klwB6bxWgX2g-1sqU/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -642,7 +933,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:37:33 GMT
+      - Thu, 18 Oct 2018 11:10:46 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -653,9 +944,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:37:33 GMT
+      - Thu, 18 Oct 2018 11:10:46 GMT
       Date:
-      - Thu, 18 Oct 2018 09:37:33 GMT
+      - Thu, 18 Oct 2018 11:10:46 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -684,13 +975,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T09:37:31.551Z"
+         "modifiedTime": "2018-10-18T11:10:43.889Z"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:37:33 GMT
+  recorded_at: Thu, 18 Oct 2018 11:10:46 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1MwMz3H5ioKJ3innEHFAWGfVfU7Adx-Pr5VxiUpTYdfE
+    uri: https://www.googleapis.com/drive/v3/files/13MNgTr1qFXNUnVyfd0OutNF6n-klwB6bxWgX2g-1sqU
     body:
       encoding: UTF-8
       string: ''
@@ -702,7 +993,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:37:33 GMT
+      - Thu, 18 Oct 2018 11:10:47 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -719,7 +1010,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:37:34 GMT
+      - Thu, 18 Oct 2018 11:10:47 GMT
       Vary:
       - Origin
       - X-Origin
@@ -731,10 +1022,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:37:34 GMT
+  recorded_at: Thu, 18 Oct 2018 11:10:47 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9364
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9549
     body:
       encoding: UTF-8
       string: ''
@@ -746,7 +1037,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:38:34 GMT
+      - Thu, 18 Oct 2018 11:11:47 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -757,9 +1048,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:38:34 GMT
+      - Thu, 18 Oct 2018 11:11:47 GMT
       Date:
-      - Thu, 18 Oct 2018 09:38:34 GMT
+      - Thu, 18 Oct 2018 11:11:47 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -785,24 +1076,24 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "9368",
+         "newStartPageToken": "9554",
          "changes": [
           {
-           "fileId": "1u9EVYrOHeQaLt0YC6uXhApTnsx5KxTgnKPzQUp_bvlw"
+           "fileId": "1gYjfy6-_aC-4iJVpWMLkAfewF4P4hqwG"
           },
           {
-           "fileId": "1MwMz3H5ioKJ3innEHFAWGfVfU7Adx-Pr5VxiUpTYdfE"
+           "fileId": "13MNgTr1qFXNUnVyfd0OutNF6n-klwB6bxWgX2g-1sqU"
           },
           {
-           "fileId": "1MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb"
+           "fileId": "1JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB"
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:38:34 GMT
+  recorded_at: Thu, 18 Oct 2018 11:11:47 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1u9EVYrOHeQaLt0YC6uXhApTnsx5KxTgnKPzQUp_bvlw?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1gYjfy6-_aC-4iJVpWMLkAfewF4P4hqwG?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -814,145 +1105,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:38:34 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 18 Oct 2018 09:38:34 GMT
-      Expires:
-      - Thu, 18 Oct 2018 09:38:34 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "notFound",
-            "message": "File not found: 1u9EVYrOHeQaLt0YC6uXhApTnsx5KxTgnKPzQUp_bvlw.",
-            "locationType": "parameter",
-            "location": "fileId"
-           }
-          ],
-          "code": 404,
-          "message": "File not found: 1u9EVYrOHeQaLt0YC6uXhApTnsx5KxTgnKPzQUp_bvlw."
-         }
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:38:34 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1MwMz3H5ioKJ3innEHFAWGfVfU7Adx-Pr5VxiUpTYdfE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 09:38:34 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 18 Oct 2018 09:38:34 GMT
-      Expires:
-      - Thu, 18 Oct 2018 09:38:34 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "notFound",
-            "message": "File not found: 1MwMz3H5ioKJ3innEHFAWGfVfU7Adx-Pr5VxiUpTYdfE.",
-            "locationType": "parameter",
-            "location": "fileId"
-           }
-          ],
-          "code": 404,
-          "message": "File not found: 1MwMz3H5ioKJ3innEHFAWGfVfU7Adx-Pr5VxiUpTYdfE."
-         }
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:38:34 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 09:38:34 GMT
+      - Thu, 18 Oct 2018 11:11:47 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -963,9 +1116,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:38:34 GMT
+      - Thu, 18 Oct 2018 11:11:47 GMT
       Date:
-      - Thu, 18 Oct 2018 09:38:34 GMT
+      - Thu, 18 Oct 2018 11:11:47 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -991,37 +1144,40 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb",
-         "name": "Test @ 2018-10-18 09:37:29 UTC",
+         "id": "1gYjfy6-_aC-4iJVpWMLkAfewF4P4hqwG",
+         "name": "8 Billion Year Bunker (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
          "thumbnailVersion": "0",
          "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
           {
            "kind": "drive#permission",
            "id": "13193959451567607887",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
+           "role": "reader",
            "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
            "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:38:34 GMT
+  recorded_at: Thu, 18 Oct 2018 11:11:47 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1gYjfy6-_aC-4iJVpWMLkAfewF4P4hqwG/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1033,7 +1189,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:38:34 GMT
+      - Thu, 18 Oct 2018 11:11:47 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1051,9 +1207,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:38:35 GMT
+      - Thu, 18 Oct 2018 11:11:48 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:38:35 GMT
+      - Thu, 18 Oct 2018 11:11:48 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1085,10 +1241,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:38:35 GMT
+  recorded_at: Thu, 18 Oct 2018 11:11:48 GMT
 - request:
-    method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1MxjCTtPvjf6nH5m5MvlhZ46bvMlotKEb
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/13MNgTr1qFXNUnVyfd0OutNF6n-klwB6bxWgX2g-1sqU?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1100,7 +1256,224 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:38:35 GMT
+      - Thu, 18 Oct 2018 11:11:48 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:11:48 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:11:48 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "notFound",
+            "message": "File not found: 13MNgTr1qFXNUnVyfd0OutNF6n-klwB6bxWgX2g-1sqU.",
+            "locationType": "parameter",
+            "location": "fileId"
+           }
+          ],
+          "code": 404,
+          "message": "File not found: 13MNgTr1qFXNUnVyfd0OutNF6n-klwB6bxWgX2g-1sqU."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:11:48 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:11:48 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:11:48 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:11:48 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB",
+         "name": "Test @ 2018-10-18 11:10:41 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:11:48 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:11:48 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:11:48 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:11:48 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:11:48 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1JYAo_HFWwOU99Xt9QbOHZeqiEV1rXmnB
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:11:48 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1117,7 +1490,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:38:35 GMT
+      - Thu, 18 Oct 2018 11:11:49 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1129,5 +1502,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:38:35 GMT
+  recorded_at: Thu, 18 Oct 2018 11:11:49 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_deletes_the_project_folder.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_deletes_the_project_folder.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 11:03:51 GMT
+      - Sat, 20 Oct 2018 20:30:13 GMT
       Server:
       - ESF
       Cache-Control:
@@ -48,12 +48,12 @@ http_interactions:
       string: |-
         {
           "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-          "expires_in": 3599,
+          "expires_in": 3600,
           "scope": "https://www.googleapis.com/auth/drive",
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:03:51 GMT
+  recorded_at: Sat, 20 Oct 2018 20:30:13 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 11:03:51 GMT
+      - Sat, 20 Oct 2018 20:30:13 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:03:51 GMT
+  recorded_at: Sat, 20 Oct 2018 20:30:13 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        11:03:51 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-20
+        20:30:13 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:03:51 GMT
+      - Sat, 20 Oct 2018 20:30:13 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:03:51 GMT
+      - Sat, 20 Oct 2018 20:30:13 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP",
-         "name": "Test @ 2018-10-18 11:03:51 UTC",
+         "id": "1cT3RMazFSw6Fv88NMbvEGhC80SZvnhHX",
+         "name": "Test @ 2018-10-20 20:30:13 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:03:51 GMT
+  recorded_at: Sat, 20 Oct 2018 20:30:13 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1cT3RMazFSw6Fv88NMbvEGhC80SZvnhHX/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:03:51 GMT
+      - Sat, 20 Oct 2018 20:30:13 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:03:52 GMT
+      - Sat, 20 Oct 2018 20:30:14 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:03:52 GMT
+  recorded_at: Sat, 20 Oct 2018 20:30:14 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:03:52 GMT
+      - Sat, 20 Oct 2018 20:30:14 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:03:52 GMT
+      - Sat, 20 Oct 2018 20:30:14 GMT
       Date:
-      - Thu, 18 Oct 2018 11:03:52 GMT
+      - Sat, 20 Oct 2018 20:30:14 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,16 +302,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "9503"
+         "startPageToken": "10713"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:03:52 GMT
+  recorded_at: Sat, 20 Oct 2018 20:30:14 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1cT3RMazFSw6Fv88NMbvEGhC80SZvnhHX"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -320,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:03:52 GMT
+      - Sat, 20 Oct 2018 20:30:16 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -337,7 +337,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:03:53 GMT
+      - Sat, 20 Oct 2018 20:30:17 GMT
       Vary:
       - Origin
       - X-Origin
@@ -361,12 +361,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1WZwlG61Y9IqRZXIa94yYYQQpHDIs_PCoMV5h9JHgUo4",
+         "id": "1CjofsU4HqYesHldEF2O1u0m__1vKPzpDWJzRJ82Oo_Y",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP"
+          "1cT3RMazFSw6Fv88NMbvEGhC80SZvnhHX"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -391,13 +391,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:03:53 GMT
+  recorded_at: Sat, 20 Oct 2018 20:30:17 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"2 Billion
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"1 Billion
         Year Bunker (Archive)","parents":["root"]}'
     headers:
       User-Agent:
@@ -407,7 +407,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:03:53 GMT
+      - Sat, 20 Oct 2018 20:30:17 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -424,7 +424,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:03:54 GMT
+      - Sat, 20 Oct 2018 20:30:17 GMT
       Vary:
       - Origin
       - X-Origin
@@ -448,8 +448,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1KfAU2ONOKbCcUx93rbSNd2MvOxeiBDzr",
-         "name": "2 Billion Year Bunker (Archive)",
+         "id": "1G-ny0Fh44M-zsvvppFFP52qRS1moJzTZ",
+         "name": "1 Billion Year Bunker (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -469,10 +469,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:03:54 GMT
+  recorded_at: Sat, 20 Oct 2018 20:30:17 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1KfAU2ONOKbCcUx93rbSNd2MvOxeiBDzr/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1G-ny0Fh44M-zsvvppFFP52qRS1moJzTZ/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -484,7 +484,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:03:54 GMT
+      - Sat, 20 Oct 2018 20:30:17 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -501,7 +501,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:03:54 GMT
+      - Sat, 20 Oct 2018 20:30:18 GMT
       Vary:
       - Origin
       - X-Origin
@@ -531,10 +531,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:03:54 GMT
+  recorded_at: Sat, 20 Oct 2018 20:30:18 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1KfAU2ONOKbCcUx93rbSNd2MvOxeiBDzr?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1G-ny0Fh44M-zsvvppFFP52qRS1moJzTZ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -546,7 +546,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:03:54 GMT
+      - Sat, 20 Oct 2018 20:30:18 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -557,9 +557,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:03:54 GMT
+      - Sat, 20 Oct 2018 20:30:18 GMT
       Date:
-      - Thu, 18 Oct 2018 11:03:54 GMT
+      - Sat, 20 Oct 2018 20:30:18 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -585,8 +585,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1KfAU2ONOKbCcUx93rbSNd2MvOxeiBDzr",
-         "name": "2 Billion Year Bunker (Archive)",
+         "id": "1G-ny0Fh44M-zsvvppFFP52qRS1moJzTZ",
+         "name": "1 Billion Year Bunker (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -615,10 +615,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:03:54 GMT
+  recorded_at: Sat, 20 Oct 2018 20:30:18 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1KfAU2ONOKbCcUx93rbSNd2MvOxeiBDzr/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1G-ny0Fh44M-zsvvppFFP52qRS1moJzTZ/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -630,7 +630,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:03:54 GMT
+      - Sat, 20 Oct 2018 20:30:18 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -648,9 +648,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:03:55 GMT
+      - Sat, 20 Oct 2018 20:30:18 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:03:55 GMT
+      - Sat, 20 Oct 2018 20:30:18 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -682,10 +682,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:03:55 GMT
+  recorded_at: Sat, 20 Oct 2018 20:30:18 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1cT3RMazFSw6Fv88NMbvEGhC80SZvnhHX?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -697,7 +697,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:03:55 GMT
+      - Sat, 20 Oct 2018 20:30:18 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -708,9 +708,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:03:55 GMT
+      - Sat, 20 Oct 2018 20:30:18 GMT
       Date:
-      - Thu, 18 Oct 2018 11:03:55 GMT
+      - Sat, 20 Oct 2018 20:30:18 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -736,8 +736,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP",
-         "name": "Test @ 2018-10-18 11:03:51 UTC",
+         "id": "1cT3RMazFSw6Fv88NMbvEGhC80SZvnhHX",
+         "name": "Test @ 2018-10-20 20:30:13 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -763,10 +763,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:03:55 GMT
+  recorded_at: Sat, 20 Oct 2018 20:30:18 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1cT3RMazFSw6Fv88NMbvEGhC80SZvnhHX/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -778,7 +778,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:03:55 GMT
+      - Sat, 20 Oct 2018 20:30:18 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -796,9 +796,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:03:55 GMT
+      - Sat, 20 Oct 2018 20:30:19 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:03:55 GMT
+      - Sat, 20 Oct 2018 20:30:19 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -830,10 +830,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:03:55 GMT
+  recorded_at: Sat, 20 Oct 2018 20:30:19 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271cT3RMazFSw6Fv88NMbvEGhC80SZvnhHX%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -845,7 +845,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:03:55 GMT
+      - Sat, 20 Oct 2018 20:30:19 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -856,9 +856,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:03:55 GMT
+      - Sat, 20 Oct 2018 20:30:19 GMT
       Date:
-      - Thu, 18 Oct 2018 11:03:55 GMT
+      - Sat, 20 Oct 2018 20:30:19 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -886,12 +886,12 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1WZwlG61Y9IqRZXIa94yYYQQpHDIs_PCoMV5h9JHgUo4",
+           "id": "1CjofsU4HqYesHldEF2O1u0m__1vKPzpDWJzRJ82Oo_Y",
            "name": "File",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP"
+            "1cT3RMazFSw6Fv88NMbvEGhC80SZvnhHX"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -918,10 +918,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:03:55 GMT
+  recorded_at: Sat, 20 Oct 2018 20:30:19 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1WZwlG61Y9IqRZXIa94yYYQQpHDIs_PCoMV5h9JHgUo4/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1CjofsU4HqYesHldEF2O1u0m__1vKPzpDWJzRJ82Oo_Y/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -933,7 +933,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:03:55 GMT
+      - Sat, 20 Oct 2018 20:30:19 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -944,9 +944,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:03:55 GMT
+      - Sat, 20 Oct 2018 20:30:19 GMT
       Date:
-      - Thu, 18 Oct 2018 11:03:55 GMT
+      - Sat, 20 Oct 2018 20:30:19 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -975,13 +975,185 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T11:03:52.884Z"
+         "modifiedTime": "2018-10-20T20:30:16.298Z"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:03:55 GMT
+  recorded_at: Sat, 20 Oct 2018 20:30:19 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1CjofsU4HqYesHldEF2O1u0m__1vKPzpDWJzRJ82Oo_Y/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"File","parents":["1G-ny0Fh44M-zsvvppFFP52qRS1moJzTZ"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:30:19 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:30:21 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1_16pekjJ-ULHNQEfD5PWPYuuIxAtvA296VXQvU-aT2c",
+         "name": "File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1G-ny0Fh44M-zsvvppFFP52qRS1moJzTZ"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:30:21 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1CjofsU4HqYesHldEF2O1u0m__1vKPzpDWJzRJ82Oo_Y/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"File","parents":["1G-ny0Fh44M-zsvvppFFP52qRS1moJzTZ"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:30:21 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:30:22 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1IOawSmIT8AwhjXlBu7tsnHqYx8drpFYdlqjEJxNzHSw",
+         "name": "File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1G-ny0Fh44M-zsvvppFFP52qRS1moJzTZ"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:30:22 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP
+    uri: https://www.googleapis.com/drive/v3/files/1cT3RMazFSw6Fv88NMbvEGhC80SZvnhHX
     body:
       encoding: UTF-8
       string: ''
@@ -993,7 +1165,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:03:55 GMT
+      - Sat, 20 Oct 2018 20:30:23 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1010,7 +1182,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:03:56 GMT
+      - Sat, 20 Oct 2018 20:30:23 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1022,10 +1194,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:03:56 GMT
+  recorded_at: Sat, 20 Oct 2018 20:30:23 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9503
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=10713
     body:
       encoding: UTF-8
       string: ''
@@ -1037,7 +1209,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:04:56 GMT
+      - Sat, 20 Oct 2018 20:31:23 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1048,9 +1220,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:04:56 GMT
+      - Sat, 20 Oct 2018 20:31:23 GMT
       Date:
-      - Thu, 18 Oct 2018 11:04:56 GMT
+      - Sat, 20 Oct 2018 20:31:23 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1076,27 +1248,30 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "9509",
+         "newStartPageToken": "10726",
          "changes": [
           {
-           "fileId": "1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo"
+           "fileId": "1G-ny0Fh44M-zsvvppFFP52qRS1moJzTZ"
           },
           {
-           "fileId": "1KfAU2ONOKbCcUx93rbSNd2MvOxeiBDzr"
+           "fileId": "1cT3RMazFSw6Fv88NMbvEGhC80SZvnhHX"
           },
           {
-           "fileId": "1A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP"
+           "fileId": "1IOawSmIT8AwhjXlBu7tsnHqYx8drpFYdlqjEJxNzHSw"
           },
           {
-           "fileId": "1WZwlG61Y9IqRZXIa94yYYQQpHDIs_PCoMV5h9JHgUo4"
+           "fileId": "1_16pekjJ-ULHNQEfD5PWPYuuIxAtvA296VXQvU-aT2c"
+          },
+          {
+           "fileId": "1CjofsU4HqYesHldEF2O1u0m__1vKPzpDWJzRJ82Oo_Y"
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:04:56 GMT
+  recorded_at: Sat, 20 Oct 2018 20:31:23 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1G-ny0Fh44M-zsvvppFFP52qRS1moJzTZ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1108,76 +1283,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:04:56 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 18 Oct 2018 11:04:56 GMT
-      Expires:
-      - Thu, 18 Oct 2018 11:04:56 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "notFound",
-            "message": "File not found: 1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo.",
-            "locationType": "parameter",
-            "location": "fileId"
-           }
-          ],
-          "code": 404,
-          "message": "File not found: 1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo."
-         }
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:04:56 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1KfAU2ONOKbCcUx93rbSNd2MvOxeiBDzr?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:04:56 GMT
+      - Sat, 20 Oct 2018 20:31:23 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1188,9 +1294,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:04:56 GMT
+      - Sat, 20 Oct 2018 20:31:23 GMT
       Date:
-      - Thu, 18 Oct 2018 11:04:56 GMT
+      - Sat, 20 Oct 2018 20:31:23 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1216,8 +1322,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1KfAU2ONOKbCcUx93rbSNd2MvOxeiBDzr",
-         "name": "2 Billion Year Bunker (Archive)",
+         "id": "1G-ny0Fh44M-zsvvppFFP52qRS1moJzTZ",
+         "name": "1 Billion Year Bunker (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -1246,10 +1352,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:04:56 GMT
+  recorded_at: Sat, 20 Oct 2018 20:31:23 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1KfAU2ONOKbCcUx93rbSNd2MvOxeiBDzr/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1G-ny0Fh44M-zsvvppFFP52qRS1moJzTZ/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1261,7 +1367,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:04:56 GMT
+      - Sat, 20 Oct 2018 20:31:23 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1279,9 +1385,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:04:57 GMT
+      - Sat, 20 Oct 2018 20:31:24 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:04:57 GMT
+      - Sat, 20 Oct 2018 20:31:24 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1313,10 +1419,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:04:57 GMT
+  recorded_at: Sat, 20 Oct 2018 20:31:24 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1cT3RMazFSw6Fv88NMbvEGhC80SZvnhHX?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1328,7 +1434,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:04:57 GMT
+      - Sat, 20 Oct 2018 20:31:24 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1346,9 +1452,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:04:57 GMT
+      - Sat, 20 Oct 2018 20:31:24 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:04:57 GMT
+      - Sat, 20 Oct 2018 20:31:24 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1372,20 +1478,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP.",
+            "message": "File not found: 1cT3RMazFSw6Fv88NMbvEGhC80SZvnhHX.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP."
+          "message": "File not found: 1cT3RMazFSw6Fv88NMbvEGhC80SZvnhHX."
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:04:57 GMT
+  recorded_at: Sat, 20 Oct 2018 20:31:24 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1WZwlG61Y9IqRZXIa94yYYQQpHDIs_PCoMV5h9JHgUo4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1IOawSmIT8AwhjXlBu7tsnHqYx8drpFYdlqjEJxNzHSw?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1397,7 +1503,417 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:04:57 GMT
+      - Sat, 20 Oct 2018 20:31:24 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:31:24 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:31:24 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1IOawSmIT8AwhjXlBu7tsnHqYx8drpFYdlqjEJxNzHSw",
+         "name": "File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1G-ny0Fh44M-zsvvppFFP52qRS1moJzTZ"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1IOawSmIT8AwhjXlBu7tsnHqYx8drpFYdlqjEJxNzHSw&v=1&s=AMedNnoAAAAAW8usvGK7udTiuqPgnbqDaJQoYaHmiSXJ&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:31:24 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1IOawSmIT8AwhjXlBu7tsnHqYx8drpFYdlqjEJxNzHSw/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:31:24 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:31:24 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:31:24 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-20T20:30:22.299Z"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:31:24 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1IOawSmIT8AwhjXlBu7tsnHqYx8drpFYdlqjEJxNzHSw&s=AMedNnoAAAAAW8usvGK7udTiuqPgnbqDaJQoYaHmiSXJ&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:31:24 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 20 Oct 2018 20:31:24 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:31:24 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1_16pekjJ-ULHNQEfD5PWPYuuIxAtvA296VXQvU-aT2c?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:31:24 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:31:24 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:31:24 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1_16pekjJ-ULHNQEfD5PWPYuuIxAtvA296VXQvU-aT2c",
+         "name": "File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1G-ny0Fh44M-zsvvppFFP52qRS1moJzTZ"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1_16pekjJ-ULHNQEfD5PWPYuuIxAtvA296VXQvU-aT2c&v=1&s=AMedNnoAAAAAW8usvJCS73FusC0nY_4AIczD6YUCHQI1&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:31:24 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1_16pekjJ-ULHNQEfD5PWPYuuIxAtvA296VXQvU-aT2c/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:31:24 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:31:25 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:31:25 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-20T20:30:20.684Z"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:31:25 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1_16pekjJ-ULHNQEfD5PWPYuuIxAtvA296VXQvU-aT2c&s=AMedNnoAAAAAW8usvJCS73FusC0nY_4AIczD6YUCHQI1&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:31:25 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 20 Oct 2018 20:31:25 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:31:25 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1CjofsU4HqYesHldEF2O1u0m__1vKPzpDWJzRJ82Oo_Y?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:31:25 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1415,9 +1931,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:04:57 GMT
+      - Sat, 20 Oct 2018 20:31:25 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:04:57 GMT
+      - Sat, 20 Oct 2018 20:31:25 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1441,15 +1957,15 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1WZwlG61Y9IqRZXIa94yYYQQpHDIs_PCoMV5h9JHgUo4.",
+            "message": "File not found: 1CjofsU4HqYesHldEF2O1u0m__1vKPzpDWJzRJ82Oo_Y.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1WZwlG61Y9IqRZXIa94yYYQQpHDIs_PCoMV5h9JHgUo4."
+          "message": "File not found: 1CjofsU4HqYesHldEF2O1u0m__1vKPzpDWJzRJ82Oo_Y."
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:04:57 GMT
+  recorded_at: Sat, 20 Oct 2018 20:31:25 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_deletes_the_project_folder.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_deletes_the_project_folder.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:39:43 GMT
+      - Thu, 18 Oct 2018 11:03:51 GMT
       Server:
       - ESF
       Cache-Control:
@@ -48,12 +48,12 @@ http_interactions:
       string: |-
         {
           "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-          "expires_in": 3600,
+          "expires_in": 3599,
           "scope": "https://www.googleapis.com/auth/drive",
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:39:43 GMT
+  recorded_at: Thu, 18 Oct 2018 11:03:51 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:39:43 GMT
+      - Thu, 18 Oct 2018 11:03:51 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:39:43 GMT
+  recorded_at: Thu, 18 Oct 2018 11:03:51 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        09:39:43 UTC","parents":["root"]}'
+        11:03:51 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:39:43 GMT
+      - Thu, 18 Oct 2018 11:03:51 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:39:43 GMT
+      - Thu, 18 Oct 2018 11:03:51 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1TF63V0pD6pZ16FkogUcfpN_iNzylqySX",
-         "name": "Test @ 2018-10-18 09:39:43 UTC",
+         "id": "1A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP",
+         "name": "Test @ 2018-10-18 11:03:51 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:39:43 GMT
+  recorded_at: Thu, 18 Oct 2018 11:03:51 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1TF63V0pD6pZ16FkogUcfpN_iNzylqySX/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:39:43 GMT
+      - Thu, 18 Oct 2018 11:03:51 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:39:44 GMT
+      - Thu, 18 Oct 2018 11:03:52 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:39:44 GMT
+  recorded_at: Thu, 18 Oct 2018 11:03:52 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:39:44 GMT
+      - Thu, 18 Oct 2018 11:03:52 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:39:44 GMT
+      - Thu, 18 Oct 2018 11:03:52 GMT
       Date:
-      - Thu, 18 Oct 2018 09:39:44 GMT
+      - Thu, 18 Oct 2018 11:03:52 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,16 +302,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "9375"
+         "startPageToken": "9503"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:39:44 GMT
+  recorded_at: Thu, 18 Oct 2018 11:03:52 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1TF63V0pD6pZ16FkogUcfpN_iNzylqySX"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -320,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:39:44 GMT
+      - Thu, 18 Oct 2018 11:03:52 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -337,7 +337,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:39:45 GMT
+      - Thu, 18 Oct 2018 11:03:53 GMT
       Vary:
       - Origin
       - X-Origin
@@ -361,12 +361,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "14jMt-3W76bv2lejSgJGNqRjmB108xjFaJIcahEIWvo8",
+         "id": "1WZwlG61Y9IqRZXIa94yYYQQpHDIs_PCoMV5h9JHgUo4",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1TF63V0pD6pZ16FkogUcfpN_iNzylqySX"
+          "1A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -391,10 +391,150 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:39:45 GMT
+  recorded_at: Thu, 18 Oct 2018 11:03:53 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"2 Billion
+        Year Bunker (Archive)","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:03:53 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:03:54 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1KfAU2ONOKbCcUx93rbSNd2MvOxeiBDzr",
+         "name": "2 Billion Year Bunker (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:03:54 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1KfAU2ONOKbCcUx93rbSNd2MvOxeiBDzr/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:03:54 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:03:54 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "13193959451567607887",
+         "type": "user",
+         "role": "reader"
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:03:54 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1TF63V0pD6pZ16FkogUcfpN_iNzylqySX?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1KfAU2ONOKbCcUx93rbSNd2MvOxeiBDzr?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -406,7 +546,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:39:45 GMT
+      - Thu, 18 Oct 2018 11:03:54 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -417,9 +557,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:39:45 GMT
+      - Thu, 18 Oct 2018 11:03:54 GMT
       Date:
-      - Thu, 18 Oct 2018 09:39:45 GMT
+      - Thu, 18 Oct 2018 11:03:54 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -445,37 +585,40 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1TF63V0pD6pZ16FkogUcfpN_iNzylqySX",
-         "name": "Test @ 2018-10-18 09:39:43 UTC",
+         "id": "1KfAU2ONOKbCcUx93rbSNd2MvOxeiBDzr",
+         "name": "2 Billion Year Bunker (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
          "thumbnailVersion": "0",
          "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
           {
            "kind": "drive#permission",
            "id": "13193959451567607887",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
+           "role": "reader",
            "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
            "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:39:46 GMT
+  recorded_at: Thu, 18 Oct 2018 11:03:54 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1TF63V0pD6pZ16FkogUcfpN_iNzylqySX/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1KfAU2ONOKbCcUx93rbSNd2MvOxeiBDzr/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -487,7 +630,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:39:46 GMT
+      - Thu, 18 Oct 2018 11:03:54 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -505,9 +648,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:39:46 GMT
+      - Thu, 18 Oct 2018 11:03:55 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:39:46 GMT
+      - Thu, 18 Oct 2018 11:03:55 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -539,10 +682,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:39:46 GMT
+  recorded_at: Thu, 18 Oct 2018 11:03:55 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271TF63V0pD6pZ16FkogUcfpN_iNzylqySX%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files/1A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -554,7 +697,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:39:46 GMT
+      - Thu, 18 Oct 2018 11:03:55 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -565,9 +708,157 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:39:46 GMT
+      - Thu, 18 Oct 2018 11:03:55 GMT
       Date:
-      - Thu, 18 Oct 2018 09:39:46 GMT
+      - Thu, 18 Oct 2018 11:03:55 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP",
+         "name": "Test @ 2018-10-18 11:03:51 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:03:55 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:03:55 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:03:55 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:03:55 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:03:55 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:03:55 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:03:55 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:03:55 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -595,12 +886,12 @@ http_interactions:
         {
          "files": [
           {
-           "id": "14jMt-3W76bv2lejSgJGNqRjmB108xjFaJIcahEIWvo8",
+           "id": "1WZwlG61Y9IqRZXIa94yYYQQpHDIs_PCoMV5h9JHgUo4",
            "name": "File",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1TF63V0pD6pZ16FkogUcfpN_iNzylqySX"
+            "1A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -627,10 +918,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:39:46 GMT
+  recorded_at: Thu, 18 Oct 2018 11:03:55 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/14jMt-3W76bv2lejSgJGNqRjmB108xjFaJIcahEIWvo8/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1WZwlG61Y9IqRZXIa94yYYQQpHDIs_PCoMV5h9JHgUo4/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -642,7 +933,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:39:46 GMT
+      - Thu, 18 Oct 2018 11:03:55 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -653,9 +944,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:39:46 GMT
+      - Thu, 18 Oct 2018 11:03:55 GMT
       Date:
-      - Thu, 18 Oct 2018 09:39:46 GMT
+      - Thu, 18 Oct 2018 11:03:55 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -684,13 +975,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T09:39:44.920Z"
+         "modifiedTime": "2018-10-18T11:03:52.884Z"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:39:46 GMT
+  recorded_at: Thu, 18 Oct 2018 11:03:55 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1TF63V0pD6pZ16FkogUcfpN_iNzylqySX
+    uri: https://www.googleapis.com/drive/v3/files/1A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP
     body:
       encoding: UTF-8
       string: ''
@@ -702,7 +993,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:39:46 GMT
+      - Thu, 18 Oct 2018 11:03:55 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -719,7 +1010,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:39:47 GMT
+      - Thu, 18 Oct 2018 11:03:56 GMT
       Vary:
       - Origin
       - X-Origin
@@ -731,10 +1022,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:39:47 GMT
+  recorded_at: Thu, 18 Oct 2018 11:03:56 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9375
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9503
     body:
       encoding: UTF-8
       string: ''
@@ -746,7 +1037,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:40:47 GMT
+      - Thu, 18 Oct 2018 11:04:56 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -757,9 +1048,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:40:47 GMT
+      - Thu, 18 Oct 2018 11:04:56 GMT
       Date:
-      - Thu, 18 Oct 2018 09:40:47 GMT
+      - Thu, 18 Oct 2018 11:04:56 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -785,21 +1076,27 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "9379",
+         "newStartPageToken": "9509",
          "changes": [
           {
-           "fileId": "1TF63V0pD6pZ16FkogUcfpN_iNzylqySX"
+           "fileId": "1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo"
           },
           {
-           "fileId": "14jMt-3W76bv2lejSgJGNqRjmB108xjFaJIcahEIWvo8"
+           "fileId": "1KfAU2ONOKbCcUx93rbSNd2MvOxeiBDzr"
+          },
+          {
+           "fileId": "1A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP"
+          },
+          {
+           "fileId": "1WZwlG61Y9IqRZXIa94yYYQQpHDIs_PCoMV5h9JHgUo4"
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:40:47 GMT
+  recorded_at: Thu, 18 Oct 2018 11:04:56 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1TF63V0pD6pZ16FkogUcfpN_iNzylqySX?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -811,7 +1108,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:40:47 GMT
+      - Thu, 18 Oct 2018 11:04:56 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -829,9 +1126,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:40:47 GMT
+      - Thu, 18 Oct 2018 11:04:56 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:40:47 GMT
+      - Thu, 18 Oct 2018 11:04:56 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -855,20 +1152,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1TF63V0pD6pZ16FkogUcfpN_iNzylqySX.",
+            "message": "File not found: 1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1TF63V0pD6pZ16FkogUcfpN_iNzylqySX."
+          "message": "File not found: 1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo."
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:40:47 GMT
+  recorded_at: Thu, 18 Oct 2018 11:04:56 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/14jMt-3W76bv2lejSgJGNqRjmB108xjFaJIcahEIWvo8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1KfAU2ONOKbCcUx93rbSNd2MvOxeiBDzr?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -880,7 +1177,158 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:40:47 GMT
+      - Thu, 18 Oct 2018 11:04:56 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:04:56 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:04:56 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1KfAU2ONOKbCcUx93rbSNd2MvOxeiBDzr",
+         "name": "2 Billion Year Bunker (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:04:56 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1KfAU2ONOKbCcUx93rbSNd2MvOxeiBDzr/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:04:56 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:04:57 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:04:57 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:04:57 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:04:57 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -898,9 +1346,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:40:47 GMT
+      - Thu, 18 Oct 2018 11:04:57 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:40:47 GMT
+      - Thu, 18 Oct 2018 11:04:57 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -924,15 +1372,84 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 14jMt-3W76bv2lejSgJGNqRjmB108xjFaJIcahEIWvo8.",
+            "message": "File not found: 1A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 14jMt-3W76bv2lejSgJGNqRjmB108xjFaJIcahEIWvo8."
+          "message": "File not found: 1A4IFXfcTTekfoyrLDzkXa8LMaMAHK3tP."
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:40:47 GMT
+  recorded_at: Thu, 18 Oct 2018 11:04:57 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1WZwlG61Y9IqRZXIa94yYYQQpHDIs_PCoMV5h9JHgUo4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:04:57 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:04:57 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:04:57 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "notFound",
+            "message": "File not found: 1WZwlG61Y9IqRZXIa94yYYQQpHDIs_PCoMV5h9JHgUo4.",
+            "locationType": "parameter",
+            "location": "fileId"
+           }
+          ],
+          "code": 404,
+          "message": "File not found: 1WZwlG61Y9IqRZXIa94yYYQQpHDIs_PCoMV5h9JHgUo4."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:04:57 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_deletes_the_project_folder.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_deletes_the_project_folder.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,42 +21,39 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:34:00 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:39:43 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:34:00 GMT
+  recorded_at: Thu, 18 Oct 2018 09:39:43 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -66,7 +63,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -78,49 +75,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:34:00 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:39:43 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:34:00 GMT
+  recorded_at: Thu, 18 Oct 2018 09:39:43 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        21:34:00 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:39:43 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -129,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:34:00 GMT
+      - Thu, 18 Oct 2018 09:39:43 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -146,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:34:01 GMT
+      - Thu, 18 Oct 2018 09:39:43 GMT
       Vary:
       - Origin
       - X-Origin
@@ -163,28 +157,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1W5lF1k0p_kvWVOUVyzyoRVRDAghZNdwY",
-         "name": "Test @ 2018-03-18 21:34:00 UTC",
+         "id": "1TF63V0pD6pZ16FkogUcfpN_iNzylqySX",
+         "name": "Test @ 2018-10-18 09:39:43 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AEIi2L68pCuiUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:34:01 GMT
+  recorded_at: Thu, 18 Oct 2018 09:39:43 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1W5lF1k0p_kvWVOUVyzyoRVRDAghZNdwY/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1TF63V0pD6pZ16FkogUcfpN_iNzylqySX/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -196,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:34:01 GMT
+      - Thu, 18 Oct 2018 09:39:43 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -213,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:34:02 GMT
+      - Thu, 18 Oct 2018 09:39:44 GMT
       Vary:
       - Origin
       - X-Origin
@@ -230,8 +234,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -244,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:34:02 GMT
+  recorded_at: Thu, 18 Oct 2018 09:39:44 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -259,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:34:02 GMT
+      - Thu, 18 Oct 2018 09:39:44 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -270,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:34:02 GMT
+      - Thu, 18 Oct 2018 09:39:44 GMT
       Date:
-      - Sun, 18 Mar 2018 21:34:02 GMT
+      - Thu, 18 Oct 2018 09:39:44 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -291,8 +294,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -300,16 +302,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "7182"
+         "startPageToken": "9375"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:34:02 GMT
+  recorded_at: Thu, 18 Oct 2018 09:39:44 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1W5lF1k0p_kvWVOUVyzyoRVRDAghZNdwY"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1TF63V0pD6pZ16FkogUcfpN_iNzylqySX"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -318,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:34:02 GMT
+      - Thu, 18 Oct 2018 09:39:44 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -335,7 +337,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:34:03 GMT
+      - Thu, 18 Oct 2018 09:39:45 GMT
       Vary:
       - Origin
       - X-Origin
@@ -352,28 +354,47 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1oSGbmhR-0AudCgJ1urYV1uCTkQQUgQuGSWU6jBZBJPI",
+         "id": "14jMt-3W76bv2lejSgJGNqRjmB108xjFaJIcahEIWvo8",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1W5lF1k0p_kvWVOUVyzyoRVRDAghZNdwY"
+          "1TF63V0pD6pZ16FkogUcfpN_iNzylqySX"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:34:03 GMT
+  recorded_at: Thu, 18 Oct 2018 09:39:45 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1W5lF1k0p_kvWVOUVyzyoRVRDAghZNdwY?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1TF63V0pD6pZ16FkogUcfpN_iNzylqySX?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -385,7 +406,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:34:03 GMT
+      - Thu, 18 Oct 2018 09:39:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -396,9 +417,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:34:03 GMT
+      - Thu, 18 Oct 2018 09:39:45 GMT
       Date:
-      - Sun, 18 Mar 2018 21:34:03 GMT
+      - Thu, 18 Oct 2018 09:39:45 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -417,25 +438,44 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1W5lF1k0p_kvWVOUVyzyoRVRDAghZNdwY",
-         "name": "Test @ 2018-03-18 21:34:00 UTC",
+         "id": "1TF63V0pD6pZ16FkogUcfpN_iNzylqySX",
+         "name": "Test @ 2018-10-18 09:39:43 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:34:04 GMT
+  recorded_at: Thu, 18 Oct 2018 09:39:46 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1W5lF1k0p_kvWVOUVyzyoRVRDAghZNdwY/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1TF63V0pD6pZ16FkogUcfpN_iNzylqySX/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -447,7 +487,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:34:04 GMT
+      - Thu, 18 Oct 2018 09:39:46 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -465,9 +505,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:34:04 GMT
+      - Thu, 18 Oct 2018 09:39:46 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:34:04 GMT
+      - Thu, 18 Oct 2018 09:39:46 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -479,8 +519,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -500,10 +539,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:34:04 GMT
+  recorded_at: Thu, 18 Oct 2018 09:39:46 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271W5lF1k0p_kvWVOUVyzyoRVRDAghZNdwY%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271TF63V0pD6pZ16FkogUcfpN_iNzylqySX%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -515,7 +554,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:34:04 GMT
+      - Thu, 18 Oct 2018 09:39:46 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -526,9 +565,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:34:04 GMT
+      - Thu, 18 Oct 2018 09:39:46 GMT
       Date:
-      - Sun, 18 Mar 2018 21:34:04 GMT
+      - Thu, 18 Oct 2018 09:39:46 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -547,8 +586,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -557,22 +595,42 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1oSGbmhR-0AudCgJ1urYV1uCTkQQUgQuGSWU6jBZBJPI",
+           "id": "14jMt-3W76bv2lejSgJGNqRjmB108xjFaJIcahEIWvo8",
            "name": "File",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1W5lF1k0p_kvWVOUVyzyoRVRDAghZNdwY"
+            "1TF63V0pD6pZ16FkogUcfpN_iNzylqySX"
            ],
-           "thumbnailVersion": "0"
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "writer",
+             "displayName": "Upshift One",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "13193959451567607887",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+             "role": "owner",
+             "displayName": "Testuser Upshift One",
+             "deleted": false
+            }
+           ]
           }
          ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:34:04 GMT
+  recorded_at: Thu, 18 Oct 2018 09:39:46 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1oSGbmhR-0AudCgJ1urYV1uCTkQQUgQuGSWU6jBZBJPI/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/14jMt-3W76bv2lejSgJGNqRjmB108xjFaJIcahEIWvo8/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -584,7 +642,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:34:04 GMT
+      - Thu, 18 Oct 2018 09:39:46 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -595,9 +653,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:34:04 GMT
+      - Thu, 18 Oct 2018 09:39:46 GMT
       Date:
-      - Sun, 18 Mar 2018 21:34:04 GMT
+      - Thu, 18 Oct 2018 09:39:46 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -616,8 +674,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -627,13 +684,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-03-18T21:34:02.928Z"
+         "modifiedTime": "2018-10-18T09:39:44.920Z"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:34:04 GMT
+  recorded_at: Thu, 18 Oct 2018 09:39:46 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1W5lF1k0p_kvWVOUVyzyoRVRDAghZNdwY
+    uri: https://www.googleapis.com/drive/v3/files/1TF63V0pD6pZ16FkogUcfpN_iNzylqySX
     body:
       encoding: UTF-8
       string: ''
@@ -645,7 +702,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:34:04 GMT
+      - Thu, 18 Oct 2018 09:39:46 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -662,23 +719,22 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:34:05 GMT
+      - Thu, 18 Oct 2018 09:39:47 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:34:05 GMT
+  recorded_at: Thu, 18 Oct 2018 09:39:47 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=7182
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9375
     body:
       encoding: UTF-8
       string: ''
@@ -690,7 +746,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:35:05 GMT
+      - Thu, 18 Oct 2018 09:40:47 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -701,9 +757,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:35:05 GMT
+      - Thu, 18 Oct 2018 09:40:47 GMT
       Date:
-      - Sun, 18 Mar 2018 21:35:05 GMT
+      - Thu, 18 Oct 2018 09:40:47 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -722,29 +778,28 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "7185",
+         "newStartPageToken": "9379",
          "changes": [
           {
-           "fileId": "1W5lF1k0p_kvWVOUVyzyoRVRDAghZNdwY"
+           "fileId": "1TF63V0pD6pZ16FkogUcfpN_iNzylqySX"
           },
           {
-           "fileId": "1oSGbmhR-0AudCgJ1urYV1uCTkQQUgQuGSWU6jBZBJPI"
+           "fileId": "14jMt-3W76bv2lejSgJGNqRjmB108xjFaJIcahEIWvo8"
           }
          ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:35:05 GMT
+  recorded_at: Thu, 18 Oct 2018 09:40:47 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1W5lF1k0p_kvWVOUVyzyoRVRDAghZNdwY?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1TF63V0pD6pZ16FkogUcfpN_iNzylqySX?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -756,7 +811,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:35:05 GMT
+      - Thu, 18 Oct 2018 09:40:47 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -774,9 +829,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:35:05 GMT
+      - Thu, 18 Oct 2018 09:40:47 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:35:05 GMT
+      - Thu, 18 Oct 2018 09:40:47 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -788,8 +843,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -801,20 +855,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1W5lF1k0p_kvWVOUVyzyoRVRDAghZNdwY.",
+            "message": "File not found: 1TF63V0pD6pZ16FkogUcfpN_iNzylqySX.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1W5lF1k0p_kvWVOUVyzyoRVRDAghZNdwY."
+          "message": "File not found: 1TF63V0pD6pZ16FkogUcfpN_iNzylqySX."
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:35:05 GMT
+  recorded_at: Thu, 18 Oct 2018 09:40:47 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1oSGbmhR-0AudCgJ1urYV1uCTkQQUgQuGSWU6jBZBJPI?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/14jMt-3W76bv2lejSgJGNqRjmB108xjFaJIcahEIWvo8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -826,7 +880,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:35:05 GMT
+      - Thu, 18 Oct 2018 09:40:47 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -844,9 +898,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:35:05 GMT
+      - Thu, 18 Oct 2018 09:40:47 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:35:05 GMT
+      - Thu, 18 Oct 2018 09:40:47 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -858,8 +912,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -871,15 +924,15 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1oSGbmhR-0AudCgJ1urYV1uCTkQQUgQuGSWU6jBZBJPI.",
+            "message": "File not found: 14jMt-3W76bv2lejSgJGNqRjmB108xjFaJIcahEIWvo8.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1oSGbmhR-0AudCgJ1urYV1uCTkQQUgQuGSWU6jBZBJPI."
+          "message": "File not found: 14jMt-3W76bv2lejSgJGNqRjmB108xjFaJIcahEIWvo8."
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:35:05 GMT
+  recorded_at: Thu, 18 Oct 2018 09:40:47 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_moves_file_out_of_project_folder.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_moves_file_out_of_project_folder.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 11:02:40 GMT
+      - Sat, 20 Oct 2018 20:18:10 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:02:40 GMT
+  recorded_at: Sat, 20 Oct 2018 20:18:10 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 11:02:40 GMT
+      - Sat, 20 Oct 2018 20:18:10 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:02:40 GMT
+  recorded_at: Sat, 20 Oct 2018 20:18:10 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        11:02:40 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-20
+        20:18:10 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:02:40 GMT
+      - Sat, 20 Oct 2018 20:18:10 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:02:41 GMT
+      - Sat, 20 Oct 2018 20:18:10 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1y24Zby6eJgLDccg8O157BTLytcQb_gMh",
-         "name": "Test @ 2018-10-18 11:02:40 UTC",
+         "id": "1lBsi0y-XJLvjbMgV4LE13ORDCkESBEsP",
+         "name": "Test @ 2018-10-20 20:18:10 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:02:41 GMT
+  recorded_at: Sat, 20 Oct 2018 20:18:10 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1y24Zby6eJgLDccg8O157BTLytcQb_gMh/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1lBsi0y-XJLvjbMgV4LE13ORDCkESBEsP/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:02:41 GMT
+      - Sat, 20 Oct 2018 20:18:10 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:02:41 GMT
+      - Sat, 20 Oct 2018 20:18:11 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:02:41 GMT
+  recorded_at: Sat, 20 Oct 2018 20:18:11 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:02:41 GMT
+      - Sat, 20 Oct 2018 20:18:11 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:02:41 GMT
+      - Sat, 20 Oct 2018 20:18:11 GMT
       Date:
-      - Thu, 18 Oct 2018 11:02:41 GMT
+      - Sat, 20 Oct 2018 20:18:11 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,17 +302,17 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "9496"
+         "startPageToken": "10569"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:02:41 GMT
+  recorded_at: Sat, 20 Oct 2018 20:18:11 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.document","name":"File To
-        Move","parents":["1y24Zby6eJgLDccg8O157BTLytcQb_gMh"]}'
+        Move","parents":["1lBsi0y-XJLvjbMgV4LE13ORDCkESBEsP"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -321,7 +321,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:02:43 GMT
+      - Sat, 20 Oct 2018 20:18:11 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -338,7 +338,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:02:43 GMT
+      - Sat, 20 Oct 2018 20:18:12 GMT
       Vary:
       - Origin
       - X-Origin
@@ -362,12 +362,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo",
+         "id": "1HvKTI0z21L1TcamDiKlGP627xZ64uRRj22kzEteSS7E",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1y24Zby6eJgLDccg8O157BTLytcQb_gMh"
+          "1lBsi0y-XJLvjbMgV4LE13ORDCkESBEsP"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -392,14 +392,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:02:44 GMT
+  recorded_at: Sat, 20 Oct 2018 20:18:12 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"1 Krikkit
-        One (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"4 Heart of
+        Gold (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -408,7 +408,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:02:44 GMT
+      - Sat, 20 Oct 2018 20:18:12 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -425,7 +425,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:02:44 GMT
+      - Sat, 20 Oct 2018 20:18:13 GMT
       Vary:
       - Origin
       - X-Origin
@@ -449,8 +449,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1FAh708487sg4uLM_xjpyTb7XGll5gldV",
-         "name": "1 Krikkit One (Archive)",
+         "id": "1hC5wLJVT_4RpYwFUqy8nCVI-LQjNjUq8",
+         "name": "4 Heart of Gold (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -470,10 +470,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:02:44 GMT
+  recorded_at: Sat, 20 Oct 2018 20:18:13 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1FAh708487sg4uLM_xjpyTb7XGll5gldV/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1hC5wLJVT_4RpYwFUqy8nCVI-LQjNjUq8/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -485,7 +485,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:02:44 GMT
+      - Sat, 20 Oct 2018 20:18:13 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -502,7 +502,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:02:45 GMT
+      - Sat, 20 Oct 2018 20:18:14 GMT
       Vary:
       - Origin
       - X-Origin
@@ -532,10 +532,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:02:45 GMT
+  recorded_at: Sat, 20 Oct 2018 20:18:14 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1FAh708487sg4uLM_xjpyTb7XGll5gldV?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1hC5wLJVT_4RpYwFUqy8nCVI-LQjNjUq8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -547,7 +547,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:02:45 GMT
+      - Sat, 20 Oct 2018 20:18:14 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -558,9 +558,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:02:45 GMT
+      - Sat, 20 Oct 2018 20:18:14 GMT
       Date:
-      - Thu, 18 Oct 2018 11:02:45 GMT
+      - Sat, 20 Oct 2018 20:18:14 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -586,8 +586,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1FAh708487sg4uLM_xjpyTb7XGll5gldV",
-         "name": "1 Krikkit One (Archive)",
+         "id": "1hC5wLJVT_4RpYwFUqy8nCVI-LQjNjUq8",
+         "name": "4 Heart of Gold (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -616,10 +616,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:02:45 GMT
+  recorded_at: Sat, 20 Oct 2018 20:18:14 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1FAh708487sg4uLM_xjpyTb7XGll5gldV/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1hC5wLJVT_4RpYwFUqy8nCVI-LQjNjUq8/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -631,7 +631,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:02:45 GMT
+      - Sat, 20 Oct 2018 20:18:14 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -649,9 +649,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:02:45 GMT
+      - Sat, 20 Oct 2018 20:18:14 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:02:45 GMT
+      - Sat, 20 Oct 2018 20:18:14 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -683,10 +683,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:02:45 GMT
+  recorded_at: Sat, 20 Oct 2018 20:18:14 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1y24Zby6eJgLDccg8O157BTLytcQb_gMh?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1lBsi0y-XJLvjbMgV4LE13ORDCkESBEsP?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -698,7 +698,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:02:45 GMT
+      - Sat, 20 Oct 2018 20:18:14 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -709,9 +709,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:02:45 GMT
+      - Sat, 20 Oct 2018 20:18:14 GMT
       Date:
-      - Thu, 18 Oct 2018 11:02:45 GMT
+      - Sat, 20 Oct 2018 20:18:14 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -737,8 +737,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1y24Zby6eJgLDccg8O157BTLytcQb_gMh",
-         "name": "Test @ 2018-10-18 11:02:40 UTC",
+         "id": "1lBsi0y-XJLvjbMgV4LE13ORDCkESBEsP",
+         "name": "Test @ 2018-10-20 20:18:10 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -764,10 +764,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:02:45 GMT
+  recorded_at: Sat, 20 Oct 2018 20:18:14 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1y24Zby6eJgLDccg8O157BTLytcQb_gMh/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1lBsi0y-XJLvjbMgV4LE13ORDCkESBEsP/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -779,7 +779,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:02:45 GMT
+      - Sat, 20 Oct 2018 20:18:14 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -797,9 +797,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:02:46 GMT
+      - Sat, 20 Oct 2018 20:18:14 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:02:46 GMT
+      - Sat, 20 Oct 2018 20:18:14 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -831,10 +831,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:02:46 GMT
+  recorded_at: Sat, 20 Oct 2018 20:18:14 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271y24Zby6eJgLDccg8O157BTLytcQb_gMh%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271lBsi0y-XJLvjbMgV4LE13ORDCkESBEsP%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -846,7 +846,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:02:46 GMT
+      - Sat, 20 Oct 2018 20:18:14 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -857,9 +857,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:02:46 GMT
+      - Sat, 20 Oct 2018 20:18:15 GMT
       Date:
-      - Thu, 18 Oct 2018 11:02:46 GMT
+      - Sat, 20 Oct 2018 20:18:15 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -887,15 +887,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo",
+           "id": "1HvKTI0z21L1TcamDiKlGP627xZ64uRRj22kzEteSS7E",
            "name": "File To Move",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1y24Zby6eJgLDccg8O157BTLytcQb_gMh"
+            "1lBsi0y-XJLvjbMgV4LE13ORDCkESBEsP"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo&v=1&s=AMedNnoAAAAAW8iEdlE-m75GxPlqVqdnywKotcwzxYVf&sz=s220",
-           "thumbnailVersion": "1",
+           "thumbnailVersion": "0",
            "permissions": [
             {
              "kind": "drive#permission",
@@ -920,10 +919,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:02:46 GMT
+  recorded_at: Sat, 20 Oct 2018 20:18:15 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1HvKTI0z21L1TcamDiKlGP627xZ64uRRj22kzEteSS7E/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -935,7 +934,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:02:46 GMT
+      - Sat, 20 Oct 2018 20:18:15 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -946,9 +945,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:02:46 GMT
+      - Sat, 20 Oct 2018 20:18:15 GMT
       Date:
-      - Thu, 18 Oct 2018 11:02:46 GMT
+      - Sat, 20 Oct 2018 20:18:15 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -977,13 +976,262 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T11:02:43.261Z"
+         "modifiedTime": "2018-10-20T20:18:12.040Z"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:02:46 GMT
+  recorded_at: Sat, 20 Oct 2018 20:18:15 GMT
 - request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo&s=AMedNnoAAAAAW8iEdlE-m75GxPlqVqdnywKotcwzxYVf&sz=s350&v=1
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1HvKTI0z21L1TcamDiKlGP627xZ64uRRj22kzEteSS7E/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"File To Move","parents":["1hC5wLJVT_4RpYwFUqy8nCVI-LQjNjUq8"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:18:15 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:18:16 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1k1Ik0KEdePj2dKh0ps7R8ulkUr9foMob3I_c9eDOiVY",
+         "name": "File To Move",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1hC5wLJVT_4RpYwFUqy8nCVI-LQjNjUq8"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:18:16 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1HvKTI0z21L1TcamDiKlGP627xZ64uRRj22kzEteSS7E/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"File To Move","parents":["1hC5wLJVT_4RpYwFUqy8nCVI-LQjNjUq8"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:18:16 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:18:18 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1LrXZFz25xq8AWese37mltzjUZPyv393ko-b2-OB3mZ4",
+         "name": "File To Move",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1hC5wLJVT_4RpYwFUqy8nCVI-LQjNjUq8"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:18:18 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"out-of-scope-folder","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:18:18 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:18:18 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1QHpmHhkXB9SDvYvSSMCYhhYp5ifAgt_S",
+         "name": "out-of-scope-folder",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AEIi2L68pCuiUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:18:18 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/drive/v3/files/1HvKTI0z21L1TcamDiKlGP627xZ64uRRj22kzEteSS7E?addParents=1QHpmHhkXB9SDvYvSSMCYhhYp5ifAgt_S&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1lBsi0y-XJLvjbMgV4LE13ORDCkESBEsP
     body:
       encoding: UTF-8
       string: ''
@@ -995,7 +1243,542 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:02:46 GMT
+      - Sat, 20 Oct 2018 20:18:18 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:18:19 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1HvKTI0z21L1TcamDiKlGP627xZ64uRRj22kzEteSS7E",
+         "name": "File To Move",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1QHpmHhkXB9SDvYvSSMCYhhYp5ifAgt_S"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1HvKTI0z21L1TcamDiKlGP627xZ64uRRj22kzEteSS7E&v=1&s=AMedNnoAAAAAW8upq8ITsu74YGjmBhxPUgz26WOVq-fZ&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:18:19 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=10569
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:19:19 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:19:19 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:19:19 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "newStartPageToken": "10588",
+         "changes": [
+          {
+           "fileId": "1hC5wLJVT_4RpYwFUqy8nCVI-LQjNjUq8"
+          },
+          {
+           "fileId": "16ePkF143Mo5V1u_qXYzvsvXtzl0GAx_50LsOu6mHbIY"
+          },
+          {
+           "fileId": "1k1Ik0KEdePj2dKh0ps7R8ulkUr9foMob3I_c9eDOiVY"
+          },
+          {
+           "fileId": "1LrXZFz25xq8AWese37mltzjUZPyv393ko-b2-OB3mZ4"
+          },
+          {
+           "fileId": "1M-hDuC9pMjUdn6-Nlb8FNqWyKN8F8fzpRBUlqu_9db4"
+          },
+          {
+           "fileId": "1ohe0qm2Lsjwqbws86-63fkYq_wVLEAYZ7eEBEQfbWYs"
+          },
+          {
+           "fileId": "1qW7JHE81hPv4mIKKp1g3biBlwHLjGaKsr5mCHmSajac"
+          },
+          {
+           "fileId": "1g5CjBRP3QQh-Mbv4--KDKUgGIqiqmDIxQu3KWyEJVO4"
+          },
+          {
+           "fileId": "1os-OXm_oRCQk7qpSQz7rKthIausLRiDHCSmqceEPvE8"
+          },
+          {
+           "fileId": "1lBsi0y-XJLvjbMgV4LE13ORDCkESBEsP"
+          },
+          {
+           "fileId": "1HvKTI0z21L1TcamDiKlGP627xZ64uRRj22kzEteSS7E"
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:19:19 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1hC5wLJVT_4RpYwFUqy8nCVI-LQjNjUq8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:19:19 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:19:19 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:19:19 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1hC5wLJVT_4RpYwFUqy8nCVI-LQjNjUq8",
+         "name": "4 Heart of Gold (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:19:19 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1hC5wLJVT_4RpYwFUqy8nCVI-LQjNjUq8/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:19:19 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Sat, 20 Oct 2018 20:19:19 GMT
+      Expires:
+      - Sat, 20 Oct 2018 20:19:19 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:19:19 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/16ePkF143Mo5V1u_qXYzvsvXtzl0GAx_50LsOu6mHbIY?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:19:19 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Sat, 20 Oct 2018 20:19:20 GMT
+      Expires:
+      - Sat, 20 Oct 2018 20:19:20 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "notFound",
+            "message": "File not found: 16ePkF143Mo5V1u_qXYzvsvXtzl0GAx_50LsOu6mHbIY.",
+            "locationType": "parameter",
+            "location": "fileId"
+           }
+          ],
+          "code": 404,
+          "message": "File not found: 16ePkF143Mo5V1u_qXYzvsvXtzl0GAx_50LsOu6mHbIY."
+         }
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:19:20 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1k1Ik0KEdePj2dKh0ps7R8ulkUr9foMob3I_c9eDOiVY?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:19:20 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:19:20 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:19:20 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1k1Ik0KEdePj2dKh0ps7R8ulkUr9foMob3I_c9eDOiVY",
+         "name": "File To Move",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1hC5wLJVT_4RpYwFUqy8nCVI-LQjNjUq8"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1k1Ik0KEdePj2dKh0ps7R8ulkUr9foMob3I_c9eDOiVY&v=1&s=AMedNnoAAAAAW8up6OuChp5gvsEFfGcCZ7_UB5MJkR7h&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:19:20 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1k1Ik0KEdePj2dKh0ps7R8ulkUr9foMob3I_c9eDOiVY/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:19:20 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:19:20 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:19:20 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-20T20:18:16.122Z"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:19:20 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1k1Ik0KEdePj2dKh0ps7R8ulkUr9foMob3I_c9eDOiVY&s=AMedNnoAAAAAW8up6OuChp5gvsEFfGcCZ7_UB5MJkR7h&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:19:20 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1026,7 +1809,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 18 Oct 2018 11:02:46 GMT
+      - Sat, 20 Oct 2018 20:19:20 GMT
       Server:
       - fife
       Content-Length:
@@ -1040,87 +1823,10 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:02:46 GMT
+  recorded_at: Sat, 20 Oct 2018 20:19:20 GMT
 - request:
-    method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"out-of-scope-folder","parents":["root"]}'
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:02:47 GMT
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Thu, 18 Oct 2018 11:02:47 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1eigphDrFSiiTbIBA7RssWWhiJcFfm6oT",
-         "name": "out-of-scope-folder",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AEIi2L68pCuiUk9PVA"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:02:47 GMT
-- request:
-    method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo?addParents=1eigphDrFSiiTbIBA7RssWWhiJcFfm6oT&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1y24Zby6eJgLDccg8O157BTLytcQb_gMh
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1LrXZFz25xq8AWese37mltzjUZPyv393ko-b2-OB3mZ4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1132,9 +1838,9 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:02:47 GMT
+      - Sat, 20 Oct 2018 20:19:20 GMT
       Authorization:
-      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
       - application/x-www-form-urlencoded
   response:
@@ -1142,14 +1848,12 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
       Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
+      - Sat, 20 Oct 2018 20:19:20 GMT
       Date:
-      - Thu, 18 Oct 2018 11:02:48 GMT
+      - Sat, 20 Oct 2018 20:19:20 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
       Vary:
       - Origin
       - X-Origin
@@ -1173,158 +1877,15 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo",
+         "id": "1LrXZFz25xq8AWese37mltzjUZPyv393ko-b2-OB3mZ4",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1eigphDrFSiiTbIBA7RssWWhiJcFfm6oT"
+          "1hC5wLJVT_4RpYwFUqy8nCVI-LQjNjUq8"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo&v=1&s=AMedNnoAAAAAW8iEeMBS94hamLeRX0Z98y_BIWzdaOgJ&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1LrXZFz25xq8AWese37mltzjUZPyv393ko-b2-OB3mZ4&v=1&s=AMedNnoAAAAAW8up6ATB7ccdNsqGrH8tdgLnnqePHn5s&sz=s220",
          "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:02:48 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9496
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:03:48 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Thu, 18 Oct 2018 11:03:48 GMT
-      Date:
-      - Thu, 18 Oct 2018 11:03:48 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "newStartPageToken": "9501",
-         "changes": [
-          {
-           "fileId": "1FAh708487sg4uLM_xjpyTb7XGll5gldV"
-          },
-          {
-           "fileId": "1y24Zby6eJgLDccg8O157BTLytcQb_gMh"
-          },
-          {
-           "fileId": "1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo"
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:03:48 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1FAh708487sg4uLM_xjpyTb7XGll5gldV?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:03:48 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Thu, 18 Oct 2018 11:03:48 GMT
-      Date:
-      - Thu, 18 Oct 2018 11:03:48 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1FAh708487sg4uLM_xjpyTb7XGll5gldV",
-         "name": "1 Krikkit One (Archive)",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
-         "thumbnailVersion": "0",
          "permissions": [
           {
            "kind": "drive#permission",
@@ -1347,10 +1908,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:03:48 GMT
+  recorded_at: Sat, 20 Oct 2018 20:19:20 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1FAh708487sg4uLM_xjpyTb7XGll5gldV/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1LrXZFz25xq8AWese37mltzjUZPyv393ko-b2-OB3mZ4/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1362,74 +1923,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:03:48 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 18 Oct 2018 11:03:48 GMT
-      Expires:
-      - Thu, 18 Oct 2018 11:03:48 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:03:48 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1y24Zby6eJgLDccg8O157BTLytcQb_gMh?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:03:48 GMT
+      - Sat, 20 Oct 2018 20:19:20 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1440,9 +1934,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:03:48 GMT
+      - Sat, 20 Oct 2018 20:19:20 GMT
       Date:
-      - Thu, 18 Oct 2018 11:03:48 GMT
+      - Sat, 20 Oct 2018 20:19:20 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1468,8 +1962,1153 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1y24Zby6eJgLDccg8O157BTLytcQb_gMh",
-         "name": "Test @ 2018-10-18 11:02:40 UTC",
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-20T20:18:17.727Z"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:19:20 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1LrXZFz25xq8AWese37mltzjUZPyv393ko-b2-OB3mZ4&s=AMedNnoAAAAAW8up6ATB7ccdNsqGrH8tdgLnnqePHn5s&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:19:20 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 20 Oct 2018 20:19:21 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:19:21 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1M-hDuC9pMjUdn6-Nlb8FNqWyKN8F8fzpRBUlqu_9db4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:19:21 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:19:21 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:19:21 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1M-hDuC9pMjUdn6-Nlb8FNqWyKN8F8fzpRBUlqu_9db4",
+         "name": "My New File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "16acBEBs1uoMQThO3JK_oq6y7vYRdK84k"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1M-hDuC9pMjUdn6-Nlb8FNqWyKN8F8fzpRBUlqu_9db4&v=1&s=AMedNnoAAAAAW8up6XKMnjxrq2uPbXwv5TJWkvb5Mii0&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:19:21 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1M-hDuC9pMjUdn6-Nlb8FNqWyKN8F8fzpRBUlqu_9db4/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:19:21 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:19:21 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:19:21 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-20T20:14:17.592Z"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:19:21 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1M-hDuC9pMjUdn6-Nlb8FNqWyKN8F8fzpRBUlqu_9db4&s=AMedNnoAAAAAW8up6XKMnjxrq2uPbXwv5TJWkvb5Mii0&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:19:21 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 20 Oct 2018 20:19:21 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:19:21 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1ohe0qm2Lsjwqbws86-63fkYq_wVLEAYZ7eEBEQfbWYs?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:19:21 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:19:22 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:19:22 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1ohe0qm2Lsjwqbws86-63fkYq_wVLEAYZ7eEBEQfbWYs",
+         "name": "File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1DzJyp-iL8iD6qBUuBiwJPtfEoIaRapAX"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1ohe0qm2Lsjwqbws86-63fkYq_wVLEAYZ7eEBEQfbWYs&v=1&s=AMedNnoAAAAAW8up6okbNW-TjAtMz-EOdJVOCryEOH4R&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:19:22 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1ohe0qm2Lsjwqbws86-63fkYq_wVLEAYZ7eEBEQfbWYs/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:19:22 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:19:22 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:19:22 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-20T20:14:43.528Z"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:19:22 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1ohe0qm2Lsjwqbws86-63fkYq_wVLEAYZ7eEBEQfbWYs&s=AMedNnoAAAAAW8up6okbNW-TjAtMz-EOdJVOCryEOH4R&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:19:22 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 20 Oct 2018 20:19:22 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:19:22 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1qW7JHE81hPv4mIKKp1g3biBlwHLjGaKsr5mCHmSajac?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:19:22 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:19:22 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:19:22 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1qW7JHE81hPv4mIKKp1g3biBlwHLjGaKsr5mCHmSajac",
+         "name": "File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1DzJyp-iL8iD6qBUuBiwJPtfEoIaRapAX"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1qW7JHE81hPv4mIKKp1g3biBlwHLjGaKsr5mCHmSajac&v=1&s=AMedNnoAAAAAW8up6l4GresevR7ObGw9W3cp-PSQlvNX&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:19:22 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1qW7JHE81hPv4mIKKp1g3biBlwHLjGaKsr5mCHmSajac/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:19:22 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:19:23 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:19:23 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-20T20:14:45.358Z"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:19:23 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1qW7JHE81hPv4mIKKp1g3biBlwHLjGaKsr5mCHmSajac&s=AMedNnoAAAAAW8up6l4GresevR7ObGw9W3cp-PSQlvNX&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:19:23 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 20 Oct 2018 20:19:23 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:19:23 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1g5CjBRP3QQh-Mbv4--KDKUgGIqiqmDIxQu3KWyEJVO4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:19:23 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:19:23 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:19:23 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1g5CjBRP3QQh-Mbv4--KDKUgGIqiqmDIxQu3KWyEJVO4",
+         "name": "File To Trash",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1LMz6-q1jj0qRVrLV3P6H6yh6xybTlZW_"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1g5CjBRP3QQh-Mbv4--KDKUgGIqiqmDIxQu3KWyEJVO4&v=1&s=AMedNnoAAAAAW8up601NbzlTltGgQN8X18IhdsdhI99R&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:19:23 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1g5CjBRP3QQh-Mbv4--KDKUgGIqiqmDIxQu3KWyEJVO4/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:19:23 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:19:23 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:19:23 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-20T20:15:56.963Z"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:19:23 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1g5CjBRP3QQh-Mbv4--KDKUgGIqiqmDIxQu3KWyEJVO4&s=AMedNnoAAAAAW8up601NbzlTltGgQN8X18IhdsdhI99R&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:19:23 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 20 Oct 2018 20:19:23 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:19:23 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1os-OXm_oRCQk7qpSQz7rKthIausLRiDHCSmqceEPvE8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:19:23 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:19:24 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:19:24 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1os-OXm_oRCQk7qpSQz7rKthIausLRiDHCSmqceEPvE8",
+         "name": "File To Trash",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1LMz6-q1jj0qRVrLV3P6H6yh6xybTlZW_"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1os-OXm_oRCQk7qpSQz7rKthIausLRiDHCSmqceEPvE8&v=1&s=AMedNnoAAAAAW8up7ESyUUb5A9H5-0LyeoL1LccANz1R&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:19:24 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1os-OXm_oRCQk7qpSQz7rKthIausLRiDHCSmqceEPvE8/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:19:24 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:19:24 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:19:24 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-20T20:15:55.323Z"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:19:24 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1os-OXm_oRCQk7qpSQz7rKthIausLRiDHCSmqceEPvE8&s=AMedNnoAAAAAW8up7ESyUUb5A9H5-0LyeoL1LccANz1R&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:19:24 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 20 Oct 2018 20:19:24 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:19:24 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1lBsi0y-XJLvjbMgV4LE13ORDCkESBEsP?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:19:24 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:19:24 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:19:24 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1lBsi0y-XJLvjbMgV4LE13ORDCkESBEsP",
+         "name": "Test @ 2018-10-20 20:18:10 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -1495,10 +3134,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:03:48 GMT
+  recorded_at: Sat, 20 Oct 2018 20:19:24 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1y24Zby6eJgLDccg8O157BTLytcQb_gMh/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1lBsi0y-XJLvjbMgV4LE13ORDCkESBEsP/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1510,7 +3149,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:03:48 GMT
+      - Sat, 20 Oct 2018 20:19:24 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1528,9 +3167,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:03:48 GMT
+      - Sat, 20 Oct 2018 20:19:24 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:03:48 GMT
+      - Sat, 20 Oct 2018 20:19:24 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1562,10 +3201,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:03:49 GMT
+  recorded_at: Sat, 20 Oct 2018 20:19:24 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1HvKTI0z21L1TcamDiKlGP627xZ64uRRj22kzEteSS7E?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1577,7 +3216,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:03:49 GMT
+      - Sat, 20 Oct 2018 20:19:24 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1595,9 +3234,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:03:49 GMT
+      - Sat, 20 Oct 2018 20:19:24 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:03:49 GMT
+      - Sat, 20 Oct 2018 20:19:24 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1621,20 +3260,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo.",
+            "message": "File not found: 1HvKTI0z21L1TcamDiKlGP627xZ64uRRj22kzEteSS7E.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo."
+          "message": "File not found: 1HvKTI0z21L1TcamDiKlGP627xZ64uRRj22kzEteSS7E."
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:03:49 GMT
+  recorded_at: Sat, 20 Oct 2018 20:19:24 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1eigphDrFSiiTbIBA7RssWWhiJcFfm6oT
+    uri: https://www.googleapis.com/drive/v3/files/1QHpmHhkXB9SDvYvSSMCYhhYp5ifAgt_S
     body:
       encoding: UTF-8
       string: ''
@@ -1646,7 +3285,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:03:49 GMT
+      - Sat, 20 Oct 2018 20:19:24 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1663,7 +3302,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:03:50 GMT
+      - Sat, 20 Oct 2018 20:19:25 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1675,10 +3314,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:03:50 GMT
+  recorded_at: Sat, 20 Oct 2018 20:19:25 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1y24Zby6eJgLDccg8O157BTLytcQb_gMh
+    uri: https://www.googleapis.com/drive/v3/files/1lBsi0y-XJLvjbMgV4LE13ORDCkESBEsP
     body:
       encoding: UTF-8
       string: ''
@@ -1690,7 +3329,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:03:50 GMT
+      - Sat, 20 Oct 2018 20:19:25 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1707,7 +3346,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:03:50 GMT
+      - Sat, 20 Oct 2018 20:19:25 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1719,5 +3358,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:03:50 GMT
+  recorded_at: Sat, 20 Oct 2018 20:19:25 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_moves_file_out_of_project_folder.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_moves_file_out_of_project_folder.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:34:08 GMT
+      - Thu, 18 Oct 2018 11:02:40 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:34:08 GMT
+  recorded_at: Thu, 18 Oct 2018 11:02:40 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:34:09 GMT
+      - Thu, 18 Oct 2018 11:02:40 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:34:09 GMT
+  recorded_at: Thu, 18 Oct 2018 11:02:40 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        09:34:09 UTC","parents":["root"]}'
+        11:02:40 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:34:09 GMT
+      - Thu, 18 Oct 2018 11:02:40 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:34:09 GMT
+      - Thu, 18 Oct 2018 11:02:41 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz",
-         "name": "Test @ 2018-10-18 09:34:09 UTC",
+         "id": "1y24Zby6eJgLDccg8O157BTLytcQb_gMh",
+         "name": "Test @ 2018-10-18 11:02:40 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:34:09 GMT
+  recorded_at: Thu, 18 Oct 2018 11:02:41 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1y24Zby6eJgLDccg8O157BTLytcQb_gMh/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:34:09 GMT
+      - Thu, 18 Oct 2018 11:02:41 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:34:10 GMT
+      - Thu, 18 Oct 2018 11:02:41 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:34:10 GMT
+  recorded_at: Thu, 18 Oct 2018 11:02:41 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:34:10 GMT
+      - Thu, 18 Oct 2018 11:02:41 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:34:10 GMT
+      - Thu, 18 Oct 2018 11:02:41 GMT
       Date:
-      - Thu, 18 Oct 2018 09:34:10 GMT
+      - Thu, 18 Oct 2018 11:02:41 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,17 +302,17 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "9346"
+         "startPageToken": "9496"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:34:10 GMT
+  recorded_at: Thu, 18 Oct 2018 11:02:41 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.document","name":"File To
-        Move","parents":["1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz"]}'
+        Move","parents":["1y24Zby6eJgLDccg8O157BTLytcQb_gMh"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -321,7 +321,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:34:10 GMT
+      - Thu, 18 Oct 2018 11:02:43 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -338,7 +338,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:34:11 GMT
+      - Thu, 18 Oct 2018 11:02:43 GMT
       Vary:
       - Origin
       - X-Origin
@@ -362,12 +362,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "193gJcpGvFfo0qBL-BRF09lGKYZ7-Arfj_cdxusnWsLQ",
+         "id": "1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz"
+          "1y24Zby6eJgLDccg8O157BTLytcQb_gMh"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -392,10 +392,150 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:34:12 GMT
+  recorded_at: Thu, 18 Oct 2018 11:02:44 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"1 Krikkit
+        One (Archive)","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:02:44 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:02:44 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1FAh708487sg4uLM_xjpyTb7XGll5gldV",
+         "name": "1 Krikkit One (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:02:44 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1FAh708487sg4uLM_xjpyTb7XGll5gldV/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:02:44 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:02:45 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "13193959451567607887",
+         "type": "user",
+         "role": "reader"
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:02:45 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1FAh708487sg4uLM_xjpyTb7XGll5gldV?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -407,7 +547,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:34:12 GMT
+      - Thu, 18 Oct 2018 11:02:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -418,9 +558,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:34:12 GMT
+      - Thu, 18 Oct 2018 11:02:45 GMT
       Date:
-      - Thu, 18 Oct 2018 09:34:12 GMT
+      - Thu, 18 Oct 2018 11:02:45 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -446,37 +586,40 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz",
-         "name": "Test @ 2018-10-18 09:34:09 UTC",
+         "id": "1FAh708487sg4uLM_xjpyTb7XGll5gldV",
+         "name": "1 Krikkit One (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
          "thumbnailVersion": "0",
          "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
           {
            "kind": "drive#permission",
            "id": "13193959451567607887",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
+           "role": "reader",
            "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
            "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:34:12 GMT
+  recorded_at: Thu, 18 Oct 2018 11:02:45 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1FAh708487sg4uLM_xjpyTb7XGll5gldV/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -488,7 +631,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:34:12 GMT
+      - Thu, 18 Oct 2018 11:02:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -506,9 +649,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:34:12 GMT
+      - Thu, 18 Oct 2018 11:02:45 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:34:12 GMT
+      - Thu, 18 Oct 2018 11:02:45 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -540,10 +683,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:34:12 GMT
+  recorded_at: Thu, 18 Oct 2018 11:02:45 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files/1y24Zby6eJgLDccg8O157BTLytcQb_gMh?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -555,7 +698,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:34:12 GMT
+      - Thu, 18 Oct 2018 11:02:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -566,9 +709,157 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:34:12 GMT
+      - Thu, 18 Oct 2018 11:02:45 GMT
       Date:
-      - Thu, 18 Oct 2018 09:34:12 GMT
+      - Thu, 18 Oct 2018 11:02:45 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1y24Zby6eJgLDccg8O157BTLytcQb_gMh",
+         "name": "Test @ 2018-10-18 11:02:40 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:02:45 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1y24Zby6eJgLDccg8O157BTLytcQb_gMh/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:02:45 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:02:46 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:02:46 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:02:46 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271y24Zby6eJgLDccg8O157BTLytcQb_gMh%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:02:46 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:02:46 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:02:46 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -596,14 +887,15 @@ http_interactions:
         {
          "files": [
           {
-           "id": "193gJcpGvFfo0qBL-BRF09lGKYZ7-Arfj_cdxusnWsLQ",
+           "id": "1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo",
            "name": "File To Move",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz"
+            "1y24Zby6eJgLDccg8O157BTLytcQb_gMh"
            ],
-           "thumbnailVersion": "0",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo&v=1&s=AMedNnoAAAAAW8iEdlE-m75GxPlqVqdnywKotcwzxYVf&sz=s220",
+           "thumbnailVersion": "1",
            "permissions": [
             {
              "kind": "drive#permission",
@@ -628,10 +920,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:34:12 GMT
+  recorded_at: Thu, 18 Oct 2018 11:02:46 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/193gJcpGvFfo0qBL-BRF09lGKYZ7-Arfj_cdxusnWsLQ/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -643,7 +935,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:34:12 GMT
+      - Thu, 18 Oct 2018 11:02:46 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -654,9 +946,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:34:12 GMT
+      - Thu, 18 Oct 2018 11:02:46 GMT
       Date:
-      - Thu, 18 Oct 2018 09:34:12 GMT
+      - Thu, 18 Oct 2018 11:02:46 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -685,10 +977,70 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T09:34:10.957Z"
+         "modifiedTime": "2018-10-18T11:02:43.261Z"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:34:12 GMT
+  recorded_at: Thu, 18 Oct 2018 11:02:46 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo&s=AMedNnoAAAAAW8iEdlE-m75GxPlqVqdnywKotcwzxYVf&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:02:46 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Thu, 18 Oct 2018 11:02:46 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:02:46 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
@@ -703,7 +1055,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:34:12 GMT
+      - Thu, 18 Oct 2018 11:02:47 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -720,7 +1072,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:34:13 GMT
+      - Thu, 18 Oct 2018 11:02:47 GMT
       Vary:
       - Origin
       - X-Origin
@@ -744,7 +1096,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1YKwXEUQ7Rae6Cx2Jc8H0iJfxp6V0_Gjy",
+         "id": "1eigphDrFSiiTbIBA7RssWWhiJcFfm6oT",
          "name": "out-of-scope-folder",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
@@ -765,10 +1117,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:34:13 GMT
+  recorded_at: Thu, 18 Oct 2018 11:02:47 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/193gJcpGvFfo0qBL-BRF09lGKYZ7-Arfj_cdxusnWsLQ?addParents=1YKwXEUQ7Rae6Cx2Jc8H0iJfxp6V0_Gjy&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz
+    uri: https://www.googleapis.com/drive/v3/files/1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo?addParents=1eigphDrFSiiTbIBA7RssWWhiJcFfm6oT&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1y24Zby6eJgLDccg8O157BTLytcQb_gMh
     body:
       encoding: UTF-8
       string: ''
@@ -780,7 +1132,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:34:13 GMT
+      - Thu, 18 Oct 2018 11:02:47 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -797,7 +1149,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:34:14 GMT
+      - Thu, 18 Oct 2018 11:02:48 GMT
       Vary:
       - Origin
       - X-Origin
@@ -821,12 +1173,156 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "193gJcpGvFfo0qBL-BRF09lGKYZ7-Arfj_cdxusnWsLQ",
+         "id": "1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1YKwXEUQ7Rae6Cx2Jc8H0iJfxp6V0_Gjy"
+          "1eigphDrFSiiTbIBA7RssWWhiJcFfm6oT"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo&v=1&s=AMedNnoAAAAAW8iEeMBS94hamLeRX0Z98y_BIWzdaOgJ&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:02:48 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9496
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:03:48 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:03:48 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:03:48 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "newStartPageToken": "9501",
+         "changes": [
+          {
+           "fileId": "1FAh708487sg4uLM_xjpyTb7XGll5gldV"
+          },
+          {
+           "fileId": "1y24Zby6eJgLDccg8O157BTLytcQb_gMh"
+          },
+          {
+           "fileId": "1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo"
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:03:48 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1FAh708487sg4uLM_xjpyTb7XGll5gldV?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:03:48 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:03:48 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:03:48 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1FAh708487sg4uLM_xjpyTb7XGll5gldV",
+         "name": "1 Krikkit One (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -835,163 +1331,26 @@ http_interactions:
            "id": "13193959451567607887",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
+           "role": "reader",
            "displayName": "Testuser Upshift One",
            "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:34:14 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9346
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 09:35:14 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Thu, 18 Oct 2018 09:35:14 GMT
-      Date:
-      - Thu, 18 Oct 2018 09:35:14 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "newStartPageToken": "9350",
-         "changes": [
-          {
-           "fileId": "1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz"
           },
-          {
-           "fileId": "193gJcpGvFfo0qBL-BRF09lGKYZ7-Arfj_cdxusnWsLQ"
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:35:14 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 09:35:14 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Thu, 18 Oct 2018 09:35:14 GMT
-      Date:
-      - Thu, 18 Oct 2018 09:35:14 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz",
-         "name": "Test @ 2018-10-18 09:34:09 UTC",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "thumbnailVersion": "0",
-         "permissions": [
           {
            "kind": "drive#permission",
            "id": "11673017242486491425",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
            "role": "owner",
-           "displayName": "Testuser Upshift One",
+           "displayName": "Upshift One",
            "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:35:14 GMT
+  recorded_at: Thu, 18 Oct 2018 11:03:48 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1FAh708487sg4uLM_xjpyTb7XGll5gldV/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1003,7 +1362,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:35:14 GMT
+      - Thu, 18 Oct 2018 11:03:48 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1021,9 +1380,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:35:14 GMT
+      - Thu, 18 Oct 2018 11:03:48 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:35:14 GMT
+      - Thu, 18 Oct 2018 11:03:48 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1055,10 +1414,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:35:14 GMT
+  recorded_at: Thu, 18 Oct 2018 11:03:48 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/193gJcpGvFfo0qBL-BRF09lGKYZ7-Arfj_cdxusnWsLQ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1y24Zby6eJgLDccg8O157BTLytcQb_gMh?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1070,7 +1429,155 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:35:14 GMT
+      - Thu, 18 Oct 2018 11:03:48 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:03:48 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:03:48 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1y24Zby6eJgLDccg8O157BTLytcQb_gMh",
+         "name": "Test @ 2018-10-18 11:02:40 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:03:48 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1y24Zby6eJgLDccg8O157BTLytcQb_gMh/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:03:48 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:03:48 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:03:48 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:03:49 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:03:49 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1088,9 +1595,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:35:14 GMT
+      - Thu, 18 Oct 2018 11:03:49 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:35:14 GMT
+      - Thu, 18 Oct 2018 11:03:49 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1114,20 +1621,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 193gJcpGvFfo0qBL-BRF09lGKYZ7-Arfj_cdxusnWsLQ.",
+            "message": "File not found: 1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 193gJcpGvFfo0qBL-BRF09lGKYZ7-Arfj_cdxusnWsLQ."
+          "message": "File not found: 1W6WnMAKIFINwq1x43iXW1Nf7oPId7bCjMbxHSY6eWAo."
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:35:14 GMT
+  recorded_at: Thu, 18 Oct 2018 11:03:49 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1YKwXEUQ7Rae6Cx2Jc8H0iJfxp6V0_Gjy
+    uri: https://www.googleapis.com/drive/v3/files/1eigphDrFSiiTbIBA7RssWWhiJcFfm6oT
     body:
       encoding: UTF-8
       string: ''
@@ -1139,7 +1646,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:35:15 GMT
+      - Thu, 18 Oct 2018 11:03:49 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1156,7 +1663,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:35:15 GMT
+      - Thu, 18 Oct 2018 11:03:50 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1168,10 +1675,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:35:15 GMT
+  recorded_at: Thu, 18 Oct 2018 11:03:50 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz
+    uri: https://www.googleapis.com/drive/v3/files/1y24Zby6eJgLDccg8O157BTLytcQb_gMh
     body:
       encoding: UTF-8
       string: ''
@@ -1183,7 +1690,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:35:15 GMT
+      - Thu, 18 Oct 2018 11:03:50 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1200,7 +1707,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:35:15 GMT
+      - Thu, 18 Oct 2018 11:03:50 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1212,5 +1719,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:35:16 GMT
+  recorded_at: Thu, 18 Oct 2018 11:03:50 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_moves_file_out_of_project_folder.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_moves_file_out_of_project_folder.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,42 +21,39 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:35:06 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:34:08 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:35:06 GMT
+  recorded_at: Thu, 18 Oct 2018 09:34:08 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -66,7 +63,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -78,49 +75,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:35:06 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:34:09 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:35:06 GMT
+  recorded_at: Thu, 18 Oct 2018 09:34:09 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        21:35:06 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:34:09 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -129,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:35:06 GMT
+      - Thu, 18 Oct 2018 09:34:09 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -146,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:35:07 GMT
+      - Thu, 18 Oct 2018 09:34:09 GMT
       Vary:
       - Origin
       - X-Origin
@@ -163,28 +157,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1va2AYQgUaTsOAa8qDqCCLrMZmibtFQd0",
-         "name": "Test @ 2018-03-18 21:35:06 UTC",
+         "id": "1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz",
+         "name": "Test @ 2018-10-18 09:34:09 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AEIi2L68pCuiUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:35:07 GMT
+  recorded_at: Thu, 18 Oct 2018 09:34:09 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1va2AYQgUaTsOAa8qDqCCLrMZmibtFQd0/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -196,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:35:07 GMT
+      - Thu, 18 Oct 2018 09:34:09 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -213,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:35:08 GMT
+      - Thu, 18 Oct 2018 09:34:10 GMT
       Vary:
       - Origin
       - X-Origin
@@ -230,8 +234,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -244,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:35:08 GMT
+  recorded_at: Thu, 18 Oct 2018 09:34:10 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -259,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:35:08 GMT
+      - Thu, 18 Oct 2018 09:34:10 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -270,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:35:08 GMT
+      - Thu, 18 Oct 2018 09:34:10 GMT
       Date:
-      - Sun, 18 Mar 2018 21:35:08 GMT
+      - Thu, 18 Oct 2018 09:34:10 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -291,8 +294,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -300,17 +302,17 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "7185"
+         "startPageToken": "9346"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:35:08 GMT
+  recorded_at: Thu, 18 Oct 2018 09:34:10 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.document","name":"File To
-        Move","parents":["1va2AYQgUaTsOAa8qDqCCLrMZmibtFQd0"]}'
+        Move","parents":["1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -319,7 +321,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:35:08 GMT
+      - Thu, 18 Oct 2018 09:34:10 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -336,7 +338,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:35:09 GMT
+      - Thu, 18 Oct 2018 09:34:11 GMT
       Vary:
       - Origin
       - X-Origin
@@ -353,28 +355,47 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "13yxgeTVJvnNbER4bzUo-LEHMAKbAgw7sHqvOgPIzd3M",
+         "id": "193gJcpGvFfo0qBL-BRF09lGKYZ7-Arfj_cdxusnWsLQ",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1va2AYQgUaTsOAa8qDqCCLrMZmibtFQd0"
+          "1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:35:09 GMT
+  recorded_at: Thu, 18 Oct 2018 09:34:12 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1va2AYQgUaTsOAa8qDqCCLrMZmibtFQd0?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -386,7 +407,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:35:09 GMT
+      - Thu, 18 Oct 2018 09:34:12 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -397,9 +418,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:35:09 GMT
+      - Thu, 18 Oct 2018 09:34:12 GMT
       Date:
-      - Sun, 18 Mar 2018 21:35:09 GMT
+      - Thu, 18 Oct 2018 09:34:12 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -418,25 +439,44 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1va2AYQgUaTsOAa8qDqCCLrMZmibtFQd0",
-         "name": "Test @ 2018-03-18 21:35:06 UTC",
+         "id": "1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz",
+         "name": "Test @ 2018-10-18 09:34:09 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:35:09 GMT
+  recorded_at: Thu, 18 Oct 2018 09:34:12 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1va2AYQgUaTsOAa8qDqCCLrMZmibtFQd0/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -448,7 +488,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:35:09 GMT
+      - Thu, 18 Oct 2018 09:34:12 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -466,9 +506,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:35:09 GMT
+      - Thu, 18 Oct 2018 09:34:12 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:35:09 GMT
+      - Thu, 18 Oct 2018 09:34:12 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -480,8 +520,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -501,10 +540,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:35:09 GMT
+  recorded_at: Thu, 18 Oct 2018 09:34:12 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271va2AYQgUaTsOAa8qDqCCLrMZmibtFQd0%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -516,7 +555,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:35:09 GMT
+      - Thu, 18 Oct 2018 09:34:12 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -527,9 +566,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:35:10 GMT
+      - Thu, 18 Oct 2018 09:34:12 GMT
       Date:
-      - Sun, 18 Mar 2018 21:35:10 GMT
+      - Thu, 18 Oct 2018 09:34:12 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -548,8 +587,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -558,22 +596,42 @@ http_interactions:
         {
          "files": [
           {
-           "id": "13yxgeTVJvnNbER4bzUo-LEHMAKbAgw7sHqvOgPIzd3M",
+           "id": "193gJcpGvFfo0qBL-BRF09lGKYZ7-Arfj_cdxusnWsLQ",
            "name": "File To Move",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1va2AYQgUaTsOAa8qDqCCLrMZmibtFQd0"
+            "1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz"
            ],
-           "thumbnailVersion": "0"
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "writer",
+             "displayName": "Upshift One",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "13193959451567607887",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+             "role": "owner",
+             "displayName": "Testuser Upshift One",
+             "deleted": false
+            }
+           ]
           }
          ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:35:10 GMT
+  recorded_at: Thu, 18 Oct 2018 09:34:12 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/13yxgeTVJvnNbER4bzUo-LEHMAKbAgw7sHqvOgPIzd3M/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/193gJcpGvFfo0qBL-BRF09lGKYZ7-Arfj_cdxusnWsLQ/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -585,7 +643,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:35:10 GMT
+      - Thu, 18 Oct 2018 09:34:12 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -596,9 +654,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:35:13 GMT
+      - Thu, 18 Oct 2018 09:34:12 GMT
       Date:
-      - Sun, 18 Mar 2018 21:35:13 GMT
+      - Thu, 18 Oct 2018 09:34:12 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -617,8 +675,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -628,13 +685,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-03-18T21:35:08.629Z"
+         "modifiedTime": "2018-10-18T09:34:10.957Z"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:35:13 GMT
+  recorded_at: Thu, 18 Oct 2018 09:34:12 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.folder","name":"out-of-scope-folder","parents":["root"]}'
@@ -646,7 +703,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:35:13 GMT
+      - Thu, 18 Oct 2018 09:34:12 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -663,7 +720,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:35:13 GMT
+      - Thu, 18 Oct 2018 09:34:13 GMT
       Vary:
       - Origin
       - X-Origin
@@ -680,28 +737,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "15OYxl2aVDaBnblr2I1Z4csgjzFK4rlb4",
+         "id": "1YKwXEUQ7Rae6Cx2Jc8H0iJfxp6V0_Gjy",
          "name": "out-of-scope-folder",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AEIi2L68pCuiUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:35:13 GMT
+  recorded_at: Thu, 18 Oct 2018 09:34:13 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/13yxgeTVJvnNbER4bzUo-LEHMAKbAgw7sHqvOgPIzd3M?addParents=15OYxl2aVDaBnblr2I1Z4csgjzFK4rlb4&fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion&removeParents=1va2AYQgUaTsOAa8qDqCCLrMZmibtFQd0
+    uri: https://www.googleapis.com/drive/v3/files/193gJcpGvFfo0qBL-BRF09lGKYZ7-Arfj_cdxusnWsLQ?addParents=1YKwXEUQ7Rae6Cx2Jc8H0iJfxp6V0_Gjy&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz
     body:
       encoding: UTF-8
       string: ''
@@ -713,7 +780,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:35:13 GMT
+      - Thu, 18 Oct 2018 09:34:13 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -730,7 +797,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:35:14 GMT
+      - Thu, 18 Oct 2018 09:34:14 GMT
       Vary:
       - Origin
       - X-Origin
@@ -747,95 +814,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "13yxgeTVJvnNbER4bzUo-LEHMAKbAgw7sHqvOgPIzd3M",
+         "id": "193gJcpGvFfo0qBL-BRF09lGKYZ7-Arfj_cdxusnWsLQ",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "15OYxl2aVDaBnblr2I1Z4csgjzFK4rlb4"
+          "1YKwXEUQ7Rae6Cx2Jc8H0iJfxp6V0_Gjy"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=13yxgeTVJvnNbER4bzUo-LEHMAKbAgw7sHqvOgPIzd3M&v=1&s=AMedNnoAAAAAWq73ssLQpIbItoqHQVkopnVNhnXo5E4u&sz=s220",
-         "thumbnailVersion": "1"
-        }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:35:14 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=7185
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sun, 18 Mar 2018 21:36:14 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sun, 18 Mar 2018 21:36:14 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:36:14 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "newStartPageToken": "7189",
-         "changes": [
+         "thumbnailVersion": "0",
+         "permissions": [
           {
-           "fileId": "1va2AYQgUaTsOAa8qDqCCLrMZmibtFQd0"
-          },
-          {
-           "fileId": "13yxgeTVJvnNbER4bzUo-LEHMAKbAgw7sHqvOgPIzd3M"
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:36:14 GMT
+  recorded_at: Thu, 18 Oct 2018 09:34:14 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1va2AYQgUaTsOAa8qDqCCLrMZmibtFQd0?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9346
     body:
       encoding: UTF-8
       string: ''
@@ -847,7 +857,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:36:14 GMT
+      - Thu, 18 Oct 2018 09:35:14 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -858,9 +868,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:36:15 GMT
+      - Thu, 18 Oct 2018 09:35:14 GMT
       Date:
-      - Sun, 18 Mar 2018 21:36:15 GMT
+      - Thu, 18 Oct 2018 09:35:14 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -879,25 +889,28 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1va2AYQgUaTsOAa8qDqCCLrMZmibtFQd0",
-         "name": "Test @ 2018-03-18 21:35:06 UTC",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "thumbnailVersion": "0"
+         "newStartPageToken": "9350",
+         "changes": [
+          {
+           "fileId": "1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz"
+          },
+          {
+           "fileId": "193gJcpGvFfo0qBL-BRF09lGKYZ7-Arfj_cdxusnWsLQ"
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:36:15 GMT
+  recorded_at: Thu, 18 Oct 2018 09:35:14 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1va2AYQgUaTsOAa8qDqCCLrMZmibtFQd0/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -909,7 +922,88 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:36:15 GMT
+      - Thu, 18 Oct 2018 09:35:14 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 09:35:14 GMT
+      Date:
+      - Thu, 18 Oct 2018 09:35:14 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz",
+         "name": "Test @ 2018-10-18 09:34:09 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 09:35:14 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 09:35:14 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -927,9 +1021,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:36:15 GMT
+      - Thu, 18 Oct 2018 09:35:14 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:36:15 GMT
+      - Thu, 18 Oct 2018 09:35:14 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -941,8 +1035,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -962,10 +1055,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:36:15 GMT
+  recorded_at: Thu, 18 Oct 2018 09:35:14 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/13yxgeTVJvnNbER4bzUo-LEHMAKbAgw7sHqvOgPIzd3M?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/193gJcpGvFfo0qBL-BRF09lGKYZ7-Arfj_cdxusnWsLQ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -977,7 +1070,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:36:15 GMT
+      - Thu, 18 Oct 2018 09:35:14 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -995,9 +1088,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:36:15 GMT
+      - Thu, 18 Oct 2018 09:35:14 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:36:15 GMT
+      - Thu, 18 Oct 2018 09:35:14 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1009,8 +1102,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -1022,20 +1114,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 13yxgeTVJvnNbER4bzUo-LEHMAKbAgw7sHqvOgPIzd3M.",
+            "message": "File not found: 193gJcpGvFfo0qBL-BRF09lGKYZ7-Arfj_cdxusnWsLQ.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 13yxgeTVJvnNbER4bzUo-LEHMAKbAgw7sHqvOgPIzd3M."
+          "message": "File not found: 193gJcpGvFfo0qBL-BRF09lGKYZ7-Arfj_cdxusnWsLQ."
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:36:15 GMT
+  recorded_at: Thu, 18 Oct 2018 09:35:14 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/15OYxl2aVDaBnblr2I1Z4csgjzFK4rlb4
+    uri: https://www.googleapis.com/drive/v3/files/1YKwXEUQ7Rae6Cx2Jc8H0iJfxp6V0_Gjy
     body:
       encoding: UTF-8
       string: ''
@@ -1047,7 +1139,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:36:15 GMT
+      - Thu, 18 Oct 2018 09:35:15 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1064,23 +1156,22 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:36:16 GMT
+      - Thu, 18 Oct 2018 09:35:15 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:36:16 GMT
+  recorded_at: Thu, 18 Oct 2018 09:35:15 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1va2AYQgUaTsOAa8qDqCCLrMZmibtFQd0
+    uri: https://www.googleapis.com/drive/v3/files/1xfsRgX_bPt0Qq7kYZwWOBzINqbAfceNz
     body:
       encoding: UTF-8
       string: ''
@@ -1092,7 +1183,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:36:16 GMT
+      - Thu, 18 Oct 2018 09:35:15 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1109,18 +1200,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:36:16 GMT
+      - Thu, 18 Oct 2018 09:35:15 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:36:16 GMT
+  recorded_at: Thu, 18 Oct 2018 09:35:16 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_moves_file_to_the_root_of_their_drive.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_moves_file_to_the_root_of_their_drive.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 11:07:14 GMT
+      - Sat, 20 Oct 2018 20:20:39 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:07:14 GMT
+  recorded_at: Sat, 20 Oct 2018 20:20:39 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 11:07:14 GMT
+      - Sat, 20 Oct 2018 20:20:39 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:07:14 GMT
+  recorded_at: Sat, 20 Oct 2018 20:20:39 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        11:07:14 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-20
+        20:20:39 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:07:14 GMT
+      - Sat, 20 Oct 2018 20:20:39 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:07:15 GMT
+      - Sat, 20 Oct 2018 20:20:40 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C",
-         "name": "Test @ 2018-10-18 11:07:14 UTC",
+         "id": "11SCjfOYS6Zb2NvXNguOhip8bMdAlssJi",
+         "name": "Test @ 2018-10-20 20:20:39 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:07:15 GMT
+  recorded_at: Sat, 20 Oct 2018 20:20:40 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/11SCjfOYS6Zb2NvXNguOhip8bMdAlssJi/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:07:15 GMT
+      - Sat, 20 Oct 2018 20:20:40 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:07:16 GMT
+      - Sat, 20 Oct 2018 20:20:41 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:07:16 GMT
+  recorded_at: Sat, 20 Oct 2018 20:20:41 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:07:16 GMT
+      - Sat, 20 Oct 2018 20:20:41 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:07:16 GMT
+      - Sat, 20 Oct 2018 20:20:41 GMT
       Date:
-      - Thu, 18 Oct 2018 11:07:16 GMT
+      - Sat, 20 Oct 2018 20:20:41 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,17 +302,17 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "9525"
+         "startPageToken": "10607"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:07:16 GMT
+  recorded_at: Sat, 20 Oct 2018 20:20:41 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.document","name":"File To
-        Move","parents":["1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C"]}'
+        Move","parents":["11SCjfOYS6Zb2NvXNguOhip8bMdAlssJi"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -321,7 +321,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:07:16 GMT
+      - Sat, 20 Oct 2018 20:20:41 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -338,7 +338,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:07:17 GMT
+      - Sat, 20 Oct 2018 20:20:42 GMT
       Vary:
       - Origin
       - X-Origin
@@ -362,12 +362,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "137m2u44ecTO7b3ykURxwoiLwQal8PujGwQiXuoVujgU",
+         "id": "1ByuG_ipxow6Wv8x9mIqtH7CJOPVjQ9vPynVJUmQG4Ms",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C"
+          "11SCjfOYS6Zb2NvXNguOhip8bMdAlssJi"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -392,14 +392,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:07:17 GMT
+  recorded_at: Sat, 20 Oct 2018 20:20:42 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"5 Vogon Constructor
-        Fleet (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"6 Billion
+        Year Bunker (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -408,7 +408,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:07:17 GMT
+      - Sat, 20 Oct 2018 20:20:42 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -425,7 +425,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:07:17 GMT
+      - Sat, 20 Oct 2018 20:20:43 GMT
       Vary:
       - Origin
       - X-Origin
@@ -449,8 +449,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1mY_MimUtrpul6XPbIXCcvRr-T-84_VdB",
-         "name": "5 Vogon Constructor Fleet (Archive)",
+         "id": "1ygghMs6VGl6AAoJX4YUtl3cHnbCGN0pG",
+         "name": "6 Billion Year Bunker (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -470,10 +470,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:07:18 GMT
+  recorded_at: Sat, 20 Oct 2018 20:20:43 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1mY_MimUtrpul6XPbIXCcvRr-T-84_VdB/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1ygghMs6VGl6AAoJX4YUtl3cHnbCGN0pG/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -485,7 +485,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:07:18 GMT
+      - Sat, 20 Oct 2018 20:20:43 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -502,7 +502,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:07:18 GMT
+      - Sat, 20 Oct 2018 20:20:43 GMT
       Vary:
       - Origin
       - X-Origin
@@ -532,10 +532,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:07:18 GMT
+  recorded_at: Sat, 20 Oct 2018 20:20:44 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1mY_MimUtrpul6XPbIXCcvRr-T-84_VdB?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ygghMs6VGl6AAoJX4YUtl3cHnbCGN0pG?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -547,7 +547,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:07:18 GMT
+      - Sat, 20 Oct 2018 20:20:44 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -558,9 +558,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:07:19 GMT
+      - Sat, 20 Oct 2018 20:20:44 GMT
       Date:
-      - Thu, 18 Oct 2018 11:07:19 GMT
+      - Sat, 20 Oct 2018 20:20:44 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -586,8 +586,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1mY_MimUtrpul6XPbIXCcvRr-T-84_VdB",
-         "name": "5 Vogon Constructor Fleet (Archive)",
+         "id": "1ygghMs6VGl6AAoJX4YUtl3cHnbCGN0pG",
+         "name": "6 Billion Year Bunker (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -616,10 +616,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:07:19 GMT
+  recorded_at: Sat, 20 Oct 2018 20:20:44 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1mY_MimUtrpul6XPbIXCcvRr-T-84_VdB/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1ygghMs6VGl6AAoJX4YUtl3cHnbCGN0pG/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -631,7 +631,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:07:19 GMT
+      - Sat, 20 Oct 2018 20:20:44 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -649,9 +649,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:07:19 GMT
+      - Sat, 20 Oct 2018 20:20:44 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:07:19 GMT
+      - Sat, 20 Oct 2018 20:20:44 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -683,10 +683,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:07:19 GMT
+  recorded_at: Sat, 20 Oct 2018 20:20:44 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/11SCjfOYS6Zb2NvXNguOhip8bMdAlssJi?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -698,7 +698,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:07:19 GMT
+      - Sat, 20 Oct 2018 20:20:44 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -709,9 +709,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:07:19 GMT
+      - Sat, 20 Oct 2018 20:20:44 GMT
       Date:
-      - Thu, 18 Oct 2018 11:07:19 GMT
+      - Sat, 20 Oct 2018 20:20:44 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -737,8 +737,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C",
-         "name": "Test @ 2018-10-18 11:07:14 UTC",
+         "id": "11SCjfOYS6Zb2NvXNguOhip8bMdAlssJi",
+         "name": "Test @ 2018-10-20 20:20:39 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -764,10 +764,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:07:19 GMT
+  recorded_at: Sat, 20 Oct 2018 20:20:44 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/11SCjfOYS6Zb2NvXNguOhip8bMdAlssJi/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -779,7 +779,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:07:19 GMT
+      - Sat, 20 Oct 2018 20:20:44 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -797,9 +797,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:07:19 GMT
+      - Sat, 20 Oct 2018 20:20:44 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:07:19 GMT
+      - Sat, 20 Oct 2018 20:20:44 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -831,10 +831,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:07:19 GMT
+  recorded_at: Sat, 20 Oct 2018 20:20:44 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%2711SCjfOYS6Zb2NvXNguOhip8bMdAlssJi%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -846,7 +846,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:07:19 GMT
+      - Sat, 20 Oct 2018 20:20:44 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -857,9 +857,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:07:19 GMT
+      - Sat, 20 Oct 2018 20:20:44 GMT
       Date:
-      - Thu, 18 Oct 2018 11:07:19 GMT
+      - Sat, 20 Oct 2018 20:20:44 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -887,14 +887,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "137m2u44ecTO7b3ykURxwoiLwQal8PujGwQiXuoVujgU",
+           "id": "1ByuG_ipxow6Wv8x9mIqtH7CJOPVjQ9vPynVJUmQG4Ms",
            "name": "File To Move",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C"
+            "11SCjfOYS6Zb2NvXNguOhip8bMdAlssJi"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=137m2u44ecTO7b3ykURxwoiLwQal8PujGwQiXuoVujgU&v=1&s=AMedNnoAAAAAW8iFh9fZy-TmxZsYvGI-rKZKTS7p2FfW&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1ByuG_ipxow6Wv8x9mIqtH7CJOPVjQ9vPynVJUmQG4Ms&v=1&s=AMedNnoAAAAAW8uqPKhbfiRYqfi82PhkRwC9iybto0oV&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -920,10 +920,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:07:19 GMT
+  recorded_at: Sat, 20 Oct 2018 20:20:44 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/137m2u44ecTO7b3ykURxwoiLwQal8PujGwQiXuoVujgU/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1ByuG_ipxow6Wv8x9mIqtH7CJOPVjQ9vPynVJUmQG4Ms/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -935,7 +935,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:07:19 GMT
+      - Sat, 20 Oct 2018 20:20:44 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -946,9 +946,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:07:19 GMT
+      - Sat, 20 Oct 2018 20:20:45 GMT
       Date:
-      - Thu, 18 Oct 2018 11:07:19 GMT
+      - Sat, 20 Oct 2018 20:20:45 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -977,13 +977,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T11:07:16.479Z"
+         "modifiedTime": "2018-10-20T20:20:41.622Z"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:07:19 GMT
+  recorded_at: Sat, 20 Oct 2018 20:20:45 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=137m2u44ecTO7b3ykURxwoiLwQal8PujGwQiXuoVujgU&s=AMedNnoAAAAAW8iFh9fZy-TmxZsYvGI-rKZKTS7p2FfW&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1ByuG_ipxow6Wv8x9mIqtH7CJOPVjQ9vPynVJUmQG4Ms&s=AMedNnoAAAAAW8uqPKhbfiRYqfi82PhkRwC9iybto0oV&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -995,7 +995,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:07:19 GMT
+      - Sat, 20 Oct 2018 20:20:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1026,7 +1026,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 18 Oct 2018 11:07:20 GMT
+      - Sat, 20 Oct 2018 20:20:45 GMT
       Server:
       - fife
       Content-Length:
@@ -1040,10 +1040,182 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:07:20 GMT
+  recorded_at: Sat, 20 Oct 2018 20:20:45 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1ByuG_ipxow6Wv8x9mIqtH7CJOPVjQ9vPynVJUmQG4Ms/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"File To Move","parents":["1ygghMs6VGl6AAoJX4YUtl3cHnbCGN0pG"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:20:45 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:20:46 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1ZG6cVwWOZxTN5fVlDtgd4q8JIEel2GzxDV2Rgrmy4zY",
+         "name": "File To Move",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1ygghMs6VGl6AAoJX4YUtl3cHnbCGN0pG"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:20:47 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1ByuG_ipxow6Wv8x9mIqtH7CJOPVjQ9vPynVJUmQG4Ms/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"File To Move","parents":["1ygghMs6VGl6AAoJX4YUtl3cHnbCGN0pG"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:20:47 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:20:48 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1TERLUE4aNlPEAOeF2Ni0Jl-V0rmRlAHKsD2xeVoryL0",
+         "name": "File To Move",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1ygghMs6VGl6AAoJX4YUtl3cHnbCGN0pG"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:20:48 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/137m2u44ecTO7b3ykURxwoiLwQal8PujGwQiXuoVujgU?addParents=root&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C
+    uri: https://www.googleapis.com/drive/v3/files/1ByuG_ipxow6Wv8x9mIqtH7CJOPVjQ9vPynVJUmQG4Ms?addParents=root&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=11SCjfOYS6Zb2NvXNguOhip8bMdAlssJi
     body:
       encoding: UTF-8
       string: ''
@@ -1055,7 +1227,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:07:20 GMT
+      - Sat, 20 Oct 2018 20:20:48 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1072,7 +1244,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:07:20 GMT
+      - Sat, 20 Oct 2018 20:20:49 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1096,14 +1268,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "137m2u44ecTO7b3ykURxwoiLwQal8PujGwQiXuoVujgU",
+         "id": "1ByuG_ipxow6Wv8x9mIqtH7CJOPVjQ9vPynVJUmQG4Ms",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
           "0AEIi2L68pCuiUk9PVA"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=137m2u44ecTO7b3ykURxwoiLwQal8PujGwQiXuoVujgU&v=1&s=AMedNnoAAAAAW8iFiNFOf-xgiChBF2vQd1jb_s-vURZE&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1ByuG_ipxow6Wv8x9mIqtH7CJOPVjQ9vPynVJUmQG4Ms&v=1&s=AMedNnoAAAAAW8uqQfqwpT993Vy0f4kwvgH9hyXXTrU4&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -1118,10 +1290,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:07:20 GMT
+  recorded_at: Sat, 20 Oct 2018 20:20:49 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9525
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=10607
     body:
       encoding: UTF-8
       string: ''
@@ -1133,7 +1305,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:08:20 GMT
+      - Sat, 20 Oct 2018 20:21:49 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1144,9 +1316,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:08:21 GMT
+      - Sat, 20 Oct 2018 20:21:49 GMT
       Date:
-      - Thu, 18 Oct 2018 11:08:21 GMT
+      - Sat, 20 Oct 2018 20:21:49 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1172,27 +1344,36 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "9531",
+         "newStartPageToken": "10622",
          "changes": [
           {
-           "fileId": "1ghQKU6LqrubhsC0OCfOcGF333QMbsGxXLlAqzaPJK8k"
+           "fileId": "1ygghMs6VGl6AAoJX4YUtl3cHnbCGN0pG"
           },
           {
-           "fileId": "1mY_MimUtrpul6XPbIXCcvRr-T-84_VdB"
+           "fileId": "1ZG6cVwWOZxTN5fVlDtgd4q8JIEel2GzxDV2Rgrmy4zY"
           },
           {
-           "fileId": "1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C"
+           "fileId": "1TERLUE4aNlPEAOeF2Ni0Jl-V0rmRlAHKsD2xeVoryL0"
           },
           {
-           "fileId": "137m2u44ecTO7b3ykURxwoiLwQal8PujGwQiXuoVujgU"
+           "fileId": "1Mik8WVnFWnTR8mo5hMByL6lEoe5LdKK4Q-dvZVidFo0"
+          },
+          {
+           "fileId": "12t3mxDeamL-0cJLi_XCJDZu8VV_dKyNTvSUwRU3H0Co"
+          },
+          {
+           "fileId": "11SCjfOYS6Zb2NvXNguOhip8bMdAlssJi"
+          },
+          {
+           "fileId": "1ByuG_ipxow6Wv8x9mIqtH7CJOPVjQ9vPynVJUmQG4Ms"
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:08:21 GMT
+  recorded_at: Sat, 20 Oct 2018 20:21:49 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1ghQKU6LqrubhsC0OCfOcGF333QMbsGxXLlAqzaPJK8k?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ygghMs6VGl6AAoJX4YUtl3cHnbCGN0pG?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1204,76 +1385,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:08:21 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 18 Oct 2018 11:08:21 GMT
-      Expires:
-      - Thu, 18 Oct 2018 11:08:21 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "notFound",
-            "message": "File not found: 1ghQKU6LqrubhsC0OCfOcGF333QMbsGxXLlAqzaPJK8k.",
-            "locationType": "parameter",
-            "location": "fileId"
-           }
-          ],
-          "code": 404,
-          "message": "File not found: 1ghQKU6LqrubhsC0OCfOcGF333QMbsGxXLlAqzaPJK8k."
-         }
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:08:21 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1mY_MimUtrpul6XPbIXCcvRr-T-84_VdB?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:08:21 GMT
+      - Sat, 20 Oct 2018 20:21:49 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1284,9 +1396,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:08:21 GMT
+      - Sat, 20 Oct 2018 20:21:49 GMT
       Date:
-      - Thu, 18 Oct 2018 11:08:21 GMT
+      - Sat, 20 Oct 2018 20:21:49 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1312,8 +1424,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1mY_MimUtrpul6XPbIXCcvRr-T-84_VdB",
-         "name": "5 Vogon Constructor Fleet (Archive)",
+         "id": "1ygghMs6VGl6AAoJX4YUtl3cHnbCGN0pG",
+         "name": "6 Billion Year Bunker (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -1342,10 +1454,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:08:21 GMT
+  recorded_at: Sat, 20 Oct 2018 20:21:49 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1mY_MimUtrpul6XPbIXCcvRr-T-84_VdB/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1ygghMs6VGl6AAoJX4YUtl3cHnbCGN0pG/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1357,7 +1469,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:08:21 GMT
+      - Sat, 20 Oct 2018 20:21:49 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1375,9 +1487,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:08:21 GMT
+      - Sat, 20 Oct 2018 20:21:49 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:08:21 GMT
+      - Sat, 20 Oct 2018 20:21:49 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1409,10 +1521,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:08:21 GMT
+  recorded_at: Sat, 20 Oct 2018 20:21:49 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ZG6cVwWOZxTN5fVlDtgd4q8JIEel2GzxDV2Rgrmy4zY?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1424,7 +1536,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:08:21 GMT
+      - Sat, 20 Oct 2018 20:21:49 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1435,9 +1547,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:08:21 GMT
+      - Sat, 20 Oct 2018 20:21:49 GMT
       Date:
-      - Thu, 18 Oct 2018 11:08:21 GMT
+      - Sat, 20 Oct 2018 20:21:49 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1463,8 +1575,828 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C",
-         "name": "Test @ 2018-10-18 11:07:14 UTC",
+         "id": "1ZG6cVwWOZxTN5fVlDtgd4q8JIEel2GzxDV2Rgrmy4zY",
+         "name": "File To Move",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1ygghMs6VGl6AAoJX4YUtl3cHnbCGN0pG"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1ZG6cVwWOZxTN5fVlDtgd4q8JIEel2GzxDV2Rgrmy4zY&v=1&s=AMedNnoAAAAAW8uqfav-E7pzIHdyaiBV2m1Ttcr5nOim&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:21:49 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1ZG6cVwWOZxTN5fVlDtgd4q8JIEel2GzxDV2Rgrmy4zY/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:21:49 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:21:50 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:21:50 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-20T20:20:46.332Z"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:21:50 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1ZG6cVwWOZxTN5fVlDtgd4q8JIEel2GzxDV2Rgrmy4zY&s=AMedNnoAAAAAW8uqfav-E7pzIHdyaiBV2m1Ttcr5nOim&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:21:50 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 20 Oct 2018 20:21:50 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:21:50 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1TERLUE4aNlPEAOeF2Ni0Jl-V0rmRlAHKsD2xeVoryL0?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:21:50 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:21:50 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:21:50 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1TERLUE4aNlPEAOeF2Ni0Jl-V0rmRlAHKsD2xeVoryL0",
+         "name": "File To Move",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1ygghMs6VGl6AAoJX4YUtl3cHnbCGN0pG"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1TERLUE4aNlPEAOeF2Ni0Jl-V0rmRlAHKsD2xeVoryL0&v=1&s=AMedNnoAAAAAW8uqfnAAYNdTK1TCyO5a3zCrdjdyU6KE&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:21:50 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1TERLUE4aNlPEAOeF2Ni0Jl-V0rmRlAHKsD2xeVoryL0/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:21:50 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:21:50 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:21:50 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-20T20:20:47.896Z"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:21:50 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1TERLUE4aNlPEAOeF2Ni0Jl-V0rmRlAHKsD2xeVoryL0&s=AMedNnoAAAAAW8uqfnAAYNdTK1TCyO5a3zCrdjdyU6KE&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:21:50 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 20 Oct 2018 20:21:50 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:21:50 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1Mik8WVnFWnTR8mo5hMByL6lEoe5LdKK4Q-dvZVidFo0?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:21:50 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:21:50 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:21:50 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1Mik8WVnFWnTR8mo5hMByL6lEoe5LdKK4Q-dvZVidFo0",
+         "name": "File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1m3_xXUioe8EhG-hNKzjDAz-kuVX__dpB"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Mik8WVnFWnTR8mo5hMByL6lEoe5LdKK4Q-dvZVidFo0&v=1&s=AMedNnoAAAAAW8uqfh8HLdO033KWu3-57c2qherWcVWw&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:21:50 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1Mik8WVnFWnTR8mo5hMByL6lEoe5LdKK4Q-dvZVidFo0/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:21:50 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:21:51 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:21:51 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-20T20:19:32.699Z"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:21:51 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1Mik8WVnFWnTR8mo5hMByL6lEoe5LdKK4Q-dvZVidFo0&s=AMedNnoAAAAAW8uqfh8HLdO033KWu3-57c2qherWcVWw&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:21:51 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 20 Oct 2018 20:21:51 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:21:51 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/12t3mxDeamL-0cJLi_XCJDZu8VV_dKyNTvSUwRU3H0Co?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:21:51 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:21:51 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:21:51 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "12t3mxDeamL-0cJLi_XCJDZu8VV_dKyNTvSUwRU3H0Co",
+         "name": "File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1m3_xXUioe8EhG-hNKzjDAz-kuVX__dpB"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=12t3mxDeamL-0cJLi_XCJDZu8VV_dKyNTvSUwRU3H0Co&v=1&s=AMedNnoAAAAAW8uqfyf9PFJARQiPTB0IKNQ2x-8sLgJm&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:21:51 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/12t3mxDeamL-0cJLi_XCJDZu8VV_dKyNTvSUwRU3H0Co/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:21:51 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:21:51 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:21:51 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-20T20:19:34.256Z"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:21:51 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=12t3mxDeamL-0cJLi_XCJDZu8VV_dKyNTvSUwRU3H0Co&s=AMedNnoAAAAAW8uqfyf9PFJARQiPTB0IKNQ2x-8sLgJm&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:21:51 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 20 Oct 2018 20:21:51 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:21:51 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/11SCjfOYS6Zb2NvXNguOhip8bMdAlssJi?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:21:51 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:21:52 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:21:52 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "11SCjfOYS6Zb2NvXNguOhip8bMdAlssJi",
+         "name": "Test @ 2018-10-20 20:20:39 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -1490,10 +2422,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:08:21 GMT
+  recorded_at: Sat, 20 Oct 2018 20:21:52 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/11SCjfOYS6Zb2NvXNguOhip8bMdAlssJi/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1505,7 +2437,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:08:21 GMT
+      - Sat, 20 Oct 2018 20:21:52 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1523,9 +2455,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:08:21 GMT
+      - Sat, 20 Oct 2018 20:21:52 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:08:21 GMT
+      - Sat, 20 Oct 2018 20:21:52 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1557,10 +2489,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:08:22 GMT
+  recorded_at: Sat, 20 Oct 2018 20:21:52 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/137m2u44ecTO7b3ykURxwoiLwQal8PujGwQiXuoVujgU?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ByuG_ipxow6Wv8x9mIqtH7CJOPVjQ9vPynVJUmQG4Ms?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1572,7 +2504,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:08:22 GMT
+      - Sat, 20 Oct 2018 20:21:52 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1590,9 +2522,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:08:22 GMT
+      - Sat, 20 Oct 2018 20:21:52 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:08:22 GMT
+      - Sat, 20 Oct 2018 20:21:52 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1616,20 +2548,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 137m2u44ecTO7b3ykURxwoiLwQal8PujGwQiXuoVujgU.",
+            "message": "File not found: 1ByuG_ipxow6Wv8x9mIqtH7CJOPVjQ9vPynVJUmQG4Ms.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 137m2u44ecTO7b3ykURxwoiLwQal8PujGwQiXuoVujgU."
+          "message": "File not found: 1ByuG_ipxow6Wv8x9mIqtH7CJOPVjQ9vPynVJUmQG4Ms."
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:08:22 GMT
+  recorded_at: Sat, 20 Oct 2018 20:21:52 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/137m2u44ecTO7b3ykURxwoiLwQal8PujGwQiXuoVujgU
+    uri: https://www.googleapis.com/drive/v3/files/1ByuG_ipxow6Wv8x9mIqtH7CJOPVjQ9vPynVJUmQG4Ms
     body:
       encoding: UTF-8
       string: ''
@@ -1641,7 +2573,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:08:22 GMT
+      - Sat, 20 Oct 2018 20:21:52 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1658,7 +2590,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:08:22 GMT
+      - Sat, 20 Oct 2018 20:21:52 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1670,10 +2602,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:08:23 GMT
+  recorded_at: Sat, 20 Oct 2018 20:21:52 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C
+    uri: https://www.googleapis.com/drive/v3/files/11SCjfOYS6Zb2NvXNguOhip8bMdAlssJi
     body:
       encoding: UTF-8
       string: ''
@@ -1685,7 +2617,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:08:23 GMT
+      - Sat, 20 Oct 2018 20:21:52 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1702,7 +2634,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:08:23 GMT
+      - Sat, 20 Oct 2018 20:21:53 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1714,5 +2646,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:08:23 GMT
+  recorded_at: Sat, 20 Oct 2018 20:21:53 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_moves_file_to_the_root_of_their_drive.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_moves_file_to_the_root_of_their_drive.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,42 +21,39 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:31:43 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:43:04 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:31:43 GMT
+  recorded_at: Thu, 18 Oct 2018 09:43:04 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -66,7 +63,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -78,49 +75,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:31:43 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:43:04 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:31:43 GMT
+  recorded_at: Thu, 18 Oct 2018 09:43:04 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        21:31:43 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:43:04 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -129,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:31:43 GMT
+      - Thu, 18 Oct 2018 09:43:04 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -146,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:31:44 GMT
+      - Thu, 18 Oct 2018 09:43:04 GMT
       Vary:
       - Origin
       - X-Origin
@@ -163,28 +157,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1XXYkW3GBDbez5DZqULqdcQPrHD68wK6s",
-         "name": "Test @ 2018-03-18 21:31:43 UTC",
+         "id": "1VNfvj1XiByBc9jLb59aO6KBYW72m5dII",
+         "name": "Test @ 2018-10-18 09:43:04 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AEIi2L68pCuiUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:31:44 GMT
+  recorded_at: Thu, 18 Oct 2018 09:43:05 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1XXYkW3GBDbez5DZqULqdcQPrHD68wK6s/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1VNfvj1XiByBc9jLb59aO6KBYW72m5dII/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -196,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:31:44 GMT
+      - Thu, 18 Oct 2018 09:43:05 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -213,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:31:45 GMT
+      - Thu, 18 Oct 2018 09:43:05 GMT
       Vary:
       - Origin
       - X-Origin
@@ -230,8 +234,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -244,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:31:45 GMT
+  recorded_at: Thu, 18 Oct 2018 09:43:05 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -259,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:31:45 GMT
+      - Thu, 18 Oct 2018 09:43:05 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -270,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:31:45 GMT
+      - Thu, 18 Oct 2018 09:43:05 GMT
       Date:
-      - Sun, 18 Mar 2018 21:31:45 GMT
+      - Thu, 18 Oct 2018 09:43:05 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -291,8 +294,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -300,17 +302,17 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "7169"
+         "startPageToken": "9395"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:31:45 GMT
+  recorded_at: Thu, 18 Oct 2018 09:43:05 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.document","name":"File To
-        Move","parents":["1XXYkW3GBDbez5DZqULqdcQPrHD68wK6s"]}'
+        Move","parents":["1VNfvj1XiByBc9jLb59aO6KBYW72m5dII"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -319,7 +321,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:31:45 GMT
+      - Thu, 18 Oct 2018 09:43:05 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -336,7 +338,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:31:46 GMT
+      - Thu, 18 Oct 2018 09:43:06 GMT
       Vary:
       - Origin
       - X-Origin
@@ -353,28 +355,47 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "17dgjMytXQZrvzVppS5uFhO-FbHu5827OU1RHHohfXcs",
+         "id": "15VrfG9n7naRqcwozoZQ8yzxUDQOnGnrbW6RTFds9LUc",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1XXYkW3GBDbez5DZqULqdcQPrHD68wK6s"
+          "1VNfvj1XiByBc9jLb59aO6KBYW72m5dII"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:31:46 GMT
+  recorded_at: Thu, 18 Oct 2018 09:43:06 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1XXYkW3GBDbez5DZqULqdcQPrHD68wK6s?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1VNfvj1XiByBc9jLb59aO6KBYW72m5dII?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -386,7 +407,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:31:46 GMT
+      - Thu, 18 Oct 2018 09:43:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -397,9 +418,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:31:47 GMT
+      - Thu, 18 Oct 2018 09:43:07 GMT
       Date:
-      - Sun, 18 Mar 2018 21:31:47 GMT
+      - Thu, 18 Oct 2018 09:43:07 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -418,25 +439,44 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1XXYkW3GBDbez5DZqULqdcQPrHD68wK6s",
-         "name": "Test @ 2018-03-18 21:31:43 UTC",
+         "id": "1VNfvj1XiByBc9jLb59aO6KBYW72m5dII",
+         "name": "Test @ 2018-10-18 09:43:04 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:31:47 GMT
+  recorded_at: Thu, 18 Oct 2018 09:43:07 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1XXYkW3GBDbez5DZqULqdcQPrHD68wK6s/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1VNfvj1XiByBc9jLb59aO6KBYW72m5dII/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -448,7 +488,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:31:47 GMT
+      - Thu, 18 Oct 2018 09:43:07 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -466,9 +506,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:31:47 GMT
+      - Thu, 18 Oct 2018 09:43:07 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:31:47 GMT
+      - Thu, 18 Oct 2018 09:43:07 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -480,8 +520,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -501,10 +540,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:31:47 GMT
+  recorded_at: Thu, 18 Oct 2018 09:43:07 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271XXYkW3GBDbez5DZqULqdcQPrHD68wK6s%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271VNfvj1XiByBc9jLb59aO6KBYW72m5dII%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -516,7 +555,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:31:47 GMT
+      - Thu, 18 Oct 2018 09:43:07 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -527,9 +566,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:31:47 GMT
+      - Thu, 18 Oct 2018 09:43:07 GMT
       Date:
-      - Sun, 18 Mar 2018 21:31:47 GMT
+      - Thu, 18 Oct 2018 09:43:07 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -548,8 +587,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -558,22 +596,42 @@ http_interactions:
         {
          "files": [
           {
-           "id": "17dgjMytXQZrvzVppS5uFhO-FbHu5827OU1RHHohfXcs",
+           "id": "15VrfG9n7naRqcwozoZQ8yzxUDQOnGnrbW6RTFds9LUc",
            "name": "File To Move",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1XXYkW3GBDbez5DZqULqdcQPrHD68wK6s"
+            "1VNfvj1XiByBc9jLb59aO6KBYW72m5dII"
            ],
-           "thumbnailVersion": "0"
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "writer",
+             "displayName": "Upshift One",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "13193959451567607887",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+             "role": "owner",
+             "displayName": "Testuser Upshift One",
+             "deleted": false
+            }
+           ]
           }
          ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:31:47 GMT
+  recorded_at: Thu, 18 Oct 2018 09:43:07 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/17dgjMytXQZrvzVppS5uFhO-FbHu5827OU1RHHohfXcs/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/15VrfG9n7naRqcwozoZQ8yzxUDQOnGnrbW6RTFds9LUc/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -585,7 +643,209 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:31:47 GMT
+      - Thu, 18 Oct 2018 09:43:07 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 09:43:07 GMT
+      Date:
+      - Thu, 18 Oct 2018 09:43:07 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-18T09:43:06.129Z"
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 09:43:07 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/drive/v3/files/15VrfG9n7naRqcwozoZQ8yzxUDQOnGnrbW6RTFds9LUc?addParents=root&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1VNfvj1XiByBc9jLb59aO6KBYW72m5dII
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 09:43:07 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 09:43:08 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "15VrfG9n7naRqcwozoZQ8yzxUDQOnGnrbW6RTFds9LUc",
+         "name": "File To Move",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "0AEIi2L68pCuiUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 09:43:08 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9395
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 09:44:08 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 09:44:08 GMT
+      Date:
+      - Thu, 18 Oct 2018 09:44:08 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "newStartPageToken": "9397",
+         "changes": [
+          {
+           "fileId": "15VrfG9n7naRqcwozoZQ8yzxUDQOnGnrbW6RTFds9LUc"
+          },
+          {
+           "fileId": "1VNfvj1XiByBc9jLb59aO6KBYW72m5dII"
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 09:44:08 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/15VrfG9n7naRqcwozoZQ8yzxUDQOnGnrbW6RTFds9LUc?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 09:44:08 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -603,9 +863,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:31:47 GMT
+      - Thu, 18 Oct 2018 09:44:08 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:31:47 GMT
+      - Thu, 18 Oct 2018 09:44:08 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -617,8 +877,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -630,87 +889,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "Revision not found: head.",
+            "message": "File not found: 15VrfG9n7naRqcwozoZQ8yzxUDQOnGnrbW6RTFds9LUc.",
             "locationType": "parameter",
-            "location": "revisionId"
+            "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "Revision not found: head."
+          "message": "File not found: 15VrfG9n7naRqcwozoZQ8yzxUDQOnGnrbW6RTFds9LUc."
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:31:47 GMT
-- request:
-    method: patch
-    uri: https://www.googleapis.com/drive/v3/files/17dgjMytXQZrvzVppS5uFhO-FbHu5827OU1RHHohfXcs?addParents=root&fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion&removeParents=1XXYkW3GBDbez5DZqULqdcQPrHD68wK6s
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sun, 18 Mar 2018 21:31:47 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:31:48 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "17dgjMytXQZrvzVppS5uFhO-FbHu5827OU1RHHohfXcs",
-         "name": "File To Move",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "0AEIi2L68pCuiUk9PVA"
-         ],
-         "thumbnailVersion": "0"
-        }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:31:48 GMT
+  recorded_at: Thu, 18 Oct 2018 09:44:08 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=7169
+    uri: https://www.googleapis.com/drive/v3/files/1VNfvj1XiByBc9jLb59aO6KBYW72m5dII?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -722,7 +914,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:32:48 GMT
+      - Thu, 18 Oct 2018 09:44:08 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -733,9 +925,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:32:48 GMT
+      - Thu, 18 Oct 2018 09:44:09 GMT
       Date:
-      - Sun, 18 Mar 2018 21:32:48 GMT
+      - Thu, 18 Oct 2018 09:44:09 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -754,29 +946,44 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "7173",
-         "changes": [
+         "id": "1VNfvj1XiByBc9jLb59aO6KBYW72m5dII",
+         "name": "Test @ 2018-10-18 09:43:04 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
           {
-           "fileId": "1XXYkW3GBDbez5DZqULqdcQPrHD68wK6s"
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
           },
           {
-           "fileId": "17dgjMytXQZrvzVppS5uFhO-FbHu5827OU1RHHohfXcs"
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:32:48 GMT
+  recorded_at: Thu, 18 Oct 2018 09:44:09 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1XXYkW3GBDbez5DZqULqdcQPrHD68wK6s?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1VNfvj1XiByBc9jLb59aO6KBYW72m5dII/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -788,69 +995,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:32:48 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sun, 18 Mar 2018 21:32:49 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:32:49 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1XXYkW3GBDbez5DZqULqdcQPrHD68wK6s",
-         "name": "Test @ 2018-03-18 21:31:43 UTC",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "thumbnailVersion": "0"
-        }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:32:49 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1XXYkW3GBDbez5DZqULqdcQPrHD68wK6s/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sun, 18 Mar 2018 21:32:49 GMT
+      - Thu, 18 Oct 2018 09:44:09 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -868,9 +1013,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:32:49 GMT
+      - Thu, 18 Oct 2018 09:44:09 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:32:49 GMT
+      - Thu, 18 Oct 2018 09:44:09 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -882,8 +1027,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -903,80 +1047,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:32:49 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/17dgjMytXQZrvzVppS5uFhO-FbHu5827OU1RHHohfXcs?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sun, 18 Mar 2018 21:32:49 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sun, 18 Mar 2018 21:32:49 GMT
-      Expires:
-      - Sun, 18 Mar 2018 21:32:49 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "notFound",
-            "message": "File not found: 17dgjMytXQZrvzVppS5uFhO-FbHu5827OU1RHHohfXcs.",
-            "locationType": "parameter",
-            "location": "fileId"
-           }
-          ],
-          "code": 404,
-          "message": "File not found: 17dgjMytXQZrvzVppS5uFhO-FbHu5827OU1RHHohfXcs."
-         }
-        }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:32:49 GMT
+  recorded_at: Thu, 18 Oct 2018 09:44:09 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/17dgjMytXQZrvzVppS5uFhO-FbHu5827OU1RHHohfXcs
+    uri: https://www.googleapis.com/drive/v3/files/15VrfG9n7naRqcwozoZQ8yzxUDQOnGnrbW6RTFds9LUc
     body:
       encoding: UTF-8
       string: ''
@@ -988,7 +1062,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:32:49 GMT
+      - Thu, 18 Oct 2018 09:44:09 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1005,23 +1079,22 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:32:50 GMT
+      - Thu, 18 Oct 2018 09:44:09 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:32:50 GMT
+  recorded_at: Thu, 18 Oct 2018 09:44:09 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1XXYkW3GBDbez5DZqULqdcQPrHD68wK6s
+    uri: https://www.googleapis.com/drive/v3/files/1VNfvj1XiByBc9jLb59aO6KBYW72m5dII
     body:
       encoding: UTF-8
       string: ''
@@ -1033,7 +1106,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:32:50 GMT
+      - Thu, 18 Oct 2018 09:44:09 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1050,18 +1123,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:32:51 GMT
+      - Thu, 18 Oct 2018 09:44:10 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:32:51 GMT
+  recorded_at: Thu, 18 Oct 2018 09:44:10 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_moves_file_to_the_root_of_their_drive.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_moves_file_to_the_root_of_their_drive.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:43:04 GMT
+      - Thu, 18 Oct 2018 11:07:14 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:43:04 GMT
+  recorded_at: Thu, 18 Oct 2018 11:07:14 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:43:04 GMT
+      - Thu, 18 Oct 2018 11:07:14 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:43:04 GMT
+  recorded_at: Thu, 18 Oct 2018 11:07:14 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        09:43:04 UTC","parents":["root"]}'
+        11:07:14 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:43:04 GMT
+      - Thu, 18 Oct 2018 11:07:14 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:43:04 GMT
+      - Thu, 18 Oct 2018 11:07:15 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1VNfvj1XiByBc9jLb59aO6KBYW72m5dII",
-         "name": "Test @ 2018-10-18 09:43:04 UTC",
+         "id": "1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C",
+         "name": "Test @ 2018-10-18 11:07:14 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:43:05 GMT
+  recorded_at: Thu, 18 Oct 2018 11:07:15 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1VNfvj1XiByBc9jLb59aO6KBYW72m5dII/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:43:05 GMT
+      - Thu, 18 Oct 2018 11:07:15 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:43:05 GMT
+      - Thu, 18 Oct 2018 11:07:16 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:43:05 GMT
+  recorded_at: Thu, 18 Oct 2018 11:07:16 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:43:05 GMT
+      - Thu, 18 Oct 2018 11:07:16 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:43:05 GMT
+      - Thu, 18 Oct 2018 11:07:16 GMT
       Date:
-      - Thu, 18 Oct 2018 09:43:05 GMT
+      - Thu, 18 Oct 2018 11:07:16 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,17 +302,17 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "9395"
+         "startPageToken": "9525"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:43:05 GMT
+  recorded_at: Thu, 18 Oct 2018 11:07:16 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.document","name":"File To
-        Move","parents":["1VNfvj1XiByBc9jLb59aO6KBYW72m5dII"]}'
+        Move","parents":["1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -321,7 +321,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:43:05 GMT
+      - Thu, 18 Oct 2018 11:07:16 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -338,7 +338,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:43:06 GMT
+      - Thu, 18 Oct 2018 11:07:17 GMT
       Vary:
       - Origin
       - X-Origin
@@ -362,12 +362,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "15VrfG9n7naRqcwozoZQ8yzxUDQOnGnrbW6RTFds9LUc",
+         "id": "137m2u44ecTO7b3ykURxwoiLwQal8PujGwQiXuoVujgU",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1VNfvj1XiByBc9jLb59aO6KBYW72m5dII"
+          "1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -392,10 +392,150 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:43:06 GMT
+  recorded_at: Thu, 18 Oct 2018 11:07:17 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"5 Vogon Constructor
+        Fleet (Archive)","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:07:17 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:07:17 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1mY_MimUtrpul6XPbIXCcvRr-T-84_VdB",
+         "name": "5 Vogon Constructor Fleet (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:07:18 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1mY_MimUtrpul6XPbIXCcvRr-T-84_VdB/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:07:18 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:07:18 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "13193959451567607887",
+         "type": "user",
+         "role": "reader"
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:07:18 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1VNfvj1XiByBc9jLb59aO6KBYW72m5dII?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1mY_MimUtrpul6XPbIXCcvRr-T-84_VdB?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -407,7 +547,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:43:06 GMT
+      - Thu, 18 Oct 2018 11:07:18 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -418,9 +558,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:43:07 GMT
+      - Thu, 18 Oct 2018 11:07:19 GMT
       Date:
-      - Thu, 18 Oct 2018 09:43:07 GMT
+      - Thu, 18 Oct 2018 11:07:19 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -446,37 +586,40 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1VNfvj1XiByBc9jLb59aO6KBYW72m5dII",
-         "name": "Test @ 2018-10-18 09:43:04 UTC",
+         "id": "1mY_MimUtrpul6XPbIXCcvRr-T-84_VdB",
+         "name": "5 Vogon Constructor Fleet (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
          "thumbnailVersion": "0",
          "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
           {
            "kind": "drive#permission",
            "id": "13193959451567607887",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
+           "role": "reader",
            "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
            "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:43:07 GMT
+  recorded_at: Thu, 18 Oct 2018 11:07:19 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1VNfvj1XiByBc9jLb59aO6KBYW72m5dII/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1mY_MimUtrpul6XPbIXCcvRr-T-84_VdB/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -488,7 +631,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:43:07 GMT
+      - Thu, 18 Oct 2018 11:07:19 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -506,9 +649,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:43:07 GMT
+      - Thu, 18 Oct 2018 11:07:19 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:43:07 GMT
+      - Thu, 18 Oct 2018 11:07:19 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -540,10 +683,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:43:07 GMT
+  recorded_at: Thu, 18 Oct 2018 11:07:19 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271VNfvj1XiByBc9jLb59aO6KBYW72m5dII%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files/1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -555,7 +698,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:43:07 GMT
+      - Thu, 18 Oct 2018 11:07:19 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -566,9 +709,157 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:43:07 GMT
+      - Thu, 18 Oct 2018 11:07:19 GMT
       Date:
-      - Thu, 18 Oct 2018 09:43:07 GMT
+      - Thu, 18 Oct 2018 11:07:19 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C",
+         "name": "Test @ 2018-10-18 11:07:14 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:07:19 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:07:19 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:07:19 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:07:19 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:07:19 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:07:19 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:07:19 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:07:19 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -596,14 +887,15 @@ http_interactions:
         {
          "files": [
           {
-           "id": "15VrfG9n7naRqcwozoZQ8yzxUDQOnGnrbW6RTFds9LUc",
+           "id": "137m2u44ecTO7b3ykURxwoiLwQal8PujGwQiXuoVujgU",
            "name": "File To Move",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1VNfvj1XiByBc9jLb59aO6KBYW72m5dII"
+            "1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C"
            ],
-           "thumbnailVersion": "0",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=137m2u44ecTO7b3ykURxwoiLwQal8PujGwQiXuoVujgU&v=1&s=AMedNnoAAAAAW8iFh9fZy-TmxZsYvGI-rKZKTS7p2FfW&sz=s220",
+           "thumbnailVersion": "1",
            "permissions": [
             {
              "kind": "drive#permission",
@@ -628,10 +920,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:43:07 GMT
+  recorded_at: Thu, 18 Oct 2018 11:07:19 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/15VrfG9n7naRqcwozoZQ8yzxUDQOnGnrbW6RTFds9LUc/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/137m2u44ecTO7b3ykURxwoiLwQal8PujGwQiXuoVujgU/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -643,7 +935,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:43:07 GMT
+      - Thu, 18 Oct 2018 11:07:19 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -654,9 +946,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:43:07 GMT
+      - Thu, 18 Oct 2018 11:07:19 GMT
       Date:
-      - Thu, 18 Oct 2018 09:43:07 GMT
+      - Thu, 18 Oct 2018 11:07:19 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -685,13 +977,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T09:43:06.129Z"
+         "modifiedTime": "2018-10-18T11:07:16.479Z"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:43:07 GMT
+  recorded_at: Thu, 18 Oct 2018 11:07:19 GMT
 - request:
-    method: patch
-    uri: https://www.googleapis.com/drive/v3/files/15VrfG9n7naRqcwozoZQ8yzxUDQOnGnrbW6RTFds9LUc?addParents=root&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1VNfvj1XiByBc9jLb59aO6KBYW72m5dII
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=137m2u44ecTO7b3ykURxwoiLwQal8PujGwQiXuoVujgU&s=AMedNnoAAAAAW8iFh9fZy-TmxZsYvGI-rKZKTS7p2FfW&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -703,7 +995,67 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:43:07 GMT
+      - Thu, 18 Oct 2018 11:07:19 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Thu, 18 Oct 2018 11:07:20 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:07:20 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/drive/v3/files/137m2u44ecTO7b3ykURxwoiLwQal8PujGwQiXuoVujgU?addParents=root&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:07:20 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -720,7 +1072,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:43:08 GMT
+      - Thu, 18 Oct 2018 11:07:20 GMT
       Vary:
       - Origin
       - X-Origin
@@ -744,14 +1096,15 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "15VrfG9n7naRqcwozoZQ8yzxUDQOnGnrbW6RTFds9LUc",
+         "id": "137m2u44ecTO7b3ykURxwoiLwQal8PujGwQiXuoVujgU",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
           "0AEIi2L68pCuiUk9PVA"
          ],
-         "thumbnailVersion": "0",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=137m2u44ecTO7b3ykURxwoiLwQal8PujGwQiXuoVujgU&v=1&s=AMedNnoAAAAAW8iFiNFOf-xgiChBF2vQd1jb_s-vURZE&sz=s220",
+         "thumbnailVersion": "1",
          "permissions": [
           {
            "kind": "drive#permission",
@@ -765,10 +1118,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:43:08 GMT
+  recorded_at: Thu, 18 Oct 2018 11:07:20 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9395
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9525
     body:
       encoding: UTF-8
       string: ''
@@ -780,7 +1133,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:08 GMT
+      - Thu, 18 Oct 2018 11:08:20 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -791,9 +1144,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:44:08 GMT
+      - Thu, 18 Oct 2018 11:08:21 GMT
       Date:
-      - Thu, 18 Oct 2018 09:44:08 GMT
+      - Thu, 18 Oct 2018 11:08:21 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -819,21 +1172,27 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "9397",
+         "newStartPageToken": "9531",
          "changes": [
           {
-           "fileId": "15VrfG9n7naRqcwozoZQ8yzxUDQOnGnrbW6RTFds9LUc"
+           "fileId": "1ghQKU6LqrubhsC0OCfOcGF333QMbsGxXLlAqzaPJK8k"
           },
           {
-           "fileId": "1VNfvj1XiByBc9jLb59aO6KBYW72m5dII"
+           "fileId": "1mY_MimUtrpul6XPbIXCcvRr-T-84_VdB"
+          },
+          {
+           "fileId": "1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C"
+          },
+          {
+           "fileId": "137m2u44ecTO7b3ykURxwoiLwQal8PujGwQiXuoVujgU"
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:44:08 GMT
+  recorded_at: Thu, 18 Oct 2018 11:08:21 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/15VrfG9n7naRqcwozoZQ8yzxUDQOnGnrbW6RTFds9LUc?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ghQKU6LqrubhsC0OCfOcGF333QMbsGxXLlAqzaPJK8k?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -845,7 +1204,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:08 GMT
+      - Thu, 18 Oct 2018 11:08:21 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -863,9 +1222,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:44:08 GMT
+      - Thu, 18 Oct 2018 11:08:21 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:44:08 GMT
+      - Thu, 18 Oct 2018 11:08:21 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -889,20 +1248,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 15VrfG9n7naRqcwozoZQ8yzxUDQOnGnrbW6RTFds9LUc.",
+            "message": "File not found: 1ghQKU6LqrubhsC0OCfOcGF333QMbsGxXLlAqzaPJK8k.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 15VrfG9n7naRqcwozoZQ8yzxUDQOnGnrbW6RTFds9LUc."
+          "message": "File not found: 1ghQKU6LqrubhsC0OCfOcGF333QMbsGxXLlAqzaPJK8k."
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:44:08 GMT
+  recorded_at: Thu, 18 Oct 2018 11:08:21 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1VNfvj1XiByBc9jLb59aO6KBYW72m5dII?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1mY_MimUtrpul6XPbIXCcvRr-T-84_VdB?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -914,7 +1273,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:08 GMT
+      - Thu, 18 Oct 2018 11:08:21 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -925,9 +1284,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:44:09 GMT
+      - Thu, 18 Oct 2018 11:08:21 GMT
       Date:
-      - Thu, 18 Oct 2018 09:44:09 GMT
+      - Thu, 18 Oct 2018 11:08:21 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -953,37 +1312,40 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1VNfvj1XiByBc9jLb59aO6KBYW72m5dII",
-         "name": "Test @ 2018-10-18 09:43:04 UTC",
+         "id": "1mY_MimUtrpul6XPbIXCcvRr-T-84_VdB",
+         "name": "5 Vogon Constructor Fleet (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
          "thumbnailVersion": "0",
          "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
           {
            "kind": "drive#permission",
            "id": "13193959451567607887",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
+           "role": "reader",
            "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
            "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:44:09 GMT
+  recorded_at: Thu, 18 Oct 2018 11:08:21 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1VNfvj1XiByBc9jLb59aO6KBYW72m5dII/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1mY_MimUtrpul6XPbIXCcvRr-T-84_VdB/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -995,7 +1357,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:09 GMT
+      - Thu, 18 Oct 2018 11:08:21 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1013,9 +1375,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:44:09 GMT
+      - Thu, 18 Oct 2018 11:08:21 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:44:09 GMT
+      - Thu, 18 Oct 2018 11:08:21 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1047,10 +1409,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:44:09 GMT
+  recorded_at: Thu, 18 Oct 2018 11:08:21 GMT
 - request:
-    method: delete
-    uri: https://www.googleapis.com/drive/v3/files/15VrfG9n7naRqcwozoZQ8yzxUDQOnGnrbW6RTFds9LUc
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1062,7 +1424,224 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:09 GMT
+      - Thu, 18 Oct 2018 11:08:21 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:08:21 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:08:21 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C",
+         "name": "Test @ 2018-10-18 11:07:14 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:08:21 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:08:21 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:08:21 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:08:21 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:08:22 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/137m2u44ecTO7b3ykURxwoiLwQal8PujGwQiXuoVujgU?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:08:22 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:08:22 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:08:22 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "notFound",
+            "message": "File not found: 137m2u44ecTO7b3ykURxwoiLwQal8PujGwQiXuoVujgU.",
+            "locationType": "parameter",
+            "location": "fileId"
+           }
+          ],
+          "code": 404,
+          "message": "File not found: 137m2u44ecTO7b3ykURxwoiLwQal8PujGwQiXuoVujgU."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:08:22 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/137m2u44ecTO7b3ykURxwoiLwQal8PujGwQiXuoVujgU
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:08:22 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1079,7 +1658,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:44:09 GMT
+      - Thu, 18 Oct 2018 11:08:22 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1091,10 +1670,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:44:09 GMT
+  recorded_at: Thu, 18 Oct 2018 11:08:23 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1VNfvj1XiByBc9jLb59aO6KBYW72m5dII
+    uri: https://www.googleapis.com/drive/v3/files/1tjorPpTHtxwz_UiLq9TV50m9o1ycmV8C
     body:
       encoding: UTF-8
       string: ''
@@ -1106,7 +1685,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:09 GMT
+      - Thu, 18 Oct 2018 11:08:23 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1123,7 +1702,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:44:10 GMT
+      - Thu, 18 Oct 2018 11:08:23 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1135,5 +1714,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:44:10 GMT
+  recorded_at: Thu, 18 Oct 2018 11:08:23 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_moves_file_within_project_folder.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_moves_file_within_project_folder.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:40:48 GMT
+      - Thu, 18 Oct 2018 11:11:50 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:40:48 GMT
+  recorded_at: Thu, 18 Oct 2018 11:11:50 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:40:48 GMT
+      - Thu, 18 Oct 2018 11:11:50 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:40:48 GMT
+  recorded_at: Thu, 18 Oct 2018 11:11:50 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        09:40:48 UTC","parents":["root"]}'
+        11:11:50 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:40:48 GMT
+      - Thu, 18 Oct 2018 11:11:50 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:40:48 GMT
+      - Thu, 18 Oct 2018 11:11:50 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J",
-         "name": "Test @ 2018-10-18 09:40:48 UTC",
+         "id": "1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN",
+         "name": "Test @ 2018-10-18 11:11:50 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:40:49 GMT
+  recorded_at: Thu, 18 Oct 2018 11:11:50 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:40:49 GMT
+      - Thu, 18 Oct 2018 11:11:50 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:40:49 GMT
+      - Thu, 18 Oct 2018 11:11:51 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:40:49 GMT
+  recorded_at: Thu, 18 Oct 2018 11:11:51 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:40:49 GMT
+      - Thu, 18 Oct 2018 11:11:51 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:40:49 GMT
+      - Thu, 18 Oct 2018 11:11:51 GMT
       Date:
-      - Thu, 18 Oct 2018 09:40:49 GMT
+      - Thu, 18 Oct 2018 11:11:51 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,16 +302,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "9380"
+         "startPageToken": "9555"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:40:50 GMT
+  recorded_at: Thu, 18 Oct 2018 11:11:51 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -320,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:40:50 GMT
+      - Thu, 18 Oct 2018 11:11:51 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -337,7 +337,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:40:50 GMT
+      - Thu, 18 Oct 2018 11:11:52 GMT
       Vary:
       - Origin
       - X-Origin
@@ -361,12 +361,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj",
+         "id": "1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu",
          "name": "Folder",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J"
+          "1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -391,14 +391,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:40:50 GMT
+  recorded_at: Thu, 18 Oct 2018 11:11:52 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.document","name":"File To
-        Move","parents":["1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj"]}'
+        Move","parents":["1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -407,7 +407,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:40:50 GMT
+      - Thu, 18 Oct 2018 11:11:52 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -424,7 +424,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:40:51 GMT
+      - Thu, 18 Oct 2018 11:11:54 GMT
       Vary:
       - Origin
       - X-Origin
@@ -448,12 +448,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws",
+         "id": "1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj"
+          "1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -478,13 +478,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:40:51 GMT
+  recorded_at: Thu, 18 Oct 2018 11:11:54 GMT
 - request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: ''
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"9 RW6 (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -493,462 +493,11 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:40:51 GMT
+      - Thu, 18 Oct 2018 11:11:54 GMT
+      Content-Type:
+      - application/json
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Thu, 18 Oct 2018 09:40:51 GMT
-      Date:
-      - Thu, 18 Oct 2018 09:40:51 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J",
-         "name": "Test @ 2018-10-18 09:40:48 UTC",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:40:51 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 09:40:51 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 18 Oct 2018 09:40:51 GMT
-      Expires:
-      - Thu, 18 Oct 2018 09:40:51 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:40:52 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J%27%20in%20parents
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 09:40:52 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Thu, 18 Oct 2018 09:40:52 GMT
-      Date:
-      - Thu, 18 Oct 2018 09:40:52 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "files": [
-          {
-           "id": "1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj",
-           "name": "Folder",
-           "mimeType": "application/vnd.google-apps.folder",
-           "trashed": false,
-           "parents": [
-            "1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J"
-           ],
-           "thumbnailVersion": "0",
-           "permissions": [
-            {
-             "kind": "drive#permission",
-             "id": "11673017242486491425",
-             "type": "user",
-             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-             "role": "writer",
-             "displayName": "Upshift One",
-             "deleted": false
-            },
-            {
-             "kind": "drive#permission",
-             "id": "13193959451567607887",
-             "type": "user",
-             "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-             "role": "owner",
-             "displayName": "Testuser Upshift One",
-             "deleted": false
-            }
-           ]
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:40:52 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 09:40:52 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 18 Oct 2018 09:40:52 GMT
-      Expires:
-      - Thu, 18 Oct 2018 09:40:52 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:40:52 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj%27%20in%20parents
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 09:40:52 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Thu, 18 Oct 2018 09:40:52 GMT
-      Date:
-      - Thu, 18 Oct 2018 09:40:52 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "files": [
-          {
-           "id": "1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws",
-           "name": "File To Move",
-           "mimeType": "application/vnd.google-apps.document",
-           "trashed": false,
-           "parents": [
-            "1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj"
-           ],
-           "thumbnailVersion": "0",
-           "permissions": [
-            {
-             "kind": "drive#permission",
-             "id": "11673017242486491425",
-             "type": "user",
-             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-             "role": "writer",
-             "displayName": "Upshift One",
-             "deleted": false
-            },
-            {
-             "kind": "drive#permission",
-             "id": "13193959451567607887",
-             "type": "user",
-             "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-             "role": "owner",
-             "displayName": "Testuser Upshift One",
-             "deleted": false
-            }
-           ]
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:40:52 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 09:40:52 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Thu, 18 Oct 2018 09:40:52 GMT
-      Date:
-      - Thu, 18 Oct 2018 09:40:52 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "kind": "drive#revision",
-         "id": "1",
-         "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T09:40:50.846Z"
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:40:52 GMT
-- request:
-    method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws?addParents=1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 09:40:52 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
   response:
     status:
       code: 200
@@ -961,7 +510,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:40:53 GMT
+      - Thu, 18 Oct 2018 11:11:54 GMT
       Vary:
       - Origin
       - X-Origin
@@ -985,164 +534,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws",
-         "name": "File To Move",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:40:53 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9380
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 09:41:53 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Thu, 18 Oct 2018 09:41:53 GMT
-      Date:
-      - Thu, 18 Oct 2018 09:41:53 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "newStartPageToken": "9385",
-         "changes": [
-          {
-           "fileId": "1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj"
-          },
-          {
-           "fileId": "1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws"
-          },
-          {
-           "fileId": "1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J"
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:41:53 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 09:41:53 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Thu, 18 Oct 2018 09:41:53 GMT
-      Date:
-      - Thu, 18 Oct 2018 09:41:53 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj",
-         "name": "Folder",
+         "id": "1eOPdp6aPJ3BIq5eQ1xP_3IBNE6Tgdi46",
+         "name": "9 RW6 (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J"
+          "0AIeK5UAEPQfeUk9PVA"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1151,26 +548,79 @@ http_interactions:
            "id": "11673017242486491425",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
            "role": "owner",
-           "displayName": "Testuser Upshift One",
+           "displayName": "Upshift One",
            "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:41:54 GMT
+  recorded_at: Thu, 18 Oct 2018 11:11:54 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1eOPdp6aPJ3BIq5eQ1xP_3IBNE6Tgdi46/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:11:54 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:11:55 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "13193959451567607887",
+         "type": "user",
+         "role": "reader"
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:11:55 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1eOPdp6aPJ3BIq5eQ1xP_3IBNE6Tgdi46?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1182,7 +632,91 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:41:54 GMT
+      - Thu, 18 Oct 2018 11:11:55 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:11:55 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:11:55 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1eOPdp6aPJ3BIq5eQ1xP_3IBNE6Tgdi46",
+         "name": "9 RW6 (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:11:55 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1eOPdp6aPJ3BIq5eQ1xP_3IBNE6Tgdi46/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:11:55 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1200,9 +734,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:41:54 GMT
+      - Thu, 18 Oct 2018 11:11:55 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:41:54 GMT
+      - Thu, 18 Oct 2018 11:11:55 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1234,10 +768,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:41:54 GMT
+  recorded_at: Thu, 18 Oct 2018 11:11:55 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1249,7 +783,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:41:54 GMT
+      - Thu, 18 Oct 2018 11:11:55 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1260,9 +794,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:41:54 GMT
+      - Thu, 18 Oct 2018 11:11:56 GMT
       Date:
-      - Thu, 18 Oct 2018 09:41:54 GMT
+      - Thu, 18 Oct 2018 11:11:56 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1288,15 +822,11 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws",
-         "name": "File To Move",
-         "mimeType": "application/vnd.google-apps.document",
+         "id": "1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN",
+         "name": "Test @ 2018-10-18 11:11:50 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
-         "parents": [
-          "1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws&v=1&s=AMedNnoAAAAAW8hxgl6O9MGRm-LELRJax41B-gM97bzU&sz=s220",
-         "thumbnailVersion": "1",
+         "thumbnailVersion": "0",
          "permissions": [
           {
            "kind": "drive#permission",
@@ -1319,10 +849,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:41:54 GMT
+  recorded_at: Thu, 18 Oct 2018 11:11:56 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1334,7 +864,74 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:41:54 GMT
+      - Thu, 18 Oct 2018 11:11:56 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:11:56 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:11:56 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:11:56 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:11:56 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1345,9 +942,253 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:41:54 GMT
+      - Thu, 18 Oct 2018 11:11:57 GMT
       Date:
-      - Thu, 18 Oct 2018 09:41:54 GMT
+      - Thu, 18 Oct 2018 11:11:57 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "files": [
+          {
+           "id": "1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu",
+           "name": "Folder",
+           "mimeType": "application/vnd.google-apps.folder",
+           "trashed": false,
+           "parents": [
+            "1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN"
+           ],
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "writer",
+             "displayName": "Upshift One",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "13193959451567607887",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+             "role": "owner",
+             "displayName": "Testuser Upshift One",
+             "deleted": false
+            }
+           ]
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:11:57 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:11:57 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:11:57 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:11:57 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:11:57 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:11:57 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:11:59 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:11:59 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "files": [
+          {
+           "id": "1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM",
+           "name": "File To Move",
+           "mimeType": "application/vnd.google-apps.document",
+           "trashed": false,
+           "parents": [
+            "1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu"
+           ],
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM&v=1&s=AMedNnoAAAAAW8iGn_lakt0q-cXyiJZpZpWm5q4bYjJ_&sz=s220",
+           "thumbnailVersion": "1",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "writer",
+             "displayName": "Upshift One",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "13193959451567607887",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+             "role": "owner",
+             "displayName": "Testuser Upshift One",
+             "deleted": false
+            }
+           ]
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:11:59 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:11:59 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:11:59 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:11:59 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1376,13 +1217,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T09:40:50.846Z"
+         "modifiedTime": "2018-10-18T11:11:53.198Z"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:41:54 GMT
+  recorded_at: Thu, 18 Oct 2018 11:11:59 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws&s=AMedNnoAAAAAW8hxgl6O9MGRm-LELRJax41B-gM97bzU&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM&s=AMedNnoAAAAAW8iGn_lakt0q-cXyiJZpZpWm5q4bYjJ_&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1394,7 +1235,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:41:54 GMT
+      - Thu, 18 Oct 2018 11:11:59 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1425,7 +1266,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 18 Oct 2018 09:41:54 GMT
+      - Thu, 18 Oct 2018 11:11:59 GMT
       Server:
       - fife
       Content-Length:
@@ -1439,10 +1280,10 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:41:54 GMT
+  recorded_at: Thu, 18 Oct 2018 11:11:59 GMT
 - request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    method: patch
+    uri: https://www.googleapis.com/drive/v3/files/1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM?addParents=1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu
     body:
       encoding: UTF-8
       string: ''
@@ -1454,7 +1295,94 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:41:54 GMT
+      - Thu, 18 Oct 2018 11:11:59 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:12:00 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM",
+         "name": "File To Move",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM&v=1&s=AMedNnoAAAAAW8iGoJt-__9dC1vTK5cqNcm3a14OlVrK&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:12:00 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9555
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:13:00 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1465,9 +1393,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:41:55 GMT
+      - Thu, 18 Oct 2018 11:13:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:41:55 GMT
+      - Thu, 18 Oct 2018 11:13:00 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1493,37 +1421,27 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J",
-         "name": "Test @ 2018-10-18 09:40:48 UTC",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "thumbnailVersion": "0",
-         "permissions": [
+         "newStartPageToken": "9563",
+         "changes": [
           {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
+           "fileId": "1eOPdp6aPJ3BIq5eQ1xP_3IBNE6Tgdi46"
           },
           {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
+           "fileId": "1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu"
+          },
+          {
+           "fileId": "1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM"
+          },
+          {
+           "fileId": "1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN"
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:41:55 GMT
+  recorded_at: Thu, 18 Oct 2018 11:13:00 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1eOPdp6aPJ3BIq5eQ1xP_3IBNE6Tgdi46?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1535,7 +1453,91 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:41:55 GMT
+      - Thu, 18 Oct 2018 11:13:00 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:13:01 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:13:01 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1eOPdp6aPJ3BIq5eQ1xP_3IBNE6Tgdi46",
+         "name": "9 RW6 (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:13:01 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1eOPdp6aPJ3BIq5eQ1xP_3IBNE6Tgdi46/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:13:01 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1553,9 +1555,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:41:55 GMT
+      - Thu, 18 Oct 2018 11:13:01 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:41:55 GMT
+      - Thu, 18 Oct 2018 11:13:01 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1587,10 +1589,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:41:55 GMT
+  recorded_at: Thu, 18 Oct 2018 11:13:01 GMT
 - request:
-    method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1602,7 +1604,451 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:41:55 GMT
+      - Thu, 18 Oct 2018 11:13:01 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:13:01 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:13:01 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu",
+         "name": "Folder",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:13:01 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:13:01 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:13:01 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:13:01 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:13:01 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:13:01 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:13:01 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:13:01 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM",
+         "name": "File To Move",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM&v=1&s=AMedNnoAAAAAW8iG3akAyZIZTYVFcvW0krTMMOhImJNH&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:13:01 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:13:01 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:13:01 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:13:01 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-18T11:11:53.198Z"
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:13:01 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:13:01 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:13:02 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:13:02 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN",
+         "name": "Test @ 2018-10-18 11:11:50 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:13:02 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:13:02 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:13:02 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:13:02 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:13:02 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:13:02 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1619,7 +2065,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:41:56 GMT
+      - Thu, 18 Oct 2018 11:13:03 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1631,5 +2077,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:41:56 GMT
+  recorded_at: Thu, 18 Oct 2018 11:13:03 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_moves_file_within_project_folder.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_moves_file_within_project_folder.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,42 +21,39 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:38:31 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:40:48 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:38:31 GMT
+  recorded_at: Thu, 18 Oct 2018 09:40:48 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -66,7 +63,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -78,49 +75,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:38:31 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:40:48 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:38:31 GMT
+  recorded_at: Thu, 18 Oct 2018 09:40:48 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        21:38:31 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:40:48 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -129,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:38:31 GMT
+      - Thu, 18 Oct 2018 09:40:48 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -146,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:38:32 GMT
+      - Thu, 18 Oct 2018 09:40:48 GMT
       Vary:
       - Origin
       - X-Origin
@@ -163,28 +157,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1MkZf1kVbSvlg3_LjN4xGhWyZGuKF28WK",
-         "name": "Test @ 2018-03-18 21:38:31 UTC",
+         "id": "1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J",
+         "name": "Test @ 2018-10-18 09:40:48 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AEIi2L68pCuiUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:38:32 GMT
+  recorded_at: Thu, 18 Oct 2018 09:40:49 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1MkZf1kVbSvlg3_LjN4xGhWyZGuKF28WK/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -196,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:38:32 GMT
+      - Thu, 18 Oct 2018 09:40:49 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -213,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:38:33 GMT
+      - Thu, 18 Oct 2018 09:40:49 GMT
       Vary:
       - Origin
       - X-Origin
@@ -230,8 +234,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -244,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:38:33 GMT
+  recorded_at: Thu, 18 Oct 2018 09:40:49 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -259,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:38:33 GMT
+      - Thu, 18 Oct 2018 09:40:49 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -270,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:38:33 GMT
+      - Thu, 18 Oct 2018 09:40:49 GMT
       Date:
-      - Sun, 18 Mar 2018 21:38:33 GMT
+      - Thu, 18 Oct 2018 09:40:49 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -291,8 +294,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -300,16 +302,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "7203"
+         "startPageToken": "9380"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:38:33 GMT
+  recorded_at: Thu, 18 Oct 2018 09:40:50 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1MkZf1kVbSvlg3_LjN4xGhWyZGuKF28WK"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -318,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:38:33 GMT
+      - Thu, 18 Oct 2018 09:40:50 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -335,7 +337,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:38:34 GMT
+      - Thu, 18 Oct 2018 09:40:50 GMT
       Vary:
       - Origin
       - X-Origin
@@ -352,32 +354,51 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1TsVcrc7la-bNj_qQyW6_OILVYM3_7XKx",
+         "id": "1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj",
          "name": "Folder",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1MkZf1kVbSvlg3_LjN4xGhWyZGuKF28WK"
+          "1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:38:34 GMT
+  recorded_at: Thu, 18 Oct 2018 09:40:50 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.document","name":"File To
-        Move","parents":["1TsVcrc7la-bNj_qQyW6_OILVYM3_7XKx"]}'
+        Move","parents":["1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -386,7 +407,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:38:34 GMT
+      - Thu, 18 Oct 2018 09:40:50 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -403,7 +424,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:38:35 GMT
+      - Thu, 18 Oct 2018 09:40:51 GMT
       Vary:
       - Origin
       - X-Origin
@@ -420,28 +441,47 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1vraf6GsXTP17RUWxL8DIYQF9v9-iKRt0gYN3AUWzhDg",
+         "id": "1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1TsVcrc7la-bNj_qQyW6_OILVYM3_7XKx"
+          "1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:38:35 GMT
+  recorded_at: Thu, 18 Oct 2018 09:40:51 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1MkZf1kVbSvlg3_LjN4xGhWyZGuKF28WK?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -453,7 +493,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:38:35 GMT
+      - Thu, 18 Oct 2018 09:40:51 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -464,9 +504,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:38:35 GMT
+      - Thu, 18 Oct 2018 09:40:51 GMT
       Date:
-      - Sun, 18 Mar 2018 21:38:35 GMT
+      - Thu, 18 Oct 2018 09:40:51 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -485,25 +525,44 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1MkZf1kVbSvlg3_LjN4xGhWyZGuKF28WK",
-         "name": "Test @ 2018-03-18 21:38:31 UTC",
+         "id": "1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J",
+         "name": "Test @ 2018-10-18 09:40:48 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:38:35 GMT
+  recorded_at: Thu, 18 Oct 2018 09:40:51 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1MkZf1kVbSvlg3_LjN4xGhWyZGuKF28WK/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -515,7 +574,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:38:35 GMT
+      - Thu, 18 Oct 2018 09:40:51 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -533,9 +592,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:38:35 GMT
+      - Thu, 18 Oct 2018 09:40:51 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:38:35 GMT
+      - Thu, 18 Oct 2018 09:40:51 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -547,8 +606,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -568,10 +626,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:38:35 GMT
+  recorded_at: Thu, 18 Oct 2018 09:40:52 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271MkZf1kVbSvlg3_LjN4xGhWyZGuKF28WK%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -583,7 +641,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:38:35 GMT
+      - Thu, 18 Oct 2018 09:40:52 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -594,9 +652,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:38:35 GMT
+      - Thu, 18 Oct 2018 09:40:52 GMT
       Date:
-      - Sun, 18 Mar 2018 21:38:35 GMT
+      - Thu, 18 Oct 2018 09:40:52 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -615,8 +673,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -625,22 +682,42 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1TsVcrc7la-bNj_qQyW6_OILVYM3_7XKx",
+           "id": "1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj",
            "name": "Folder",
            "mimeType": "application/vnd.google-apps.folder",
            "trashed": false,
            "parents": [
-            "1MkZf1kVbSvlg3_LjN4xGhWyZGuKF28WK"
+            "1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J"
            ],
-           "thumbnailVersion": "0"
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "writer",
+             "displayName": "Upshift One",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "13193959451567607887",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+             "role": "owner",
+             "displayName": "Testuser Upshift One",
+             "deleted": false
+            }
+           ]
           }
          ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:38:35 GMT
+  recorded_at: Thu, 18 Oct 2018 09:40:52 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1TsVcrc7la-bNj_qQyW6_OILVYM3_7XKx/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -652,7 +729,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:38:35 GMT
+      - Thu, 18 Oct 2018 09:40:52 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -670,9 +747,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:38:35 GMT
+      - Thu, 18 Oct 2018 09:40:52 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:38:35 GMT
+      - Thu, 18 Oct 2018 09:40:52 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -684,8 +761,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -705,10 +781,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:38:35 GMT
+  recorded_at: Thu, 18 Oct 2018 09:40:52 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271TsVcrc7la-bNj_qQyW6_OILVYM3_7XKx%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -720,7 +796,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:38:35 GMT
+      - Thu, 18 Oct 2018 09:40:52 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -731,9 +807,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:38:36 GMT
+      - Thu, 18 Oct 2018 09:40:52 GMT
       Date:
-      - Sun, 18 Mar 2018 21:38:36 GMT
+      - Thu, 18 Oct 2018 09:40:52 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -752,8 +828,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -762,22 +837,42 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1vraf6GsXTP17RUWxL8DIYQF9v9-iKRt0gYN3AUWzhDg",
+           "id": "1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws",
            "name": "File To Move",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1TsVcrc7la-bNj_qQyW6_OILVYM3_7XKx"
+            "1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj"
            ],
-           "thumbnailVersion": "0"
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "writer",
+             "displayName": "Upshift One",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "13193959451567607887",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+             "role": "owner",
+             "displayName": "Testuser Upshift One",
+             "deleted": false
+            }
+           ]
           }
          ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:38:36 GMT
+  recorded_at: Thu, 18 Oct 2018 09:40:52 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1vraf6GsXTP17RUWxL8DIYQF9v9-iKRt0gYN3AUWzhDg/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -789,144 +884,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:38:36 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sun, 18 Mar 2018 21:38:36 GMT
-      Expires:
-      - Sun, 18 Mar 2018 21:38:36 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "notFound",
-            "message": "Revision not found: head.",
-            "locationType": "parameter",
-            "location": "revisionId"
-           }
-          ],
-          "code": 404,
-          "message": "Revision not found: head."
-         }
-        }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:38:36 GMT
-- request:
-    method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1vraf6GsXTP17RUWxL8DIYQF9v9-iKRt0gYN3AUWzhDg?addParents=1MkZf1kVbSvlg3_LjN4xGhWyZGuKF28WK&fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion&removeParents=1TsVcrc7la-bNj_qQyW6_OILVYM3_7XKx
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sun, 18 Mar 2018 21:38:36 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:38:36 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1vraf6GsXTP17RUWxL8DIYQF9v9-iKRt0gYN3AUWzhDg",
-         "name": "File To Move",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1MkZf1kVbSvlg3_LjN4xGhWyZGuKF28WK"
-         ],
-         "thumbnailVersion": "0"
-        }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:38:37 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=7203
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sun, 18 Mar 2018 21:39:37 GMT
+      - Thu, 18 Oct 2018 09:40:52 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -937,9 +895,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:39:37 GMT
+      - Thu, 18 Oct 2018 09:40:52 GMT
       Date:
-      - Sun, 18 Mar 2018 21:39:37 GMT
+      - Thu, 18 Oct 2018 09:40:52 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -958,276 +916,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "newStartPageToken": "7208",
-         "changes": [
-          {
-           "fileId": "1TsVcrc7la-bNj_qQyW6_OILVYM3_7XKx"
-          },
-          {
-           "fileId": "1vraf6GsXTP17RUWxL8DIYQF9v9-iKRt0gYN3AUWzhDg"
-          },
-          {
-           "fileId": "1MkZf1kVbSvlg3_LjN4xGhWyZGuKF28WK"
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:39:37 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1TsVcrc7la-bNj_qQyW6_OILVYM3_7XKx?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sun, 18 Mar 2018 21:39:37 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sun, 18 Mar 2018 21:39:37 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:39:37 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1TsVcrc7la-bNj_qQyW6_OILVYM3_7XKx",
-         "name": "Folder",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "1MkZf1kVbSvlg3_LjN4xGhWyZGuKF28WK"
-         ],
-         "thumbnailVersion": "0"
-        }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:39:37 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1TsVcrc7la-bNj_qQyW6_OILVYM3_7XKx/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sun, 18 Mar 2018 21:39:37 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sun, 18 Mar 2018 21:39:37 GMT
-      Expires:
-      - Sun, 18 Mar 2018 21:39:37 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:39:38 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1vraf6GsXTP17RUWxL8DIYQF9v9-iKRt0gYN3AUWzhDg?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sun, 18 Mar 2018 21:39:38 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sun, 18 Mar 2018 21:39:38 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:39:38 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1vraf6GsXTP17RUWxL8DIYQF9v9-iKRt0gYN3AUWzhDg",
-         "name": "File To Move",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1MkZf1kVbSvlg3_LjN4xGhWyZGuKF28WK"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1vraf6GsXTP17RUWxL8DIYQF9v9-iKRt0gYN3AUWzhDg&v=1&s=AMedNnoAAAAAWq74uj6d02MVpUIqKkZVTaZlHTb1DI8-&sz=s220",
-         "thumbnailVersion": "1"
-        }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:39:38 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1vraf6GsXTP17RUWxL8DIYQF9v9-iKRt0gYN3AUWzhDg/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sun, 18 Mar 2018 21:39:38 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sun, 18 Mar 2018 21:39:38 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:39:38 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -1237,13 +926,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-03-18T21:38:34.599Z"
+         "modifiedTime": "2018-10-18T09:40:50.846Z"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:39:38 GMT
+  recorded_at: Thu, 18 Oct 2018 09:40:52 GMT
 - request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1vraf6GsXTP17RUWxL8DIYQF9v9-iKRt0gYN3AUWzhDg&s=AMedNnoAAAAAWq74uj6d02MVpUIqKkZVTaZlHTb1DI8-&sz=s350&v=1
+    method: patch
+    uri: https://www.googleapis.com/drive/v3/files/1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws?addParents=1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj
     body:
       encoding: UTF-8
       string: ''
@@ -1255,7 +944,457 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:39:38 GMT
+      - Thu, 18 Oct 2018 09:40:52 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 09:40:53 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws",
+         "name": "File To Move",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 09:40:53 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9380
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 09:41:53 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 09:41:53 GMT
+      Date:
+      - Thu, 18 Oct 2018 09:41:53 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "newStartPageToken": "9385",
+         "changes": [
+          {
+           "fileId": "1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj"
+          },
+          {
+           "fileId": "1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws"
+          },
+          {
+           "fileId": "1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J"
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 09:41:53 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 09:41:53 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 09:41:53 GMT
+      Date:
+      - Thu, 18 Oct 2018 09:41:53 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj",
+         "name": "Folder",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 09:41:54 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 09:41:54 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 09:41:54 GMT
+      Expires:
+      - Thu, 18 Oct 2018 09:41:54 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 09:41:54 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 09:41:54 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 09:41:54 GMT
+      Date:
+      - Thu, 18 Oct 2018 09:41:54 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws",
+         "name": "File To Move",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws&v=1&s=AMedNnoAAAAAW8hxgl6O9MGRm-LELRJax41B-gM97bzU&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 09:41:54 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 09:41:54 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 09:41:54 GMT
+      Date:
+      - Thu, 18 Oct 2018 09:41:54 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-18T09:40:50.846Z"
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 09:41:54 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws&s=AMedNnoAAAAAW8hxgl6O9MGRm-LELRJax41B-gM97bzU&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 09:41:54 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1286,7 +1425,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Sun, 18 Mar 2018 21:39:38 GMT
+      - Thu, 18 Oct 2018 09:41:54 GMT
       Server:
       - fife
       Content-Length:
@@ -1294,17 +1433,16 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:39:38 GMT
+  recorded_at: Thu, 18 Oct 2018 09:41:54 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1MkZf1kVbSvlg3_LjN4xGhWyZGuKF28WK?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1316,7 +1454,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:39:38 GMT
+      - Thu, 18 Oct 2018 09:41:54 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1327,9 +1465,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:39:38 GMT
+      - Thu, 18 Oct 2018 09:41:55 GMT
       Date:
-      - Sun, 18 Mar 2018 21:39:38 GMT
+      - Thu, 18 Oct 2018 09:41:55 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1348,25 +1486,44 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1MkZf1kVbSvlg3_LjN4xGhWyZGuKF28WK",
-         "name": "Test @ 2018-03-18 21:38:31 UTC",
+         "id": "1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J",
+         "name": "Test @ 2018-10-18 09:40:48 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:39:38 GMT
+  recorded_at: Thu, 18 Oct 2018 09:41:55 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1MkZf1kVbSvlg3_LjN4xGhWyZGuKF28WK/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1378,7 +1535,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:39:38 GMT
+      - Thu, 18 Oct 2018 09:41:55 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1396,9 +1553,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:39:39 GMT
+      - Thu, 18 Oct 2018 09:41:55 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:39:39 GMT
+      - Thu, 18 Oct 2018 09:41:55 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1410,8 +1567,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -1431,10 +1587,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:39:39 GMT
+  recorded_at: Thu, 18 Oct 2018 09:41:55 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1MkZf1kVbSvlg3_LjN4xGhWyZGuKF28WK
+    uri: https://www.googleapis.com/drive/v3/files/1CrxzNe47EAUPKUK73_2sa6DaJ9dKwg4J
     body:
       encoding: UTF-8
       string: ''
@@ -1446,7 +1602,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:39:39 GMT
+      - Thu, 18 Oct 2018 09:41:55 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1463,18 +1619,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:39:40 GMT
+      - Thu, 18 Oct 2018 09:41:56 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:39:40 GMT
+  recorded_at: Thu, 18 Oct 2018 09:41:56 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_moves_file_within_project_folder.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_moves_file_within_project_folder.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 11:11:50 GMT
+      - Sun, 21 Oct 2018 16:19:04 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:11:50 GMT
+  recorded_at: Sun, 21 Oct 2018 16:19:04 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 11:11:50 GMT
+      - Sun, 21 Oct 2018 16:19:04 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:11:50 GMT
+  recorded_at: Sun, 21 Oct 2018 16:19:04 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        11:11:50 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-21
+        16:19:04 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:11:50 GMT
+      - Sun, 21 Oct 2018 16:19:04 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:11:50 GMT
+      - Sun, 21 Oct 2018 16:19:04 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN",
-         "name": "Test @ 2018-10-18 11:11:50 UTC",
+         "id": "1yzkZv75Lp_DIgSkkD1oiPoHreWwrJMWd",
+         "name": "Test @ 2018-10-21 16:19:04 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:11:50 GMT
+  recorded_at: Sun, 21 Oct 2018 16:19:04 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1yzkZv75Lp_DIgSkkD1oiPoHreWwrJMWd/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:11:50 GMT
+      - Sun, 21 Oct 2018 16:19:04 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:11:51 GMT
+      - Sun, 21 Oct 2018 16:19:05 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:11:51 GMT
+  recorded_at: Sun, 21 Oct 2018 16:19:05 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:11:51 GMT
+      - Sun, 21 Oct 2018 16:19:05 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:11:51 GMT
+      - Sun, 21 Oct 2018 16:19:05 GMT
       Date:
-      - Thu, 18 Oct 2018 11:11:51 GMT
+      - Sun, 21 Oct 2018 16:19:05 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,16 +302,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "9555"
+         "startPageToken": "10843"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:11:51 GMT
+  recorded_at: Sun, 21 Oct 2018 16:19:05 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1yzkZv75Lp_DIgSkkD1oiPoHreWwrJMWd"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -320,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:11:51 GMT
+      - Sun, 21 Oct 2018 16:19:05 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -337,7 +337,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:11:52 GMT
+      - Sun, 21 Oct 2018 16:19:06 GMT
       Vary:
       - Origin
       - X-Origin
@@ -361,12 +361,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu",
+         "id": "1bsMcsThzyi8MFgxfo0dROvHk2J1Qbwoe",
          "name": "Folder",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN"
+          "1yzkZv75Lp_DIgSkkD1oiPoHreWwrJMWd"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -391,14 +391,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:11:52 GMT
+  recorded_at: Sun, 21 Oct 2018 16:19:06 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.document","name":"File To
-        Move","parents":["1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu"]}'
+        Move","parents":["1bsMcsThzyi8MFgxfo0dROvHk2J1Qbwoe"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -407,7 +407,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:11:52 GMT
+      - Sun, 21 Oct 2018 16:19:06 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -424,7 +424,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:11:54 GMT
+      - Sun, 21 Oct 2018 16:19:08 GMT
       Vary:
       - Origin
       - X-Origin
@@ -448,12 +448,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM",
+         "id": "1daVaNJwynsvOmKc4XGQEKzTyoXcMh7e1-ZlEg5EIvHg",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu"
+          "1bsMcsThzyi8MFgxfo0dROvHk2J1Qbwoe"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -478,13 +478,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:11:54 GMT
+  recorded_at: Sun, 21 Oct 2018 16:19:08 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"9 RW6 (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"5 Starship
+        Titanic (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -493,7 +494,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:11:54 GMT
+      - Sun, 21 Oct 2018 16:19:08 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -510,7 +511,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:11:54 GMT
+      - Sun, 21 Oct 2018 16:19:08 GMT
       Vary:
       - Origin
       - X-Origin
@@ -534,8 +535,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1eOPdp6aPJ3BIq5eQ1xP_3IBNE6Tgdi46",
-         "name": "9 RW6 (Archive)",
+         "id": "14KXEHMUvtph5b778Vtl1un4sDpiSOo_Z",
+         "name": "5 Starship Titanic (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -555,10 +556,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:11:54 GMT
+  recorded_at: Sun, 21 Oct 2018 16:19:08 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1eOPdp6aPJ3BIq5eQ1xP_3IBNE6Tgdi46/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/14KXEHMUvtph5b778Vtl1un4sDpiSOo_Z/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -570,7 +571,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:11:54 GMT
+      - Sun, 21 Oct 2018 16:19:08 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -587,7 +588,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:11:55 GMT
+      - Sun, 21 Oct 2018 16:19:09 GMT
       Vary:
       - Origin
       - X-Origin
@@ -617,10 +618,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:11:55 GMT
+  recorded_at: Sun, 21 Oct 2018 16:19:09 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1eOPdp6aPJ3BIq5eQ1xP_3IBNE6Tgdi46?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/14KXEHMUvtph5b778Vtl1un4sDpiSOo_Z?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -632,7 +633,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:11:55 GMT
+      - Sun, 21 Oct 2018 16:19:09 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -643,9 +644,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:11:55 GMT
+      - Sun, 21 Oct 2018 16:19:09 GMT
       Date:
-      - Thu, 18 Oct 2018 11:11:55 GMT
+      - Sun, 21 Oct 2018 16:19:09 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -671,8 +672,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1eOPdp6aPJ3BIq5eQ1xP_3IBNE6Tgdi46",
-         "name": "9 RW6 (Archive)",
+         "id": "14KXEHMUvtph5b778Vtl1un4sDpiSOo_Z",
+         "name": "5 Starship Titanic (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -701,10 +702,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:11:55 GMT
+  recorded_at: Sun, 21 Oct 2018 16:19:09 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1eOPdp6aPJ3BIq5eQ1xP_3IBNE6Tgdi46/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/14KXEHMUvtph5b778Vtl1un4sDpiSOo_Z/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -716,7 +717,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:11:55 GMT
+      - Sun, 21 Oct 2018 16:19:09 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -734,9 +735,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:11:55 GMT
+      - Sun, 21 Oct 2018 16:19:09 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:11:55 GMT
+      - Sun, 21 Oct 2018 16:19:09 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -768,10 +769,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:11:55 GMT
+  recorded_at: Sun, 21 Oct 2018 16:19:09 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1yzkZv75Lp_DIgSkkD1oiPoHreWwrJMWd?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -783,7 +784,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:11:55 GMT
+      - Sun, 21 Oct 2018 16:19:09 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -794,9 +795,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:11:56 GMT
+      - Sun, 21 Oct 2018 16:19:09 GMT
       Date:
-      - Thu, 18 Oct 2018 11:11:56 GMT
+      - Sun, 21 Oct 2018 16:19:09 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -822,8 +823,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN",
-         "name": "Test @ 2018-10-18 11:11:50 UTC",
+         "id": "1yzkZv75Lp_DIgSkkD1oiPoHreWwrJMWd",
+         "name": "Test @ 2018-10-21 16:19:04 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -849,10 +850,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:11:56 GMT
+  recorded_at: Sun, 21 Oct 2018 16:19:10 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1yzkZv75Lp_DIgSkkD1oiPoHreWwrJMWd/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -864,7 +865,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:11:56 GMT
+      - Sun, 21 Oct 2018 16:19:10 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -882,9 +883,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:11:56 GMT
+      - Sun, 21 Oct 2018 16:19:10 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:11:56 GMT
+      - Sun, 21 Oct 2018 16:19:10 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -916,10 +917,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:11:56 GMT
+  recorded_at: Sun, 21 Oct 2018 16:19:10 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271yzkZv75Lp_DIgSkkD1oiPoHreWwrJMWd%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -931,7 +932,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:11:56 GMT
+      - Sun, 21 Oct 2018 16:19:10 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -942,9 +943,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:11:57 GMT
+      - Sun, 21 Oct 2018 16:19:10 GMT
       Date:
-      - Thu, 18 Oct 2018 11:11:57 GMT
+      - Sun, 21 Oct 2018 16:19:10 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -972,12 +973,12 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu",
+           "id": "1bsMcsThzyi8MFgxfo0dROvHk2J1Qbwoe",
            "name": "Folder",
            "mimeType": "application/vnd.google-apps.folder",
            "trashed": false,
            "parents": [
-            "1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN"
+            "1yzkZv75Lp_DIgSkkD1oiPoHreWwrJMWd"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -1004,10 +1005,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:11:57 GMT
+  recorded_at: Sun, 21 Oct 2018 16:19:10 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1bsMcsThzyi8MFgxfo0dROvHk2J1Qbwoe/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1019,7 +1020,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:11:57 GMT
+      - Sun, 21 Oct 2018 16:19:10 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1037,9 +1038,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:11:57 GMT
+      - Sun, 21 Oct 2018 16:19:10 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:11:57 GMT
+      - Sun, 21 Oct 2018 16:19:10 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1071,10 +1072,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:11:57 GMT
+  recorded_at: Sun, 21 Oct 2018 16:19:10 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271bsMcsThzyi8MFgxfo0dROvHk2J1Qbwoe%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -1086,7 +1087,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:11:57 GMT
+      - Sun, 21 Oct 2018 16:19:10 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1097,9 +1098,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:11:59 GMT
+      - Sun, 21 Oct 2018 16:19:11 GMT
       Date:
-      - Thu, 18 Oct 2018 11:11:59 GMT
+      - Sun, 21 Oct 2018 16:19:11 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1127,14 +1128,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM",
+           "id": "1daVaNJwynsvOmKc4XGQEKzTyoXcMh7e1-ZlEg5EIvHg",
            "name": "File To Move",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu"
+            "1bsMcsThzyi8MFgxfo0dROvHk2J1Qbwoe"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM&v=1&s=AMedNnoAAAAAW8iGn_lakt0q-cXyiJZpZpWm5q4bYjJ_&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1daVaNJwynsvOmKc4XGQEKzTyoXcMh7e1-ZlEg5EIvHg&v=1&s=AMedNnoAAAAAW8zDHywjoJXjRINpyk6KxKX3mpX-92l3&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -1160,10 +1161,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:11:59 GMT
+  recorded_at: Sun, 21 Oct 2018 16:19:11 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1daVaNJwynsvOmKc4XGQEKzTyoXcMh7e1-ZlEg5EIvHg/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1175,7 +1176,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:11:59 GMT
+      - Sun, 21 Oct 2018 16:19:11 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1186,9 +1187,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:11:59 GMT
+      - Sun, 21 Oct 2018 16:19:11 GMT
       Date:
-      - Thu, 18 Oct 2018 11:11:59 GMT
+      - Sun, 21 Oct 2018 16:19:11 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1217,13 +1218,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T11:11:53.198Z"
+         "modifiedTime": "2018-10-21T16:19:07.084Z"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:11:59 GMT
+  recorded_at: Sun, 21 Oct 2018 16:19:11 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM&s=AMedNnoAAAAAW8iGn_lakt0q-cXyiJZpZpWm5q4bYjJ_&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1daVaNJwynsvOmKc4XGQEKzTyoXcMh7e1-ZlEg5EIvHg&s=AMedNnoAAAAAW8zDHywjoJXjRINpyk6KxKX3mpX-92l3&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1235,7 +1236,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:11:59 GMT
+      - Sun, 21 Oct 2018 16:19:11 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1266,7 +1267,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 18 Oct 2018 11:11:59 GMT
+      - Sun, 21 Oct 2018 16:19:11 GMT
       Server:
       - fife
       Content-Length:
@@ -1280,13 +1281,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:11:59 GMT
+  recorded_at: Sun, 21 Oct 2018 16:19:11 GMT
 - request:
-    method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM?addParents=1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1daVaNJwynsvOmKc4XGQEKzTyoXcMh7e1-ZlEg5EIvHg/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: ''
+      string: '{"name":"File To Move","parents":["14KXEHMUvtph5b778Vtl1un4sDpiSOo_Z"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1295,11 +1296,11 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:11:59 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+      - Sun, 21 Oct 2018 16:19:11 GMT
       Content-Type:
-      - application/x-www-form-urlencoded
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
   response:
     status:
       code: 200
@@ -1312,7 +1313,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:12:00 GMT
+      - Sun, 21 Oct 2018 16:19:13 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1336,14 +1337,100 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM",
+         "id": "1bNQm03xVRxfAPzTzhTeW5EQ-E8FHJMaJALqg95gV6E0",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN"
+          "14KXEHMUvtph5b778Vtl1un4sDpiSOo_Z"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM&v=1&s=AMedNnoAAAAAW8iGoJt-__9dC1vTK5cqNcm3a14OlVrK&sz=s220",
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:19:13 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/drive/v3/files/1daVaNJwynsvOmKc4XGQEKzTyoXcMh7e1-ZlEg5EIvHg?addParents=1yzkZv75Lp_DIgSkkD1oiPoHreWwrJMWd&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1bsMcsThzyi8MFgxfo0dROvHk2J1Qbwoe
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:19:13 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:19:14 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1daVaNJwynsvOmKc4XGQEKzTyoXcMh7e1-ZlEg5EIvHg",
+         "name": "File To Move",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1yzkZv75Lp_DIgSkkD1oiPoHreWwrJMWd"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1daVaNJwynsvOmKc4XGQEKzTyoXcMh7e1-ZlEg5EIvHg&v=1&s=AMedNnoAAAAAW8zDIrLQFu2Foqyh0W19u8vd9HnccSLy&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -1367,10 +1454,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:12:00 GMT
+  recorded_at: Sun, 21 Oct 2018 16:19:14 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9555
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=10843
     body:
       encoding: UTF-8
       string: ''
@@ -1382,7 +1469,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:13:00 GMT
+      - Sun, 21 Oct 2018 16:20:14 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1393,9 +1480,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:13:00 GMT
+      - Sun, 21 Oct 2018 16:20:14 GMT
       Date:
-      - Thu, 18 Oct 2018 11:13:00 GMT
+      - Sun, 21 Oct 2018 16:20:14 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1421,27 +1508,30 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "9563",
+         "newStartPageToken": "10854",
          "changes": [
           {
-           "fileId": "1eOPdp6aPJ3BIq5eQ1xP_3IBNE6Tgdi46"
+           "fileId": "14KXEHMUvtph5b778Vtl1un4sDpiSOo_Z"
           },
           {
-           "fileId": "1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu"
+           "fileId": "1bNQm03xVRxfAPzTzhTeW5EQ-E8FHJMaJALqg95gV6E0"
           },
           {
-           "fileId": "1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM"
+           "fileId": "1bsMcsThzyi8MFgxfo0dROvHk2J1Qbwoe"
           },
           {
-           "fileId": "1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN"
+           "fileId": "1daVaNJwynsvOmKc4XGQEKzTyoXcMh7e1-ZlEg5EIvHg"
+          },
+          {
+           "fileId": "1yzkZv75Lp_DIgSkkD1oiPoHreWwrJMWd"
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:13:00 GMT
+  recorded_at: Sun, 21 Oct 2018 16:20:14 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1eOPdp6aPJ3BIq5eQ1xP_3IBNE6Tgdi46?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/14KXEHMUvtph5b778Vtl1un4sDpiSOo_Z?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1453,7 +1543,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:13:00 GMT
+      - Sun, 21 Oct 2018 16:20:14 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1464,9 +1554,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:13:01 GMT
+      - Sun, 21 Oct 2018 16:20:14 GMT
       Date:
-      - Thu, 18 Oct 2018 11:13:01 GMT
+      - Sun, 21 Oct 2018 16:20:14 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1492,8 +1582,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1eOPdp6aPJ3BIq5eQ1xP_3IBNE6Tgdi46",
-         "name": "9 RW6 (Archive)",
+         "id": "14KXEHMUvtph5b778Vtl1un4sDpiSOo_Z",
+         "name": "5 Starship Titanic (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -1522,10 +1612,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:13:01 GMT
+  recorded_at: Sun, 21 Oct 2018 16:20:14 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1eOPdp6aPJ3BIq5eQ1xP_3IBNE6Tgdi46/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/14KXEHMUvtph5b778Vtl1un4sDpiSOo_Z/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1537,7 +1627,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:13:01 GMT
+      - Sun, 21 Oct 2018 16:20:14 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1555,9 +1645,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:13:01 GMT
+      - Sun, 21 Oct 2018 16:20:14 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:13:01 GMT
+      - Sun, 21 Oct 2018 16:20:14 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1589,10 +1679,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:13:01 GMT
+  recorded_at: Sun, 21 Oct 2018 16:20:14 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1bNQm03xVRxfAPzTzhTeW5EQ-E8FHJMaJALqg95gV6E0?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1604,7 +1694,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:13:01 GMT
+      - Sun, 21 Oct 2018 16:20:14 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1615,9 +1705,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:13:01 GMT
+      - Sun, 21 Oct 2018 16:20:14 GMT
       Date:
-      - Thu, 18 Oct 2018 11:13:01 GMT
+      - Sun, 21 Oct 2018 16:20:14 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1643,192 +1733,41 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu",
-         "name": "Folder",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:13:01 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1IPnBJOfnKYth5f5EBMOWmV2rBmz9GNhu/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:13:01 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 18 Oct 2018 11:13:01 GMT
-      Expires:
-      - Thu, 18 Oct 2018 11:13:01 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:13:01 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:13:01 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Thu, 18 Oct 2018 11:13:01 GMT
-      Date:
-      - Thu, 18 Oct 2018 11:13:01 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM",
+         "id": "1bNQm03xVRxfAPzTzhTeW5EQ-E8FHJMaJALqg95gV6E0",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN"
+          "14KXEHMUvtph5b778Vtl1un4sDpiSOo_Z"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM&v=1&s=AMedNnoAAAAAW8iG3akAyZIZTYVFcvW0krTMMOhImJNH&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1bNQm03xVRxfAPzTzhTeW5EQ-E8FHJMaJALqg95gV6E0&v=1&s=AMedNnoAAAAAW8zDXvQT5wYbNXF4oYEwN-EaYfLISLDQ&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
           {
            "kind": "drive#permission",
            "id": "13193959451567607887",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
+           "role": "reader",
            "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
            "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:13:01 GMT
+  recorded_at: Sun, 21 Oct 2018 16:20:14 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1vTxuFbytJulnOtiQP9_Zy7Gz1ugtVliMmEgZnjrU0nM/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1bNQm03xVRxfAPzTzhTeW5EQ-E8FHJMaJALqg95gV6E0/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1840,7 +1779,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:13:01 GMT
+      - Sun, 21 Oct 2018 16:20:15 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1851,9 +1790,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:13:01 GMT
+      - Sun, 21 Oct 2018 16:20:15 GMT
       Date:
-      - Thu, 18 Oct 2018 11:13:01 GMT
+      - Sun, 21 Oct 2018 16:20:15 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1882,13 +1821,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T11:11:53.198Z"
+         "modifiedTime": "2018-10-21T16:19:12.435Z"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:13:01 GMT
+  recorded_at: Sun, 21 Oct 2018 16:20:15 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1bNQm03xVRxfAPzTzhTeW5EQ-E8FHJMaJALqg95gV6E0&s=AMedNnoAAAAAW8zDXvQT5wYbNXF4oYEwN-EaYfLISLDQ&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1900,7 +1839,67 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:13:01 GMT
+      - Sun, 21 Oct 2018 16:20:15 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sun, 21 Oct 2018 16:20:15 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:20:15 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1bsMcsThzyi8MFgxfo0dROvHk2J1Qbwoe?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:20:15 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1911,9 +1910,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:13:02 GMT
+      - Sun, 21 Oct 2018 16:20:15 GMT
       Date:
-      - Thu, 18 Oct 2018 11:13:02 GMT
+      - Sun, 21 Oct 2018 16:20:15 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1939,10 +1938,13 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN",
-         "name": "Test @ 2018-10-18 11:11:50 UTC",
+         "id": "1bsMcsThzyi8MFgxfo0dROvHk2J1Qbwoe",
+         "name": "Folder",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
+         "parents": [
+          "1yzkZv75Lp_DIgSkkD1oiPoHreWwrJMWd"
+         ],
          "thumbnailVersion": "0",
          "permissions": [
           {
@@ -1966,10 +1968,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:13:02 GMT
+  recorded_at: Sun, 21 Oct 2018 16:20:15 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1bsMcsThzyi8MFgxfo0dROvHk2J1Qbwoe/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1981,7 +1983,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:13:02 GMT
+      - Sun, 21 Oct 2018 16:20:15 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1999,9 +2001,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:13:02 GMT
+      - Sun, 21 Oct 2018 16:20:15 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:13:02 GMT
+      - Sun, 21 Oct 2018 16:20:15 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -2033,10 +2035,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:13:02 GMT
+  recorded_at: Sun, 21 Oct 2018 16:20:15 GMT
 - request:
-    method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1g_uyv3t-_kbO-eKO0cTI-mYmXir-FxZN
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1daVaNJwynsvOmKc4XGQEKzTyoXcMh7e1-ZlEg5EIvHg?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -2048,7 +2050,386 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:13:02 GMT
+      - Sun, 21 Oct 2018 16:20:15 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 21 Oct 2018 16:20:16 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:20:16 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1daVaNJwynsvOmKc4XGQEKzTyoXcMh7e1-ZlEg5EIvHg",
+         "name": "File To Move",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1yzkZv75Lp_DIgSkkD1oiPoHreWwrJMWd"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1daVaNJwynsvOmKc4XGQEKzTyoXcMh7e1-ZlEg5EIvHg&v=1&s=AMedNnoAAAAAW8zDYC2tiEdCjDSJDmKDlJ5GXB3LYF5E&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:20:16 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1daVaNJwynsvOmKc4XGQEKzTyoXcMh7e1-ZlEg5EIvHg/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:20:16 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 21 Oct 2018 16:20:16 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:20:16 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-21T16:19:07.084Z"
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:20:16 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1daVaNJwynsvOmKc4XGQEKzTyoXcMh7e1-ZlEg5EIvHg/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"File To Move","parents":["14KXEHMUvtph5b778Vtl1un4sDpiSOo_Z"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:20:16 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:20:18 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1Mjb1iM9PpOiMpWKdXTEKQDMSBO4el2W-l05rz7befLI",
+         "name": "File To Move",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "14KXEHMUvtph5b778Vtl1un4sDpiSOo_Z"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:20:18 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1yzkZv75Lp_DIgSkkD1oiPoHreWwrJMWd?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:20:18 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 21 Oct 2018 16:20:19 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:20:19 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1yzkZv75Lp_DIgSkkD1oiPoHreWwrJMWd",
+         "name": "Test @ 2018-10-21 16:19:04 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:20:19 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1yzkZv75Lp_DIgSkkD1oiPoHreWwrJMWd/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:20:19 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Sun, 21 Oct 2018 16:20:19 GMT
+      Expires:
+      - Sun, 21 Oct 2018 16:20:19 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:20:19 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1yzkZv75Lp_DIgSkkD1oiPoHreWwrJMWd
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:20:19 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -2065,7 +2446,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:13:03 GMT
+      - Sun, 21 Oct 2018 16:20:20 GMT
       Vary:
       - Origin
       - X-Origin
@@ -2077,5 +2458,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:13:03 GMT
+  recorded_at: Sun, 21 Oct 2018 16:20:20 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_renames_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_renames_file.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,42 +21,39 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:29:29 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:38:36 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:29:29 GMT
+  recorded_at: Thu, 18 Oct 2018 09:38:36 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -66,7 +63,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -78,49 +75,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:29:29 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:38:36 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:29:29 GMT
+  recorded_at: Thu, 18 Oct 2018 09:38:36 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        21:29:29 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:38:36 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -129,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:29:29 GMT
+      - Thu, 18 Oct 2018 09:38:36 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -146,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:29:30 GMT
+      - Thu, 18 Oct 2018 09:38:36 GMT
       Vary:
       - Origin
       - X-Origin
@@ -163,28 +157,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1aWBMHiCtTsJbksTfNRd1qZECO73J9SdW",
-         "name": "Test @ 2018-03-18 21:29:29 UTC",
+         "id": "1pDmrjP_emwrQta8m26PSiNomfZ8q83JG",
+         "name": "Test @ 2018-10-18 09:38:36 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AEIi2L68pCuiUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:29:30 GMT
+  recorded_at: Thu, 18 Oct 2018 09:38:36 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1aWBMHiCtTsJbksTfNRd1qZECO73J9SdW/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1pDmrjP_emwrQta8m26PSiNomfZ8q83JG/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -196,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:29:30 GMT
+      - Thu, 18 Oct 2018 09:38:36 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -213,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:29:31 GMT
+      - Thu, 18 Oct 2018 09:38:37 GMT
       Vary:
       - Origin
       - X-Origin
@@ -230,8 +234,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -244,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:29:31 GMT
+  recorded_at: Thu, 18 Oct 2018 09:38:37 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -259,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:29:31 GMT
+      - Thu, 18 Oct 2018 09:38:37 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -270,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:29:31 GMT
+      - Thu, 18 Oct 2018 09:38:37 GMT
       Date:
-      - Sun, 18 Mar 2018 21:29:31 GMT
+      - Thu, 18 Oct 2018 09:38:37 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -291,8 +294,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -300,16 +302,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "7159"
+         "startPageToken": "9370"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:29:31 GMT
+  recorded_at: Thu, 18 Oct 2018 09:38:37 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1aWBMHiCtTsJbksTfNRd1qZECO73J9SdW"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1pDmrjP_emwrQta8m26PSiNomfZ8q83JG"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -318,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:29:31 GMT
+      - Thu, 18 Oct 2018 09:38:37 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -335,7 +337,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:29:32 GMT
+      - Thu, 18 Oct 2018 09:38:38 GMT
       Vary:
       - Origin
       - X-Origin
@@ -352,28 +354,47 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1r2PdAoVVnogkIrwstIlcvYqzrbX_f0VaNNuZdn62soQ",
+         "id": "1Vw5GhCLptwLWO8woKvEUGwGQk8AsuXNMcjUSKMNhyfw",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1aWBMHiCtTsJbksTfNRd1qZECO73J9SdW"
+          "1pDmrjP_emwrQta8m26PSiNomfZ8q83JG"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:29:32 GMT
+  recorded_at: Thu, 18 Oct 2018 09:38:39 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1aWBMHiCtTsJbksTfNRd1qZECO73J9SdW?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1pDmrjP_emwrQta8m26PSiNomfZ8q83JG?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -385,7 +406,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:29:32 GMT
+      - Thu, 18 Oct 2018 09:38:39 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -396,9 +417,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:29:32 GMT
+      - Thu, 18 Oct 2018 09:38:39 GMT
       Date:
-      - Sun, 18 Mar 2018 21:29:32 GMT
+      - Thu, 18 Oct 2018 09:38:39 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -417,25 +438,44 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1aWBMHiCtTsJbksTfNRd1qZECO73J9SdW",
-         "name": "Test @ 2018-03-18 21:29:29 UTC",
+         "id": "1pDmrjP_emwrQta8m26PSiNomfZ8q83JG",
+         "name": "Test @ 2018-10-18 09:38:36 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:29:32 GMT
+  recorded_at: Thu, 18 Oct 2018 09:38:39 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1aWBMHiCtTsJbksTfNRd1qZECO73J9SdW/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1pDmrjP_emwrQta8m26PSiNomfZ8q83JG/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -447,7 +487,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:29:32 GMT
+      - Thu, 18 Oct 2018 09:38:39 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -465,9 +505,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:29:33 GMT
+      - Thu, 18 Oct 2018 09:38:39 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:29:33 GMT
+      - Thu, 18 Oct 2018 09:38:39 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -479,8 +519,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -500,10 +539,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:29:33 GMT
+  recorded_at: Thu, 18 Oct 2018 09:38:39 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271aWBMHiCtTsJbksTfNRd1qZECO73J9SdW%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271pDmrjP_emwrQta8m26PSiNomfZ8q83JG%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -515,7 +554,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:29:33 GMT
+      - Thu, 18 Oct 2018 09:38:39 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -526,9 +565,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:29:33 GMT
+      - Thu, 18 Oct 2018 09:38:39 GMT
       Date:
-      - Sun, 18 Mar 2018 21:29:33 GMT
+      - Thu, 18 Oct 2018 09:38:39 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -547,8 +586,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -557,22 +595,42 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1r2PdAoVVnogkIrwstIlcvYqzrbX_f0VaNNuZdn62soQ",
+           "id": "1Vw5GhCLptwLWO8woKvEUGwGQk8AsuXNMcjUSKMNhyfw",
            "name": "File",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1aWBMHiCtTsJbksTfNRd1qZECO73J9SdW"
+            "1pDmrjP_emwrQta8m26PSiNomfZ8q83JG"
            ],
-           "thumbnailVersion": "0"
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "writer",
+             "displayName": "Upshift One",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "13193959451567607887",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+             "role": "owner",
+             "displayName": "Testuser Upshift One",
+             "deleted": false
+            }
+           ]
           }
          ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:29:33 GMT
+  recorded_at: Thu, 18 Oct 2018 09:38:39 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1r2PdAoVVnogkIrwstIlcvYqzrbX_f0VaNNuZdn62soQ/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1Vw5GhCLptwLWO8woKvEUGwGQk8AsuXNMcjUSKMNhyfw/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -584,16 +642,22 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:29:33 GMT
+      - Thu, 18 Oct 2018 09:38:39 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
       - application/x-www-form-urlencoded
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 200
+      message: OK
     headers:
+      Expires:
+      - Thu, 18 Oct 2018 09:38:39 GMT
+      Date:
+      - Thu, 18 Oct 2018 09:38:39 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
       Vary:
       - Origin
       - X-Origin
@@ -601,12 +665,6 @@ http_interactions:
       - application/json; charset=UTF-8
       Content-Encoding:
       - gzip
-      Date:
-      - Sun, 18 Mar 2018 21:29:33 GMT
-      Expires:
-      - Sun, 18 Mar 2018 21:29:33 GMT
-      Cache-Control:
-      - private, max-age=0
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -616,33 +674,23 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "notFound",
-            "message": "Revision not found: head.",
-            "locationType": "parameter",
-            "location": "revisionId"
-           }
-          ],
-          "code": 404,
-          "message": "Revision not found: head."
-         }
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-18T09:38:37.964Z"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:29:33 GMT
+  recorded_at: Thu, 18 Oct 2018 09:38:39 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1r2PdAoVVnogkIrwstIlcvYqzrbX_f0VaNNuZdn62soQ?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1Vw5GhCLptwLWO8woKvEUGwGQk8AsuXNMcjUSKMNhyfw?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"name":"New File Name"}'
@@ -654,7 +702,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:29:33 GMT
+      - Thu, 18 Oct 2018 09:38:39 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -671,7 +719,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:29:34 GMT
+      - Thu, 18 Oct 2018 09:38:40 GMT
       Vary:
       - Origin
       - X-Origin
@@ -688,94 +736,47 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1r2PdAoVVnogkIrwstIlcvYqzrbX_f0VaNNuZdn62soQ",
+         "id": "1Vw5GhCLptwLWO8woKvEUGwGQk8AsuXNMcjUSKMNhyfw",
          "name": "New File Name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1aWBMHiCtTsJbksTfNRd1qZECO73J9SdW"
+          "1pDmrjP_emwrQta8m26PSiNomfZ8q83JG"
          ],
-         "thumbnailVersion": "0"
-        }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:29:34 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=7159
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sun, 18 Mar 2018 21:30:34 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sun, 18 Mar 2018 21:30:34 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:30:34 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "newStartPageToken": "7162",
-         "changes": [
+         "thumbnailVersion": "0",
+         "permissions": [
           {
-           "fileId": "1aWBMHiCtTsJbksTfNRd1qZECO73J9SdW"
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
           },
           {
-           "fileId": "1r2PdAoVVnogkIrwstIlcvYqzrbX_f0VaNNuZdn62soQ"
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:30:34 GMT
+  recorded_at: Thu, 18 Oct 2018 09:38:40 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1aWBMHiCtTsJbksTfNRd1qZECO73J9SdW?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9370
     body:
       encoding: UTF-8
       string: ''
@@ -787,7 +788,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:30:34 GMT
+      - Thu, 18 Oct 2018 09:39:40 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -798,9 +799,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:30:34 GMT
+      - Thu, 18 Oct 2018 09:39:40 GMT
       Date:
-      - Sun, 18 Mar 2018 21:30:34 GMT
+      - Thu, 18 Oct 2018 09:39:40 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -819,25 +820,28 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1aWBMHiCtTsJbksTfNRd1qZECO73J9SdW",
-         "name": "Test @ 2018-03-18 21:29:29 UTC",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "thumbnailVersion": "0"
+         "newStartPageToken": "9373",
+         "changes": [
+          {
+           "fileId": "1pDmrjP_emwrQta8m26PSiNomfZ8q83JG"
+          },
+          {
+           "fileId": "1Vw5GhCLptwLWO8woKvEUGwGQk8AsuXNMcjUSKMNhyfw"
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:30:34 GMT
+  recorded_at: Thu, 18 Oct 2018 09:39:40 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1aWBMHiCtTsJbksTfNRd1qZECO73J9SdW/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1pDmrjP_emwrQta8m26PSiNomfZ8q83JG?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -849,7 +853,88 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:30:34 GMT
+      - Thu, 18 Oct 2018 09:39:40 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 09:39:41 GMT
+      Date:
+      - Thu, 18 Oct 2018 09:39:41 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1pDmrjP_emwrQta8m26PSiNomfZ8q83JG",
+         "name": "Test @ 2018-10-18 09:38:36 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 09:39:41 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1pDmrjP_emwrQta8m26PSiNomfZ8q83JG/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 09:39:41 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -867,9 +952,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:30:34 GMT
+      - Thu, 18 Oct 2018 09:39:41 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:30:34 GMT
+      - Thu, 18 Oct 2018 09:39:41 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -881,8 +966,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -902,10 +986,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:30:34 GMT
+  recorded_at: Thu, 18 Oct 2018 09:39:41 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1r2PdAoVVnogkIrwstIlcvYqzrbX_f0VaNNuZdn62soQ?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1Vw5GhCLptwLWO8woKvEUGwGQk8AsuXNMcjUSKMNhyfw?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -917,7 +1001,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:30:34 GMT
+      - Thu, 18 Oct 2018 09:39:41 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -928,9 +1012,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:30:34 GMT
+      - Thu, 18 Oct 2018 09:39:41 GMT
       Date:
-      - Sun, 18 Mar 2018 21:30:34 GMT
+      - Thu, 18 Oct 2018 09:39:41 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -949,29 +1033,48 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1r2PdAoVVnogkIrwstIlcvYqzrbX_f0VaNNuZdn62soQ",
+         "id": "1Vw5GhCLptwLWO8woKvEUGwGQk8AsuXNMcjUSKMNhyfw",
          "name": "New File Name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1aWBMHiCtTsJbksTfNRd1qZECO73J9SdW"
+          "1pDmrjP_emwrQta8m26PSiNomfZ8q83JG"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1r2PdAoVVnogkIrwstIlcvYqzrbX_f0VaNNuZdn62soQ&v=1&s=AMedNnoAAAAAWq72mlUN4g3MCycyxa_y7J1l8gdLAyAt&sz=s220",
-         "thumbnailVersion": "1"
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Vw5GhCLptwLWO8woKvEUGwGQk8AsuXNMcjUSKMNhyfw&v=1&s=AMedNnoAAAAAW8hw_VdfFfDkmw_y6oub4oXO4E-hiWtB&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:30:34 GMT
+  recorded_at: Thu, 18 Oct 2018 09:39:41 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1r2PdAoVVnogkIrwstIlcvYqzrbX_f0VaNNuZdn62soQ/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1Vw5GhCLptwLWO8woKvEUGwGQk8AsuXNMcjUSKMNhyfw/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -983,7 +1086,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:30:34 GMT
+      - Thu, 18 Oct 2018 09:39:41 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -994,9 +1097,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:30:35 GMT
+      - Thu, 18 Oct 2018 09:39:41 GMT
       Date:
-      - Sun, 18 Mar 2018 21:30:35 GMT
+      - Thu, 18 Oct 2018 09:39:41 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1015,8 +1118,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -1026,13 +1128,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-03-18T21:29:31.883Z"
+         "modifiedTime": "2018-10-18T09:38:37.964Z"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:30:35 GMT
+  recorded_at: Thu, 18 Oct 2018 09:39:41 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1r2PdAoVVnogkIrwstIlcvYqzrbX_f0VaNNuZdn62soQ&s=AMedNnoAAAAAWq72mlUN4g3MCycyxa_y7J1l8gdLAyAt&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1Vw5GhCLptwLWO8woKvEUGwGQk8AsuXNMcjUSKMNhyfw&s=AMedNnoAAAAAW8hw_VdfFfDkmw_y6oub4oXO4E-hiWtB&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1044,7 +1146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:30:35 GMT
+      - Thu, 18 Oct 2018 09:39:41 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1075,7 +1177,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Sun, 18 Mar 2018 21:30:35 GMT
+      - Thu, 18 Oct 2018 09:39:41 GMT
       Server:
       - fife
       Content-Length:
@@ -1083,17 +1185,16 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:30:35 GMT
+  recorded_at: Thu, 18 Oct 2018 09:39:41 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1aWBMHiCtTsJbksTfNRd1qZECO73J9SdW
+    uri: https://www.googleapis.com/drive/v3/files/1pDmrjP_emwrQta8m26PSiNomfZ8q83JG
     body:
       encoding: UTF-8
       string: ''
@@ -1105,7 +1206,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:30:35 GMT
+      - Thu, 18 Oct 2018 09:39:42 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1122,18 +1223,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:30:36 GMT
+      - Thu, 18 Oct 2018 09:39:42 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:30:36 GMT
+  recorded_at: Thu, 18 Oct 2018 09:39:42 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_renames_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_renames_file.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 11:04:57 GMT
+      - Sun, 21 Oct 2018 16:15:09 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:04:57 GMT
+  recorded_at: Sun, 21 Oct 2018 16:15:09 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 11:04:57 GMT
+      - Sun, 21 Oct 2018 16:15:09 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:04:57 GMT
+  recorded_at: Sun, 21 Oct 2018 16:15:09 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        11:04:57 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-21
+        16:15:09 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:04:57 GMT
+      - Sun, 21 Oct 2018 16:15:09 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:04:58 GMT
+      - Sun, 21 Oct 2018 16:15:10 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm",
-         "name": "Test @ 2018-10-18 11:04:57 UTC",
+         "id": "1ie0T_xcjXS8UyErIYEXWX22LCSAYByNb",
+         "name": "Test @ 2018-10-21 16:15:09 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:04:58 GMT
+  recorded_at: Sun, 21 Oct 2018 16:15:10 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1ie0T_xcjXS8UyErIYEXWX22LCSAYByNb/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:04:58 GMT
+      - Sun, 21 Oct 2018 16:15:10 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:04:59 GMT
+      - Sun, 21 Oct 2018 16:15:11 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:04:59 GMT
+  recorded_at: Sun, 21 Oct 2018 16:15:11 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:04:59 GMT
+      - Sun, 21 Oct 2018 16:15:11 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:04:59 GMT
+      - Sun, 21 Oct 2018 16:15:11 GMT
       Date:
-      - Thu, 18 Oct 2018 11:04:59 GMT
+      - Sun, 21 Oct 2018 16:15:11 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,16 +302,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "9509"
+         "startPageToken": "10825"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:04:59 GMT
+  recorded_at: Sun, 21 Oct 2018 16:15:11 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1ie0T_xcjXS8UyErIYEXWX22LCSAYByNb"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -320,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:04:59 GMT
+      - Sun, 21 Oct 2018 16:15:12 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -337,7 +337,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:05:00 GMT
+      - Sun, 21 Oct 2018 16:15:13 GMT
       Vary:
       - Origin
       - X-Origin
@@ -361,12 +361,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM",
+         "id": "1LeAbkQGBNoYfWQE2hWgVllpEDOutH4RCZru9K_IKYRw",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm"
+          "1ie0T_xcjXS8UyErIYEXWX22LCSAYByNb"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -391,14 +391,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:05:00 GMT
+  recorded_at: Sun, 21 Oct 2018 16:15:13 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"3 Golgafrinchan
-        Ark Fleet Ship B (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"1 Heart of
+        Gold (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -407,7 +407,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:05:00 GMT
+      - Sun, 21 Oct 2018 16:15:13 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -424,7 +424,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:05:01 GMT
+      - Sun, 21 Oct 2018 16:15:14 GMT
       Vary:
       - Origin
       - X-Origin
@@ -448,8 +448,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1kEst22_0nNwF7ev-lD1bZX1ZhYpzS7pn",
-         "name": "3 Golgafrinchan Ark Fleet Ship B (Archive)",
+         "id": "1NmcwznKIXENLr5QVaHxtS3loTbuBDZgu",
+         "name": "1 Heart of Gold (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -469,10 +469,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:05:01 GMT
+  recorded_at: Sun, 21 Oct 2018 16:15:14 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1kEst22_0nNwF7ev-lD1bZX1ZhYpzS7pn/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1NmcwznKIXENLr5QVaHxtS3loTbuBDZgu/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -484,7 +484,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:05:01 GMT
+      - Sun, 21 Oct 2018 16:15:14 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -501,7 +501,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:05:02 GMT
+      - Sun, 21 Oct 2018 16:15:15 GMT
       Vary:
       - Origin
       - X-Origin
@@ -531,10 +531,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:05:02 GMT
+  recorded_at: Sun, 21 Oct 2018 16:15:15 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1kEst22_0nNwF7ev-lD1bZX1ZhYpzS7pn?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1NmcwznKIXENLr5QVaHxtS3loTbuBDZgu?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -546,7 +546,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:05:02 GMT
+      - Sun, 21 Oct 2018 16:15:15 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -557,9 +557,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:05:02 GMT
+      - Sun, 21 Oct 2018 16:15:15 GMT
       Date:
-      - Thu, 18 Oct 2018 11:05:02 GMT
+      - Sun, 21 Oct 2018 16:15:15 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -585,8 +585,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1kEst22_0nNwF7ev-lD1bZX1ZhYpzS7pn",
-         "name": "3 Golgafrinchan Ark Fleet Ship B (Archive)",
+         "id": "1NmcwznKIXENLr5QVaHxtS3loTbuBDZgu",
+         "name": "1 Heart of Gold (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -615,10 +615,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:05:02 GMT
+  recorded_at: Sun, 21 Oct 2018 16:15:15 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1kEst22_0nNwF7ev-lD1bZX1ZhYpzS7pn/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1NmcwznKIXENLr5QVaHxtS3loTbuBDZgu/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -630,7 +630,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:05:02 GMT
+      - Sun, 21 Oct 2018 16:15:15 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -648,9 +648,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:05:02 GMT
+      - Sun, 21 Oct 2018 16:15:15 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:05:02 GMT
+      - Sun, 21 Oct 2018 16:15:15 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -682,10 +682,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:05:02 GMT
+  recorded_at: Sun, 21 Oct 2018 16:15:15 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ie0T_xcjXS8UyErIYEXWX22LCSAYByNb?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -697,7 +697,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:05:02 GMT
+      - Sun, 21 Oct 2018 16:15:15 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -708,9 +708,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:05:02 GMT
+      - Sun, 21 Oct 2018 16:15:16 GMT
       Date:
-      - Thu, 18 Oct 2018 11:05:02 GMT
+      - Sun, 21 Oct 2018 16:15:16 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -736,8 +736,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm",
-         "name": "Test @ 2018-10-18 11:04:57 UTC",
+         "id": "1ie0T_xcjXS8UyErIYEXWX22LCSAYByNb",
+         "name": "Test @ 2018-10-21 16:15:09 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -763,10 +763,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:05:02 GMT
+  recorded_at: Sun, 21 Oct 2018 16:15:16 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1ie0T_xcjXS8UyErIYEXWX22LCSAYByNb/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -778,7 +778,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:05:02 GMT
+      - Sun, 21 Oct 2018 16:15:16 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -796,9 +796,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:05:02 GMT
+      - Sun, 21 Oct 2018 16:15:16 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:05:02 GMT
+      - Sun, 21 Oct 2018 16:15:16 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -830,10 +830,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:05:02 GMT
+  recorded_at: Sun, 21 Oct 2018 16:15:16 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271ie0T_xcjXS8UyErIYEXWX22LCSAYByNb%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -845,7 +845,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:05:02 GMT
+      - Sun, 21 Oct 2018 16:15:16 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -856,9 +856,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:05:02 GMT
+      - Sun, 21 Oct 2018 16:15:16 GMT
       Date:
-      - Thu, 18 Oct 2018 11:05:02 GMT
+      - Sun, 21 Oct 2018 16:15:16 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -886,14 +886,15 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM",
+           "id": "1LeAbkQGBNoYfWQE2hWgVllpEDOutH4RCZru9K_IKYRw",
            "name": "File",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm"
+            "1ie0T_xcjXS8UyErIYEXWX22LCSAYByNb"
            ],
-           "thumbnailVersion": "0",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1LeAbkQGBNoYfWQE2hWgVllpEDOutH4RCZru9K_IKYRw&v=1&s=AMedNnoAAAAAW8zCNFZNpsh93fyoNB3eo5_rZDU8FcGT&sz=s220",
+           "thumbnailVersion": "1",
            "permissions": [
             {
              "kind": "drive#permission",
@@ -918,10 +919,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:05:02 GMT
+  recorded_at: Sun, 21 Oct 2018 16:15:16 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1LeAbkQGBNoYfWQE2hWgVllpEDOutH4RCZru9K_IKYRw/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -933,7 +934,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:05:02 GMT
+      - Sun, 21 Oct 2018 16:15:16 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -944,9 +945,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:05:03 GMT
+      - Sun, 21 Oct 2018 16:15:16 GMT
       Date:
-      - Thu, 18 Oct 2018 11:05:03 GMT
+      - Sun, 21 Oct 2018 16:15:16 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -975,99 +976,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T11:04:59.778Z"
+         "modifiedTime": "2018-10-21T16:15:13.066Z"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:05:03 GMT
-- request:
-    method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: '{"name":"New File Name"}'
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:05:03 GMT
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Thu, 18 Oct 2018 11:05:03 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM",
-         "name": "New File Name",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:05:03 GMT
+  recorded_at: Sun, 21 Oct 2018 16:15:16 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9509
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1LeAbkQGBNoYfWQE2hWgVllpEDOutH4RCZru9K_IKYRw&s=AMedNnoAAAAAW8zCNFZNpsh93fyoNB3eo5_rZDU8FcGT&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1079,519 +994,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:06:03 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Thu, 18 Oct 2018 11:06:03 GMT
-      Date:
-      - Thu, 18 Oct 2018 11:06:03 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "newStartPageToken": "9515",
-         "changes": [
-          {
-           "fileId": "1kEst22_0nNwF7ev-lD1bZX1ZhYpzS7pn"
-          },
-          {
-           "fileId": "1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm"
-          },
-          {
-           "fileId": "1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM"
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:06:03 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1kEst22_0nNwF7ev-lD1bZX1ZhYpzS7pn?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:06:04 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Thu, 18 Oct 2018 11:06:04 GMT
-      Date:
-      - Thu, 18 Oct 2018 11:06:04 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1kEst22_0nNwF7ev-lD1bZX1ZhYpzS7pn",
-         "name": "3 Golgafrinchan Ark Fleet Ship B (Archive)",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:06:04 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1kEst22_0nNwF7ev-lD1bZX1ZhYpzS7pn/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:06:04 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 18 Oct 2018 11:06:04 GMT
-      Expires:
-      - Thu, 18 Oct 2018 11:06:04 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:06:04 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:06:04 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Thu, 18 Oct 2018 11:06:04 GMT
-      Date:
-      - Thu, 18 Oct 2018 11:06:04 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm",
-         "name": "Test @ 2018-10-18 11:04:57 UTC",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:06:04 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:06:04 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 18 Oct 2018 11:06:04 GMT
-      Expires:
-      - Thu, 18 Oct 2018 11:06:04 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:06:04 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:06:04 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Thu, 18 Oct 2018 11:06:04 GMT
-      Date:
-      - Thu, 18 Oct 2018 11:06:04 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM",
-         "name": "New File Name",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM&v=1&s=AMedNnoAAAAAW8iFPEVByGayxBZM8ryvtuMX6cTFJSYZ&sz=s220",
-         "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:06:04 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:06:04 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Thu, 18 Oct 2018 11:06:04 GMT
-      Date:
-      - Thu, 18 Oct 2018 11:06:04 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "kind": "drive#revision",
-         "id": "1",
-         "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T11:04:59.778Z"
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:06:04 GMT
-- request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM&s=AMedNnoAAAAAW8iFPEVByGayxBZM8ryvtuMX6cTFJSYZ&sz=s350&v=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:06:04 GMT
+      - Sun, 21 Oct 2018 16:15:16 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1622,7 +1025,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 18 Oct 2018 11:06:05 GMT
+      - Sun, 21 Oct 2018 16:15:16 GMT
       Server:
       - fife
       Content-Length:
@@ -1636,10 +1039,183 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:06:05 GMT
+  recorded_at: Sun, 21 Oct 2018 16:15:16 GMT
 - request:
-    method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1LeAbkQGBNoYfWQE2hWgVllpEDOutH4RCZru9K_IKYRw/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"File","parents":["1NmcwznKIXENLr5QVaHxtS3loTbuBDZgu"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:15:17 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:15:18 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1s8fCqN_0oZZ1n5D4ElzC1sBgup5R-SbHwpLAR5ApeJk",
+         "name": "File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1NmcwznKIXENLr5QVaHxtS3loTbuBDZgu"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:15:18 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/drive/v3/files/1LeAbkQGBNoYfWQE2hWgVllpEDOutH4RCZru9K_IKYRw?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"New File Name"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:15:19 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:15:19 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1LeAbkQGBNoYfWQE2hWgVllpEDOutH4RCZru9K_IKYRw",
+         "name": "New File Name",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1ie0T_xcjXS8UyErIYEXWX22LCSAYByNb"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1LeAbkQGBNoYfWQE2hWgVllpEDOutH4RCZru9K_IKYRw&v=2&s=AMedNnoAAAAAW8zCN47MDRLCm7W2ZzA-ebl6MAx86ADF&sz=s220",
+         "thumbnailVersion": "2",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:15:19 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=10825
     body:
       encoding: UTF-8
       string: ''
@@ -1651,7 +1227,1042 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:06:05 GMT
+      - Sun, 21 Oct 2018 16:16:19 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 21 Oct 2018 16:16:19 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:16:19 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "newStartPageToken": "10834",
+         "changes": [
+          {
+           "fileId": "1NmcwznKIXENLr5QVaHxtS3loTbuBDZgu"
+          },
+          {
+           "fileId": "1s8fCqN_0oZZ1n5D4ElzC1sBgup5R-SbHwpLAR5ApeJk"
+          },
+          {
+           "fileId": "1ie0T_xcjXS8UyErIYEXWX22LCSAYByNb"
+          },
+          {
+           "fileId": "1LeAbkQGBNoYfWQE2hWgVllpEDOutH4RCZru9K_IKYRw"
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:16:19 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1NmcwznKIXENLr5QVaHxtS3loTbuBDZgu?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:16:19 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 21 Oct 2018 16:16:20 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:16:20 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1NmcwznKIXENLr5QVaHxtS3loTbuBDZgu",
+         "name": "1 Heart of Gold (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:16:20 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1NmcwznKIXENLr5QVaHxtS3loTbuBDZgu/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:16:20 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Sun, 21 Oct 2018 16:16:20 GMT
+      Expires:
+      - Sun, 21 Oct 2018 16:16:20 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:16:20 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1s8fCqN_0oZZ1n5D4ElzC1sBgup5R-SbHwpLAR5ApeJk?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:16:20 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 21 Oct 2018 16:16:20 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:16:20 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1s8fCqN_0oZZ1n5D4ElzC1sBgup5R-SbHwpLAR5ApeJk",
+         "name": "File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1NmcwznKIXENLr5QVaHxtS3loTbuBDZgu"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1s8fCqN_0oZZ1n5D4ElzC1sBgup5R-SbHwpLAR5ApeJk&v=1&s=AMedNnoAAAAAW8zCdOu-gJM7DMy0o5x1NuVKM2o8MoNw&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:16:20 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1s8fCqN_0oZZ1n5D4ElzC1sBgup5R-SbHwpLAR5ApeJk/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:16:20 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 21 Oct 2018 16:16:20 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:16:20 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-21T16:15:18.026Z"
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:16:20 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1s8fCqN_0oZZ1n5D4ElzC1sBgup5R-SbHwpLAR5ApeJk&s=AMedNnoAAAAAW8zCdOu-gJM7DMy0o5x1NuVKM2o8MoNw&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:16:20 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sun, 21 Oct 2018 16:16:20 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:16:20 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1ie0T_xcjXS8UyErIYEXWX22LCSAYByNb?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:16:20 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 21 Oct 2018 16:16:20 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:16:20 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1ie0T_xcjXS8UyErIYEXWX22LCSAYByNb",
+         "name": "Test @ 2018-10-21 16:15:09 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:16:21 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1ie0T_xcjXS8UyErIYEXWX22LCSAYByNb/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:16:21 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Sun, 21 Oct 2018 16:16:21 GMT
+      Expires:
+      - Sun, 21 Oct 2018 16:16:21 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:16:21 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1LeAbkQGBNoYfWQE2hWgVllpEDOutH4RCZru9K_IKYRw?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:16:21 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 21 Oct 2018 16:16:21 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:16:21 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1LeAbkQGBNoYfWQE2hWgVllpEDOutH4RCZru9K_IKYRw",
+         "name": "New File Name",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1ie0T_xcjXS8UyErIYEXWX22LCSAYByNb"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1LeAbkQGBNoYfWQE2hWgVllpEDOutH4RCZru9K_IKYRw&v=2&s=AMedNnoAAAAAW8zCdYE0Q4mucRHaeROziXG0i25K2cCj&sz=s220",
+         "thumbnailVersion": "2",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:16:21 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1LeAbkQGBNoYfWQE2hWgVllpEDOutH4RCZru9K_IKYRw/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:16:21 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 21 Oct 2018 16:16:21 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:16:21 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-21T16:15:13.066Z"
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:16:21 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1LeAbkQGBNoYfWQE2hWgVllpEDOutH4RCZru9K_IKYRw&s=AMedNnoAAAAAW8zCdYE0Q4mucRHaeROziXG0i25K2cCj&sz=s350&v=2
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:16:21 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v2"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sun, 21 Oct 2018 16:16:21 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:16:21 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1LeAbkQGBNoYfWQE2hWgVllpEDOutH4RCZru9K_IKYRw/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"New File Name","parents":["1NmcwznKIXENLr5QVaHxtS3loTbuBDZgu"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:16:21 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:16:23 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "18Un2d6fcWhssUpadEvSMcZ_kXLWfvFFjcIgmbr_SDgo",
+         "name": "New File Name",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1NmcwznKIXENLr5QVaHxtS3loTbuBDZgu"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:16:23 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/18Un2d6fcWhssUpadEvSMcZ_kXLWfvFFjcIgmbr_SDgo?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:16:24 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 21 Oct 2018 16:16:24 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:16:24 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "18Un2d6fcWhssUpadEvSMcZ_kXLWfvFFjcIgmbr_SDgo",
+         "name": "New File Name",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1NmcwznKIXENLr5QVaHxtS3loTbuBDZgu"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:16:24 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1s8fCqN_0oZZ1n5D4ElzC1sBgup5R-SbHwpLAR5ApeJk?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:16:24 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 21 Oct 2018 16:16:24 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:16:24 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1s8fCqN_0oZZ1n5D4ElzC1sBgup5R-SbHwpLAR5ApeJk",
+         "name": "File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1NmcwznKIXENLr5QVaHxtS3loTbuBDZgu"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1s8fCqN_0oZZ1n5D4ElzC1sBgup5R-SbHwpLAR5ApeJk&v=1&s=AMedNnoAAAAAW8zCeMOsH1ZNaoYm72aFGAcjRuvN1Y8K&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:16:24 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1ie0T_xcjXS8UyErIYEXWX22LCSAYByNb
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:16:24 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1668,7 +2279,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:06:05 GMT
+      - Sun, 21 Oct 2018 16:16:24 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1680,5 +2291,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:06:06 GMT
+  recorded_at: Sun, 21 Oct 2018 16:16:24 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_renames_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_renames_file.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:38:36 GMT
+      - Thu, 18 Oct 2018 11:04:57 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:38:36 GMT
+  recorded_at: Thu, 18 Oct 2018 11:04:57 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:38:36 GMT
+      - Thu, 18 Oct 2018 11:04:57 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:38:36 GMT
+  recorded_at: Thu, 18 Oct 2018 11:04:57 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        09:38:36 UTC","parents":["root"]}'
+        11:04:57 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:38:36 GMT
+      - Thu, 18 Oct 2018 11:04:57 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:38:36 GMT
+      - Thu, 18 Oct 2018 11:04:58 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1pDmrjP_emwrQta8m26PSiNomfZ8q83JG",
-         "name": "Test @ 2018-10-18 09:38:36 UTC",
+         "id": "1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm",
+         "name": "Test @ 2018-10-18 11:04:57 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:38:36 GMT
+  recorded_at: Thu, 18 Oct 2018 11:04:58 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1pDmrjP_emwrQta8m26PSiNomfZ8q83JG/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:38:36 GMT
+      - Thu, 18 Oct 2018 11:04:58 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:38:37 GMT
+      - Thu, 18 Oct 2018 11:04:59 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:38:37 GMT
+  recorded_at: Thu, 18 Oct 2018 11:04:59 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:38:37 GMT
+      - Thu, 18 Oct 2018 11:04:59 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:38:37 GMT
+      - Thu, 18 Oct 2018 11:04:59 GMT
       Date:
-      - Thu, 18 Oct 2018 09:38:37 GMT
+      - Thu, 18 Oct 2018 11:04:59 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,16 +302,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "9370"
+         "startPageToken": "9509"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:38:37 GMT
+  recorded_at: Thu, 18 Oct 2018 11:04:59 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1pDmrjP_emwrQta8m26PSiNomfZ8q83JG"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -320,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:38:37 GMT
+      - Thu, 18 Oct 2018 11:04:59 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -337,7 +337,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:38:38 GMT
+      - Thu, 18 Oct 2018 11:05:00 GMT
       Vary:
       - Origin
       - X-Origin
@@ -361,12 +361,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1Vw5GhCLptwLWO8woKvEUGwGQk8AsuXNMcjUSKMNhyfw",
+         "id": "1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1pDmrjP_emwrQta8m26PSiNomfZ8q83JG"
+          "1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -391,10 +391,150 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:38:39 GMT
+  recorded_at: Thu, 18 Oct 2018 11:05:00 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"3 Golgafrinchan
+        Ark Fleet Ship B (Archive)","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:05:00 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:05:01 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1kEst22_0nNwF7ev-lD1bZX1ZhYpzS7pn",
+         "name": "3 Golgafrinchan Ark Fleet Ship B (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:05:01 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1kEst22_0nNwF7ev-lD1bZX1ZhYpzS7pn/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:05:01 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:05:02 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "13193959451567607887",
+         "type": "user",
+         "role": "reader"
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:05:02 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1pDmrjP_emwrQta8m26PSiNomfZ8q83JG?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1kEst22_0nNwF7ev-lD1bZX1ZhYpzS7pn?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -406,7 +546,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:38:39 GMT
+      - Thu, 18 Oct 2018 11:05:02 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -417,9 +557,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:38:39 GMT
+      - Thu, 18 Oct 2018 11:05:02 GMT
       Date:
-      - Thu, 18 Oct 2018 09:38:39 GMT
+      - Thu, 18 Oct 2018 11:05:02 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -445,37 +585,40 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1pDmrjP_emwrQta8m26PSiNomfZ8q83JG",
-         "name": "Test @ 2018-10-18 09:38:36 UTC",
+         "id": "1kEst22_0nNwF7ev-lD1bZX1ZhYpzS7pn",
+         "name": "3 Golgafrinchan Ark Fleet Ship B (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
          "thumbnailVersion": "0",
          "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
           {
            "kind": "drive#permission",
            "id": "13193959451567607887",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
+           "role": "reader",
            "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
            "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:38:39 GMT
+  recorded_at: Thu, 18 Oct 2018 11:05:02 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1pDmrjP_emwrQta8m26PSiNomfZ8q83JG/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1kEst22_0nNwF7ev-lD1bZX1ZhYpzS7pn/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -487,7 +630,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:38:39 GMT
+      - Thu, 18 Oct 2018 11:05:02 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -505,9 +648,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:38:39 GMT
+      - Thu, 18 Oct 2018 11:05:02 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:38:39 GMT
+      - Thu, 18 Oct 2018 11:05:02 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -539,10 +682,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:38:39 GMT
+  recorded_at: Thu, 18 Oct 2018 11:05:02 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271pDmrjP_emwrQta8m26PSiNomfZ8q83JG%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files/1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -554,7 +697,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:38:39 GMT
+      - Thu, 18 Oct 2018 11:05:02 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -565,9 +708,157 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:38:39 GMT
+      - Thu, 18 Oct 2018 11:05:02 GMT
       Date:
-      - Thu, 18 Oct 2018 09:38:39 GMT
+      - Thu, 18 Oct 2018 11:05:02 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm",
+         "name": "Test @ 2018-10-18 11:04:57 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:05:02 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:05:02 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:05:02 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:05:02 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:05:02 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:05:02 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:05:02 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:05:02 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -595,12 +886,12 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1Vw5GhCLptwLWO8woKvEUGwGQk8AsuXNMcjUSKMNhyfw",
+           "id": "1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM",
            "name": "File",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1pDmrjP_emwrQta8m26PSiNomfZ8q83JG"
+            "1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -627,10 +918,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:38:39 GMT
+  recorded_at: Thu, 18 Oct 2018 11:05:02 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Vw5GhCLptwLWO8woKvEUGwGQk8AsuXNMcjUSKMNhyfw/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -642,7 +933,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:38:39 GMT
+      - Thu, 18 Oct 2018 11:05:02 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -653,9 +944,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:38:39 GMT
+      - Thu, 18 Oct 2018 11:05:03 GMT
       Date:
-      - Thu, 18 Oct 2018 09:38:39 GMT
+      - Thu, 18 Oct 2018 11:05:03 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -684,13 +975,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T09:38:37.964Z"
+         "modifiedTime": "2018-10-18T11:04:59.778Z"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:38:39 GMT
+  recorded_at: Thu, 18 Oct 2018 11:05:03 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1Vw5GhCLptwLWO8woKvEUGwGQk8AsuXNMcjUSKMNhyfw?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"name":"New File Name"}'
@@ -702,7 +993,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:38:39 GMT
+      - Thu, 18 Oct 2018 11:05:03 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -719,7 +1010,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:38:40 GMT
+      - Thu, 18 Oct 2018 11:05:03 GMT
       Vary:
       - Origin
       - X-Origin
@@ -743,12 +1034,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1Vw5GhCLptwLWO8woKvEUGwGQk8AsuXNMcjUSKMNhyfw",
+         "id": "1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM",
          "name": "New File Name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1pDmrjP_emwrQta8m26PSiNomfZ8q83JG"
+          "1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -773,10 +1064,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:38:40 GMT
+  recorded_at: Thu, 18 Oct 2018 11:05:03 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9370
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9509
     body:
       encoding: UTF-8
       string: ''
@@ -788,7 +1079,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:39:40 GMT
+      - Thu, 18 Oct 2018 11:06:03 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -799,9 +1090,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:39:40 GMT
+      - Thu, 18 Oct 2018 11:06:03 GMT
       Date:
-      - Thu, 18 Oct 2018 09:39:40 GMT
+      - Thu, 18 Oct 2018 11:06:03 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -827,21 +1118,24 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "9373",
+         "newStartPageToken": "9515",
          "changes": [
           {
-           "fileId": "1pDmrjP_emwrQta8m26PSiNomfZ8q83JG"
+           "fileId": "1kEst22_0nNwF7ev-lD1bZX1ZhYpzS7pn"
           },
           {
-           "fileId": "1Vw5GhCLptwLWO8woKvEUGwGQk8AsuXNMcjUSKMNhyfw"
+           "fileId": "1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm"
+          },
+          {
+           "fileId": "1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM"
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:39:40 GMT
+  recorded_at: Thu, 18 Oct 2018 11:06:03 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1pDmrjP_emwrQta8m26PSiNomfZ8q83JG?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1kEst22_0nNwF7ev-lD1bZX1ZhYpzS7pn?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -853,7 +1147,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:39:40 GMT
+      - Thu, 18 Oct 2018 11:06:04 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -864,9 +1158,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:39:41 GMT
+      - Thu, 18 Oct 2018 11:06:04 GMT
       Date:
-      - Thu, 18 Oct 2018 09:39:41 GMT
+      - Thu, 18 Oct 2018 11:06:04 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -892,37 +1186,40 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1pDmrjP_emwrQta8m26PSiNomfZ8q83JG",
-         "name": "Test @ 2018-10-18 09:38:36 UTC",
+         "id": "1kEst22_0nNwF7ev-lD1bZX1ZhYpzS7pn",
+         "name": "3 Golgafrinchan Ark Fleet Ship B (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
          "thumbnailVersion": "0",
          "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
           {
            "kind": "drive#permission",
            "id": "13193959451567607887",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
+           "role": "reader",
            "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
            "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:39:41 GMT
+  recorded_at: Thu, 18 Oct 2018 11:06:04 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1pDmrjP_emwrQta8m26PSiNomfZ8q83JG/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1kEst22_0nNwF7ev-lD1bZX1ZhYpzS7pn/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -934,7 +1231,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:39:41 GMT
+      - Thu, 18 Oct 2018 11:06:04 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -952,9 +1249,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:39:41 GMT
+      - Thu, 18 Oct 2018 11:06:04 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:39:41 GMT
+      - Thu, 18 Oct 2018 11:06:04 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -986,10 +1283,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:39:41 GMT
+  recorded_at: Thu, 18 Oct 2018 11:06:04 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Vw5GhCLptwLWO8woKvEUGwGQk8AsuXNMcjUSKMNhyfw?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1001,7 +1298,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:39:41 GMT
+      - Thu, 18 Oct 2018 11:06:04 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1012,9 +1309,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:39:41 GMT
+      - Thu, 18 Oct 2018 11:06:04 GMT
       Date:
-      - Thu, 18 Oct 2018 09:39:41 GMT
+      - Thu, 18 Oct 2018 11:06:04 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1040,14 +1337,162 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1Vw5GhCLptwLWO8woKvEUGwGQk8AsuXNMcjUSKMNhyfw",
+         "id": "1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm",
+         "name": "Test @ 2018-10-18 11:04:57 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:06:04 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:06:04 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:06:04 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:06:04 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:06:04 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:06:04 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:06:04 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:06:04 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM",
          "name": "New File Name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1pDmrjP_emwrQta8m26PSiNomfZ8q83JG"
+          "1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Vw5GhCLptwLWO8woKvEUGwGQk8AsuXNMcjUSKMNhyfw&v=1&s=AMedNnoAAAAAW8hw_VdfFfDkmw_y6oub4oXO4E-hiWtB&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM&v=1&s=AMedNnoAAAAAW8iFPEVByGayxBZM8ryvtuMX6cTFJSYZ&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -1071,10 +1516,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:39:41 GMT
+  recorded_at: Thu, 18 Oct 2018 11:06:04 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Vw5GhCLptwLWO8woKvEUGwGQk8AsuXNMcjUSKMNhyfw/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1086,7 +1531,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:39:41 GMT
+      - Thu, 18 Oct 2018 11:06:04 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1097,9 +1542,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:39:41 GMT
+      - Thu, 18 Oct 2018 11:06:04 GMT
       Date:
-      - Thu, 18 Oct 2018 09:39:41 GMT
+      - Thu, 18 Oct 2018 11:06:04 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1128,13 +1573,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T09:38:37.964Z"
+         "modifiedTime": "2018-10-18T11:04:59.778Z"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:39:41 GMT
+  recorded_at: Thu, 18 Oct 2018 11:06:04 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1Vw5GhCLptwLWO8woKvEUGwGQk8AsuXNMcjUSKMNhyfw&s=AMedNnoAAAAAW8hw_VdfFfDkmw_y6oub4oXO4E-hiWtB&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM&s=AMedNnoAAAAAW8iFPEVByGayxBZM8ryvtuMX6cTFJSYZ&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1146,7 +1591,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:39:41 GMT
+      - Thu, 18 Oct 2018 11:06:04 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1177,7 +1622,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 18 Oct 2018 09:39:41 GMT
+      - Thu, 18 Oct 2018 11:06:05 GMT
       Server:
       - fife
       Content-Length:
@@ -1191,10 +1636,10 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:39:41 GMT
+  recorded_at: Thu, 18 Oct 2018 11:06:05 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1pDmrjP_emwrQta8m26PSiNomfZ8q83JG
+    uri: https://www.googleapis.com/drive/v3/files/1UNAQt_WpaYreMQGDxgiFpTfR5FY04Iqm
     body:
       encoding: UTF-8
       string: ''
@@ -1206,7 +1651,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:39:42 GMT
+      - Thu, 18 Oct 2018 11:06:05 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1223,7 +1668,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:39:42 GMT
+      - Thu, 18 Oct 2018 11:06:05 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1235,5 +1680,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:39:42 GMT
+  recorded_at: Thu, 18 Oct 2018 11:06:06 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_stops_sharing_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_stops_sharing_file.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,42 +21,39 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:28:21 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:33:01 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:28:21 GMT
+  recorded_at: Thu, 18 Oct 2018 09:33:01 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -66,7 +63,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -78,49 +75,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:28:22 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:33:02 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:28:22 GMT
+  recorded_at: Thu, 18 Oct 2018 09:33:02 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        21:28:22 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:33:02 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -129,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:28:22 GMT
+      - Thu, 18 Oct 2018 09:33:02 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -146,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:28:22 GMT
+      - Thu, 18 Oct 2018 09:33:02 GMT
       Vary:
       - Origin
       - X-Origin
@@ -163,28 +157,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1Q868st65J9McWM438PRRTSPo99wwK38S",
-         "name": "Test @ 2018-03-18 21:28:22 UTC",
+         "id": "1r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1",
+         "name": "Test @ 2018-10-18 09:33:02 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AEIi2L68pCuiUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:28:22 GMT
+  recorded_at: Thu, 18 Oct 2018 09:33:02 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1Q868st65J9McWM438PRRTSPo99wwK38S/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -196,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:28:22 GMT
+      - Thu, 18 Oct 2018 09:33:02 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -213,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:28:23 GMT
+      - Thu, 18 Oct 2018 09:33:03 GMT
       Vary:
       - Origin
       - X-Origin
@@ -230,8 +234,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -244,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:28:23 GMT
+  recorded_at: Thu, 18 Oct 2018 09:33:03 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -259,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:28:23 GMT
+      - Thu, 18 Oct 2018 09:33:03 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -270,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:28:24 GMT
+      - Thu, 18 Oct 2018 09:33:03 GMT
       Date:
-      - Sun, 18 Mar 2018 21:28:24 GMT
+      - Thu, 18 Oct 2018 09:33:03 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -291,8 +294,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -300,16 +302,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "7155"
+         "startPageToken": "9342"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:28:24 GMT
+  recorded_at: Thu, 18 Oct 2018 09:33:03 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1Q868st65J9McWM438PRRTSPo99wwK38S"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -318,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:28:24 GMT
+      - Thu, 18 Oct 2018 09:33:03 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -335,7 +337,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:28:25 GMT
+      - Thu, 18 Oct 2018 09:33:04 GMT
       Vary:
       - Origin
       - X-Origin
@@ -352,28 +354,47 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1dvn0muX5t_IcjgAS0A2y79RucTEdONNEwlbV0ortKZs",
+         "id": "1ufHkbm8FPkEvOCUHOh2amIT-8hyFOnC56OWwyHP2EF8",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1Q868st65J9McWM438PRRTSPo99wwK38S"
+          "1r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:28:25 GMT
+  recorded_at: Thu, 18 Oct 2018 09:33:04 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Q868st65J9McWM438PRRTSPo99wwK38S?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -385,7 +406,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:28:25 GMT
+      - Thu, 18 Oct 2018 09:33:05 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -396,9 +417,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:28:25 GMT
+      - Thu, 18 Oct 2018 09:33:05 GMT
       Date:
-      - Sun, 18 Mar 2018 21:28:25 GMT
+      - Thu, 18 Oct 2018 09:33:05 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -417,25 +438,44 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1Q868st65J9McWM438PRRTSPo99wwK38S",
-         "name": "Test @ 2018-03-18 21:28:22 UTC",
+         "id": "1r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1",
+         "name": "Test @ 2018-10-18 09:33:02 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:28:25 GMT
+  recorded_at: Thu, 18 Oct 2018 09:33:05 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Q868st65J9McWM438PRRTSPo99wwK38S/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -447,7 +487,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:28:25 GMT
+      - Thu, 18 Oct 2018 09:33:05 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -465,9 +505,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:28:25 GMT
+      - Thu, 18 Oct 2018 09:33:05 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:28:25 GMT
+      - Thu, 18 Oct 2018 09:33:05 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -479,8 +519,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -500,10 +539,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:28:25 GMT
+  recorded_at: Thu, 18 Oct 2018 09:33:05 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271Q868st65J9McWM438PRRTSPo99wwK38S%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -515,7 +554,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:28:25 GMT
+      - Thu, 18 Oct 2018 09:33:05 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -526,9 +565,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:28:25 GMT
+      - Thu, 18 Oct 2018 09:33:05 GMT
       Date:
-      - Sun, 18 Mar 2018 21:28:25 GMT
+      - Thu, 18 Oct 2018 09:33:05 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -547,8 +586,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -557,22 +595,42 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1dvn0muX5t_IcjgAS0A2y79RucTEdONNEwlbV0ortKZs",
+           "id": "1ufHkbm8FPkEvOCUHOh2amIT-8hyFOnC56OWwyHP2EF8",
            "name": "File",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1Q868st65J9McWM438PRRTSPo99wwK38S"
+            "1r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1"
            ],
-           "thumbnailVersion": "0"
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "writer",
+             "displayName": "Upshift One",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "13193959451567607887",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+             "role": "owner",
+             "displayName": "Testuser Upshift One",
+             "deleted": false
+            }
+           ]
           }
          ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:28:25 GMT
+  recorded_at: Thu, 18 Oct 2018 09:33:05 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1dvn0muX5t_IcjgAS0A2y79RucTEdONNEwlbV0ortKZs/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1ufHkbm8FPkEvOCUHOh2amIT-8hyFOnC56OWwyHP2EF8/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -584,7 +642,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:28:25 GMT
+      - Thu, 18 Oct 2018 09:33:05 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -595,9 +653,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:28:25 GMT
+      - Thu, 18 Oct 2018 09:33:05 GMT
       Date:
-      - Sun, 18 Mar 2018 21:28:25 GMT
+      - Thu, 18 Oct 2018 09:33:05 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -616,8 +674,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -627,13 +684,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-03-18T21:28:24.449Z"
+         "modifiedTime": "2018-10-18T09:33:04.042Z"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:28:25 GMT
+  recorded_at: Thu, 18 Oct 2018 09:33:05 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1dvn0muX5t_IcjgAS0A2y79RucTEdONNEwlbV0ortKZs/permissions?fields=permissions/id,%20permissions/emailAddress
+    uri: https://www.googleapis.com/drive/v3/files/1ufHkbm8FPkEvOCUHOh2amIT-8hyFOnC56OWwyHP2EF8/permissions?fields=permissions/id,%20permissions/emailAddress
     body:
       encoding: UTF-8
       string: ''
@@ -645,7 +702,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:28:25 GMT
+      - Thu, 18 Oct 2018 09:33:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -656,9 +713,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:28:26 GMT
+      - Thu, 18 Oct 2018 09:33:06 GMT
       Date:
-      - Sun, 18 Mar 2018 21:28:26 GMT
+      - Thu, 18 Oct 2018 09:33:06 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -677,8 +734,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -687,20 +743,20 @@ http_interactions:
         {
          "permissions": [
           {
-           "id": "13193959451567607887",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>"
-          },
-          {
            "id": "11673017242486491425",
            "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>"
+          },
+          {
+           "id": "13193959451567607887",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>"
           }
          ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:28:26 GMT
+  recorded_at: Thu, 18 Oct 2018 09:33:06 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1dvn0muX5t_IcjgAS0A2y79RucTEdONNEwlbV0ortKZs/permissions/11673017242486491425
+    uri: https://www.googleapis.com/drive/v3/files/1ufHkbm8FPkEvOCUHOh2amIT-8hyFOnC56OWwyHP2EF8/permissions/11673017242486491425
     body:
       encoding: UTF-8
       string: ''
@@ -712,7 +768,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:28:26 GMT
+      - Thu, 18 Oct 2018 09:33:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -729,23 +785,22 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:28:26 GMT
+      - Thu, 18 Oct 2018 09:33:06 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:28:26 GMT
+  recorded_at: Thu, 18 Oct 2018 09:33:06 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=7155
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9342
     body:
       encoding: UTF-8
       string: ''
@@ -757,7 +812,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:29:26 GMT
+      - Thu, 18 Oct 2018 09:34:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -768,9 +823,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:29:27 GMT
+      - Thu, 18 Oct 2018 09:34:07 GMT
       Date:
-      - Sun, 18 Mar 2018 21:29:27 GMT
+      - Thu, 18 Oct 2018 09:34:07 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -789,29 +844,28 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "7157",
+         "newStartPageToken": "9345",
          "changes": [
           {
-           "fileId": "1Q868st65J9McWM438PRRTSPo99wwK38S"
+           "fileId": "1r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1"
           },
           {
-           "fileId": "1dvn0muX5t_IcjgAS0A2y79RucTEdONNEwlbV0ortKZs"
+           "fileId": "1ufHkbm8FPkEvOCUHOh2amIT-8hyFOnC56OWwyHP2EF8"
           }
          ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:29:27 GMT
+  recorded_at: Thu, 18 Oct 2018 09:34:07 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Q868st65J9McWM438PRRTSPo99wwK38S?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -823,7 +877,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:29:27 GMT
+      - Thu, 18 Oct 2018 09:34:07 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -834,9 +888,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:29:27 GMT
+      - Thu, 18 Oct 2018 09:34:07 GMT
       Date:
-      - Sun, 18 Mar 2018 21:29:27 GMT
+      - Thu, 18 Oct 2018 09:34:07 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -855,25 +909,44 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1Q868st65J9McWM438PRRTSPo99wwK38S",
-         "name": "Test @ 2018-03-18 21:28:22 UTC",
+         "id": "1r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1",
+         "name": "Test @ 2018-10-18 09:33:02 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:29:27 GMT
+  recorded_at: Thu, 18 Oct 2018 09:34:07 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Q868st65J9McWM438PRRTSPo99wwK38S/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -885,7 +958,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:29:27 GMT
+      - Thu, 18 Oct 2018 09:34:07 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -903,9 +976,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:29:27 GMT
+      - Thu, 18 Oct 2018 09:34:07 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:29:27 GMT
+      - Thu, 18 Oct 2018 09:34:07 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -917,8 +990,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -938,10 +1010,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:29:27 GMT
+  recorded_at: Thu, 18 Oct 2018 09:34:07 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1dvn0muX5t_IcjgAS0A2y79RucTEdONNEwlbV0ortKZs?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ufHkbm8FPkEvOCUHOh2amIT-8hyFOnC56OWwyHP2EF8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -953,7 +1025,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:29:27 GMT
+      - Thu, 18 Oct 2018 09:34:07 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -971,9 +1043,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:29:27 GMT
+      - Thu, 18 Oct 2018 09:34:07 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:29:27 GMT
+      - Thu, 18 Oct 2018 09:34:07 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -985,8 +1057,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -998,20 +1069,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1dvn0muX5t_IcjgAS0A2y79RucTEdONNEwlbV0ortKZs.",
+            "message": "File not found: 1ufHkbm8FPkEvOCUHOh2amIT-8hyFOnC56OWwyHP2EF8.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1dvn0muX5t_IcjgAS0A2y79RucTEdONNEwlbV0ortKZs."
+          "message": "File not found: 1ufHkbm8FPkEvOCUHOh2amIT-8hyFOnC56OWwyHP2EF8."
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:29:27 GMT
+  recorded_at: Thu, 18 Oct 2018 09:34:07 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1Q868st65J9McWM438PRRTSPo99wwK38S
+    uri: https://www.googleapis.com/drive/v3/files/1r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1
     body:
       encoding: UTF-8
       string: ''
@@ -1023,7 +1094,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:29:27 GMT
+      - Thu, 18 Oct 2018 09:34:08 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1040,18 +1111,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:29:28 GMT
+      - Thu, 18 Oct 2018 09:34:08 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:29:28 GMT
+  recorded_at: Thu, 18 Oct 2018 09:34:08 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_stops_sharing_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_stops_sharing_file.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 11:08:23 GMT
+      - Sat, 20 Oct 2018 20:19:26 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:08:23 GMT
+  recorded_at: Sat, 20 Oct 2018 20:19:26 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 11:08:23 GMT
+      - Sat, 20 Oct 2018 20:19:26 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:08:23 GMT
+  recorded_at: Sat, 20 Oct 2018 20:19:26 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        11:08:23 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-20
+        20:19:26 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:08:23 GMT
+      - Sat, 20 Oct 2018 20:19:26 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:08:24 GMT
+      - Sat, 20 Oct 2018 20:19:26 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1xStW6UOtedLYqcEaK5pRwE68KfP0D8_s",
-         "name": "Test @ 2018-10-18 11:08:23 UTC",
+         "id": "1f3v75Zy9E3CJWydsXzD_SyLGUwwKpdcW",
+         "name": "Test @ 2018-10-20 20:19:26 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:08:24 GMT
+  recorded_at: Sat, 20 Oct 2018 20:19:26 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1xStW6UOtedLYqcEaK5pRwE68KfP0D8_s/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1f3v75Zy9E3CJWydsXzD_SyLGUwwKpdcW/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:08:24 GMT
+      - Sat, 20 Oct 2018 20:19:26 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:08:25 GMT
+      - Sat, 20 Oct 2018 20:19:27 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:08:25 GMT
+  recorded_at: Sat, 20 Oct 2018 20:19:27 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:08:25 GMT
+      - Sat, 20 Oct 2018 20:19:27 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:08:25 GMT
+      - Sat, 20 Oct 2018 20:19:27 GMT
       Date:
-      - Thu, 18 Oct 2018 11:08:25 GMT
+      - Sat, 20 Oct 2018 20:19:27 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,16 +302,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "9534"
+         "startPageToken": "10589"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:08:25 GMT
+  recorded_at: Sat, 20 Oct 2018 20:19:27 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1xStW6UOtedLYqcEaK5pRwE68KfP0D8_s"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1f3v75Zy9E3CJWydsXzD_SyLGUwwKpdcW"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -320,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:08:25 GMT
+      - Sat, 20 Oct 2018 20:19:27 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -337,7 +337,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:08:26 GMT
+      - Sat, 20 Oct 2018 20:19:28 GMT
       Vary:
       - Origin
       - X-Origin
@@ -361,12 +361,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1lpqOLQDiznfD2C9DOZFQ4NkOm8cxVueKO6G5SZGWU78",
+         "id": "18Rhe2PFOzlLcOGK8g40DIeUZIpmP2FQ-xDoQ5VoKQJU",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1xStW6UOtedLYqcEaK5pRwE68KfP0D8_s"
+          "1f3v75Zy9E3CJWydsXzD_SyLGUwwKpdcW"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -391,14 +391,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:08:26 GMT
+  recorded_at: Sat, 20 Oct 2018 20:19:28 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"6 Tanngrisnir
-        (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"5 Starship
+        Titanic (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -407,7 +407,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:08:26 GMT
+      - Sat, 20 Oct 2018 20:19:28 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -424,7 +424,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:08:26 GMT
+      - Sat, 20 Oct 2018 20:19:29 GMT
       Vary:
       - Origin
       - X-Origin
@@ -448,8 +448,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1XMWfIeKiaOsQVY_TKMSSUg8IlHJFCcOc",
-         "name": "6 Tanngrisnir (Archive)",
+         "id": "1m3_xXUioe8EhG-hNKzjDAz-kuVX__dpB",
+         "name": "5 Starship Titanic (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -469,10 +469,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:08:26 GMT
+  recorded_at: Sat, 20 Oct 2018 20:19:29 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1XMWfIeKiaOsQVY_TKMSSUg8IlHJFCcOc/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1m3_xXUioe8EhG-hNKzjDAz-kuVX__dpB/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -484,7 +484,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:08:26 GMT
+      - Sat, 20 Oct 2018 20:19:29 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -501,7 +501,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:08:27 GMT
+      - Sat, 20 Oct 2018 20:19:30 GMT
       Vary:
       - Origin
       - X-Origin
@@ -531,10 +531,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:08:27 GMT
+  recorded_at: Sat, 20 Oct 2018 20:19:30 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1XMWfIeKiaOsQVY_TKMSSUg8IlHJFCcOc?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1m3_xXUioe8EhG-hNKzjDAz-kuVX__dpB?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -546,7 +546,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:08:27 GMT
+      - Sat, 20 Oct 2018 20:19:30 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -557,9 +557,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:08:27 GMT
+      - Sat, 20 Oct 2018 20:19:30 GMT
       Date:
-      - Thu, 18 Oct 2018 11:08:27 GMT
+      - Sat, 20 Oct 2018 20:19:30 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -585,8 +585,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1XMWfIeKiaOsQVY_TKMSSUg8IlHJFCcOc",
-         "name": "6 Tanngrisnir (Archive)",
+         "id": "1m3_xXUioe8EhG-hNKzjDAz-kuVX__dpB",
+         "name": "5 Starship Titanic (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -615,10 +615,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:08:27 GMT
+  recorded_at: Sat, 20 Oct 2018 20:19:30 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1XMWfIeKiaOsQVY_TKMSSUg8IlHJFCcOc/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1m3_xXUioe8EhG-hNKzjDAz-kuVX__dpB/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -630,7 +630,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:08:27 GMT
+      - Sat, 20 Oct 2018 20:19:30 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -648,9 +648,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:08:27 GMT
+      - Sat, 20 Oct 2018 20:19:30 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:08:27 GMT
+      - Sat, 20 Oct 2018 20:19:30 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -682,10 +682,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:08:27 GMT
+  recorded_at: Sat, 20 Oct 2018 20:19:30 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1xStW6UOtedLYqcEaK5pRwE68KfP0D8_s?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1f3v75Zy9E3CJWydsXzD_SyLGUwwKpdcW?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -697,7 +697,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:08:27 GMT
+      - Sat, 20 Oct 2018 20:19:30 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -708,9 +708,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:08:27 GMT
+      - Sat, 20 Oct 2018 20:19:30 GMT
       Date:
-      - Thu, 18 Oct 2018 11:08:27 GMT
+      - Sat, 20 Oct 2018 20:19:30 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -736,8 +736,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1xStW6UOtedLYqcEaK5pRwE68KfP0D8_s",
-         "name": "Test @ 2018-10-18 11:08:23 UTC",
+         "id": "1f3v75Zy9E3CJWydsXzD_SyLGUwwKpdcW",
+         "name": "Test @ 2018-10-20 20:19:26 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -763,10 +763,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:08:27 GMT
+  recorded_at: Sat, 20 Oct 2018 20:19:30 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1xStW6UOtedLYqcEaK5pRwE68KfP0D8_s/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1f3v75Zy9E3CJWydsXzD_SyLGUwwKpdcW/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -778,7 +778,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:08:27 GMT
+      - Sat, 20 Oct 2018 20:19:30 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -796,9 +796,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:08:28 GMT
+      - Sat, 20 Oct 2018 20:19:31 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:08:28 GMT
+      - Sat, 20 Oct 2018 20:19:31 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -830,10 +830,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:08:28 GMT
+  recorded_at: Sat, 20 Oct 2018 20:19:31 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271xStW6UOtedLYqcEaK5pRwE68KfP0D8_s%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271f3v75Zy9E3CJWydsXzD_SyLGUwwKpdcW%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -845,7 +845,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:08:28 GMT
+      - Sat, 20 Oct 2018 20:19:31 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -856,9 +856,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:08:28 GMT
+      - Sat, 20 Oct 2018 20:19:31 GMT
       Date:
-      - Thu, 18 Oct 2018 11:08:28 GMT
+      - Sat, 20 Oct 2018 20:19:31 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -886,12 +886,12 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1lpqOLQDiznfD2C9DOZFQ4NkOm8cxVueKO6G5SZGWU78",
+           "id": "18Rhe2PFOzlLcOGK8g40DIeUZIpmP2FQ-xDoQ5VoKQJU",
            "name": "File",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1xStW6UOtedLYqcEaK5pRwE68KfP0D8_s"
+            "1f3v75Zy9E3CJWydsXzD_SyLGUwwKpdcW"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -918,10 +918,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:08:28 GMT
+  recorded_at: Sat, 20 Oct 2018 20:19:31 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1lpqOLQDiznfD2C9DOZFQ4NkOm8cxVueKO6G5SZGWU78/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/18Rhe2PFOzlLcOGK8g40DIeUZIpmP2FQ-xDoQ5VoKQJU/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -933,7 +933,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:08:28 GMT
+      - Sat, 20 Oct 2018 20:19:31 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -944,9 +944,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:08:28 GMT
+      - Sat, 20 Oct 2018 20:19:31 GMT
       Date:
-      - Thu, 18 Oct 2018 11:08:28 GMT
+      - Sat, 20 Oct 2018 20:19:31 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -975,13 +975,185 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T11:08:25.545Z"
+         "modifiedTime": "2018-10-20T20:19:28.098Z"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:08:28 GMT
+  recorded_at: Sat, 20 Oct 2018 20:19:31 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/18Rhe2PFOzlLcOGK8g40DIeUZIpmP2FQ-xDoQ5VoKQJU/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"File","parents":["1m3_xXUioe8EhG-hNKzjDAz-kuVX__dpB"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:19:31 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:19:33 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1Mik8WVnFWnTR8mo5hMByL6lEoe5LdKK4Q-dvZVidFo0",
+         "name": "File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1m3_xXUioe8EhG-hNKzjDAz-kuVX__dpB"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:19:33 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/18Rhe2PFOzlLcOGK8g40DIeUZIpmP2FQ-xDoQ5VoKQJU/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"File","parents":["1m3_xXUioe8EhG-hNKzjDAz-kuVX__dpB"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:19:33 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:19:34 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "12t3mxDeamL-0cJLi_XCJDZu8VV_dKyNTvSUwRU3H0Co",
+         "name": "File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1m3_xXUioe8EhG-hNKzjDAz-kuVX__dpB"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:19:34 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1lpqOLQDiznfD2C9DOZFQ4NkOm8cxVueKO6G5SZGWU78/permissions?fields=permissions/id,%20permissions/emailAddress
+    uri: https://www.googleapis.com/drive/v3/files/18Rhe2PFOzlLcOGK8g40DIeUZIpmP2FQ-xDoQ5VoKQJU/permissions?fields=permissions/id,%20permissions/emailAddress
     body:
       encoding: UTF-8
       string: ''
@@ -993,7 +1165,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:08:28 GMT
+      - Sat, 20 Oct 2018 20:19:35 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1004,9 +1176,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:08:28 GMT
+      - Sat, 20 Oct 2018 20:19:35 GMT
       Date:
-      - Thu, 18 Oct 2018 11:08:28 GMT
+      - Sat, 20 Oct 2018 20:19:35 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1044,10 +1216,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:08:28 GMT
+  recorded_at: Sat, 20 Oct 2018 20:19:35 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1lpqOLQDiznfD2C9DOZFQ4NkOm8cxVueKO6G5SZGWU78/permissions/11673017242486491425
+    uri: https://www.googleapis.com/drive/v3/files/18Rhe2PFOzlLcOGK8g40DIeUZIpmP2FQ-xDoQ5VoKQJU/permissions/11673017242486491425
     body:
       encoding: UTF-8
       string: ''
@@ -1059,7 +1231,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:08:28 GMT
+      - Sat, 20 Oct 2018 20:19:35 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1076,7 +1248,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:08:29 GMT
+      - Sat, 20 Oct 2018 20:19:35 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1088,10 +1260,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:08:29 GMT
+  recorded_at: Sat, 20 Oct 2018 20:19:35 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9534
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=10589
     body:
       encoding: UTF-8
       string: ''
@@ -1103,7 +1275,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:09:29 GMT
+      - Sat, 20 Oct 2018 20:20:35 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1114,9 +1286,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:09:29 GMT
+      - Sat, 20 Oct 2018 20:20:35 GMT
       Date:
-      - Thu, 18 Oct 2018 11:09:29 GMT
+      - Sat, 20 Oct 2018 20:20:35 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1142,24 +1314,36 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "9539",
+         "newStartPageToken": "10605",
          "changes": [
           {
-           "fileId": "1XMWfIeKiaOsQVY_TKMSSUg8IlHJFCcOc"
+           "fileId": "1m3_xXUioe8EhG-hNKzjDAz-kuVX__dpB"
           },
           {
-           "fileId": "1lpqOLQDiznfD2C9DOZFQ4NkOm8cxVueKO6G5SZGWU78"
+           "fileId": "1HvKTI0z21L1TcamDiKlGP627xZ64uRRj22kzEteSS7E"
           },
           {
-           "fileId": "1xStW6UOtedLYqcEaK5pRwE68KfP0D8_s"
+           "fileId": "18Rhe2PFOzlLcOGK8g40DIeUZIpmP2FQ-xDoQ5VoKQJU"
+          },
+          {
+           "fileId": "1f3v75Zy9E3CJWydsXzD_SyLGUwwKpdcW"
+          },
+          {
+           "fileId": "1Mik8WVnFWnTR8mo5hMByL6lEoe5LdKK4Q-dvZVidFo0"
+          },
+          {
+           "fileId": "12t3mxDeamL-0cJLi_XCJDZu8VV_dKyNTvSUwRU3H0Co"
+          },
+          {
+           "fileId": "1zkw03wmd5XIFORK8BaCComM6ZQfqru6_iDJUfk2bUas"
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:09:29 GMT
+  recorded_at: Sat, 20 Oct 2018 20:20:35 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1XMWfIeKiaOsQVY_TKMSSUg8IlHJFCcOc?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1m3_xXUioe8EhG-hNKzjDAz-kuVX__dpB?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1171,7 +1355,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:09:29 GMT
+      - Sat, 20 Oct 2018 20:20:35 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1182,9 +1366,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:09:29 GMT
+      - Sat, 20 Oct 2018 20:20:36 GMT
       Date:
-      - Thu, 18 Oct 2018 11:09:29 GMT
+      - Sat, 20 Oct 2018 20:20:36 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1210,8 +1394,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1XMWfIeKiaOsQVY_TKMSSUg8IlHJFCcOc",
-         "name": "6 Tanngrisnir (Archive)",
+         "id": "1m3_xXUioe8EhG-hNKzjDAz-kuVX__dpB",
+         "name": "5 Starship Titanic (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -1240,10 +1424,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:09:29 GMT
+  recorded_at: Sat, 20 Oct 2018 20:20:36 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1XMWfIeKiaOsQVY_TKMSSUg8IlHJFCcOc/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1m3_xXUioe8EhG-hNKzjDAz-kuVX__dpB/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1255,7 +1439,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:09:29 GMT
+      - Sat, 20 Oct 2018 20:20:36 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1273,9 +1457,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:09:29 GMT
+      - Sat, 20 Oct 2018 20:20:36 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:09:29 GMT
+      - Sat, 20 Oct 2018 20:20:36 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1307,10 +1491,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:09:29 GMT
+  recorded_at: Sat, 20 Oct 2018 20:20:36 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1lpqOLQDiznfD2C9DOZFQ4NkOm8cxVueKO6G5SZGWU78?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1HvKTI0z21L1TcamDiKlGP627xZ64uRRj22kzEteSS7E?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1322,7 +1506,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:09:29 GMT
+      - Sat, 20 Oct 2018 20:20:36 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1340,9 +1524,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:09:29 GMT
+      - Sat, 20 Oct 2018 20:20:36 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:09:29 GMT
+      - Sat, 20 Oct 2018 20:20:36 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1366,20 +1550,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1lpqOLQDiznfD2C9DOZFQ4NkOm8cxVueKO6G5SZGWU78.",
+            "message": "File not found: 1HvKTI0z21L1TcamDiKlGP627xZ64uRRj22kzEteSS7E.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1lpqOLQDiznfD2C9DOZFQ4NkOm8cxVueKO6G5SZGWU78."
+          "message": "File not found: 1HvKTI0z21L1TcamDiKlGP627xZ64uRRj22kzEteSS7E."
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:09:29 GMT
+  recorded_at: Sat, 20 Oct 2018 20:20:36 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1xStW6UOtedLYqcEaK5pRwE68KfP0D8_s?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/18Rhe2PFOzlLcOGK8g40DIeUZIpmP2FQ-xDoQ5VoKQJU?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1391,7 +1575,76 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:09:29 GMT
+      - Sat, 20 Oct 2018 20:20:36 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Sat, 20 Oct 2018 20:20:36 GMT
+      Expires:
+      - Sat, 20 Oct 2018 20:20:36 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "notFound",
+            "message": "File not found: 18Rhe2PFOzlLcOGK8g40DIeUZIpmP2FQ-xDoQ5VoKQJU.",
+            "locationType": "parameter",
+            "location": "fileId"
+           }
+          ],
+          "code": 404,
+          "message": "File not found: 18Rhe2PFOzlLcOGK8g40DIeUZIpmP2FQ-xDoQ5VoKQJU."
+         }
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:20:36 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1f3v75Zy9E3CJWydsXzD_SyLGUwwKpdcW?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:20:36 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1402,9 +1655,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:09:30 GMT
+      - Sat, 20 Oct 2018 20:20:36 GMT
       Date:
-      - Thu, 18 Oct 2018 11:09:30 GMT
+      - Sat, 20 Oct 2018 20:20:36 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1430,8 +1683,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1xStW6UOtedLYqcEaK5pRwE68KfP0D8_s",
-         "name": "Test @ 2018-10-18 11:08:23 UTC",
+         "id": "1f3v75Zy9E3CJWydsXzD_SyLGUwwKpdcW",
+         "name": "Test @ 2018-10-20 20:19:26 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -1457,10 +1710,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:09:30 GMT
+  recorded_at: Sat, 20 Oct 2018 20:20:36 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1xStW6UOtedLYqcEaK5pRwE68KfP0D8_s/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1f3v75Zy9E3CJWydsXzD_SyLGUwwKpdcW/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1472,7 +1725,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:09:30 GMT
+      - Sat, 20 Oct 2018 20:20:36 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1490,9 +1743,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:09:30 GMT
+      - Sat, 20 Oct 2018 20:20:36 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:09:30 GMT
+      - Sat, 20 Oct 2018 20:20:36 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1524,10 +1777,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:09:30 GMT
+  recorded_at: Sat, 20 Oct 2018 20:20:36 GMT
 - request:
-    method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1xStW6UOtedLYqcEaK5pRwE68KfP0D8_s
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1Mik8WVnFWnTR8mo5hMByL6lEoe5LdKK4Q-dvZVidFo0?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1539,7 +1792,622 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:09:30 GMT
+      - Sat, 20 Oct 2018 20:20:36 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:20:37 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:20:37 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1Mik8WVnFWnTR8mo5hMByL6lEoe5LdKK4Q-dvZVidFo0",
+         "name": "File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1m3_xXUioe8EhG-hNKzjDAz-kuVX__dpB"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Mik8WVnFWnTR8mo5hMByL6lEoe5LdKK4Q-dvZVidFo0&v=1&s=AMedNnoAAAAAW8uqNeEEYw52GTtopNUetK5DGVEcs7hM&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:20:37 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1Mik8WVnFWnTR8mo5hMByL6lEoe5LdKK4Q-dvZVidFo0/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:20:37 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:20:37 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:20:37 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-20T20:19:32.699Z"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:20:37 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1Mik8WVnFWnTR8mo5hMByL6lEoe5LdKK4Q-dvZVidFo0&s=AMedNnoAAAAAW8uqNeEEYw52GTtopNUetK5DGVEcs7hM&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:20:37 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 20 Oct 2018 20:20:37 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:20:37 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/12t3mxDeamL-0cJLi_XCJDZu8VV_dKyNTvSUwRU3H0Co?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:20:37 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:20:37 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:20:37 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "12t3mxDeamL-0cJLi_XCJDZu8VV_dKyNTvSUwRU3H0Co",
+         "name": "File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1m3_xXUioe8EhG-hNKzjDAz-kuVX__dpB"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=12t3mxDeamL-0cJLi_XCJDZu8VV_dKyNTvSUwRU3H0Co&v=1&s=AMedNnoAAAAAW8uqNYeOPhjQK3Iye3XWq1kIW5UC3Va_&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:20:37 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/12t3mxDeamL-0cJLi_XCJDZu8VV_dKyNTvSUwRU3H0Co/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:20:37 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:20:37 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:20:37 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-20T20:19:34.256Z"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:20:37 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=12t3mxDeamL-0cJLi_XCJDZu8VV_dKyNTvSUwRU3H0Co&s=AMedNnoAAAAAW8uqNYeOPhjQK3Iye3XWq1kIW5UC3Va_&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:20:37 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 20 Oct 2018 20:20:38 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:20:38 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1zkw03wmd5XIFORK8BaCComM6ZQfqru6_iDJUfk2bUas?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:20:38 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:20:38 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:20:38 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1zkw03wmd5XIFORK8BaCComM6ZQfqru6_iDJUfk2bUas",
+         "name": "My New File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "10MxUqzaMmABhiVP51g1Eg7t8eXVFKg5H"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1zkw03wmd5XIFORK8BaCComM6ZQfqru6_iDJUfk2bUas&v=1&s=AMedNnoAAAAAW8uqNv7cwEMPGx1u91gGengfWefsLOS7&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:20:38 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1zkw03wmd5XIFORK8BaCComM6ZQfqru6_iDJUfk2bUas/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:20:38 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:20:38 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:20:38 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-20T20:18:08.326Z"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:20:38 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1zkw03wmd5XIFORK8BaCComM6ZQfqru6_iDJUfk2bUas&s=AMedNnoAAAAAW8uqNv7cwEMPGx1u91gGengfWefsLOS7&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:20:38 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 20 Oct 2018 20:20:38 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:20:38 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1f3v75Zy9E3CJWydsXzD_SyLGUwwKpdcW
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:20:39 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1556,7 +2424,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:09:30 GMT
+      - Sat, 20 Oct 2018 20:20:39 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1568,5 +2436,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:09:30 GMT
+  recorded_at: Sat, 20 Oct 2018 20:20:39 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_stops_sharing_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_stops_sharing_file.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:33:01 GMT
+      - Thu, 18 Oct 2018 11:08:23 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:33:01 GMT
+  recorded_at: Thu, 18 Oct 2018 11:08:23 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:33:02 GMT
+      - Thu, 18 Oct 2018 11:08:23 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:33:02 GMT
+  recorded_at: Thu, 18 Oct 2018 11:08:23 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        09:33:02 UTC","parents":["root"]}'
+        11:08:23 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:33:02 GMT
+      - Thu, 18 Oct 2018 11:08:23 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:33:02 GMT
+      - Thu, 18 Oct 2018 11:08:24 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1",
-         "name": "Test @ 2018-10-18 09:33:02 UTC",
+         "id": "1xStW6UOtedLYqcEaK5pRwE68KfP0D8_s",
+         "name": "Test @ 2018-10-18 11:08:23 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:33:02 GMT
+  recorded_at: Thu, 18 Oct 2018 11:08:24 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1xStW6UOtedLYqcEaK5pRwE68KfP0D8_s/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:33:02 GMT
+      - Thu, 18 Oct 2018 11:08:24 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:33:03 GMT
+      - Thu, 18 Oct 2018 11:08:25 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:33:03 GMT
+  recorded_at: Thu, 18 Oct 2018 11:08:25 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:33:03 GMT
+      - Thu, 18 Oct 2018 11:08:25 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:33:03 GMT
+      - Thu, 18 Oct 2018 11:08:25 GMT
       Date:
-      - Thu, 18 Oct 2018 09:33:03 GMT
+      - Thu, 18 Oct 2018 11:08:25 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,16 +302,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "9342"
+         "startPageToken": "9534"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:33:03 GMT
+  recorded_at: Thu, 18 Oct 2018 11:08:25 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1xStW6UOtedLYqcEaK5pRwE68KfP0D8_s"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -320,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:33:03 GMT
+      - Thu, 18 Oct 2018 11:08:25 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -337,7 +337,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:33:04 GMT
+      - Thu, 18 Oct 2018 11:08:26 GMT
       Vary:
       - Origin
       - X-Origin
@@ -361,12 +361,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1ufHkbm8FPkEvOCUHOh2amIT-8hyFOnC56OWwyHP2EF8",
+         "id": "1lpqOLQDiznfD2C9DOZFQ4NkOm8cxVueKO6G5SZGWU78",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1"
+          "1xStW6UOtedLYqcEaK5pRwE68KfP0D8_s"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -391,10 +391,150 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:33:04 GMT
+  recorded_at: Thu, 18 Oct 2018 11:08:26 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"6 Tanngrisnir
+        (Archive)","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:08:26 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:08:26 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1XMWfIeKiaOsQVY_TKMSSUg8IlHJFCcOc",
+         "name": "6 Tanngrisnir (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:08:26 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1XMWfIeKiaOsQVY_TKMSSUg8IlHJFCcOc/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:08:26 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:08:27 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "13193959451567607887",
+         "type": "user",
+         "role": "reader"
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:08:27 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1XMWfIeKiaOsQVY_TKMSSUg8IlHJFCcOc?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -406,7 +546,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:33:05 GMT
+      - Thu, 18 Oct 2018 11:08:27 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -417,9 +557,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:33:05 GMT
+      - Thu, 18 Oct 2018 11:08:27 GMT
       Date:
-      - Thu, 18 Oct 2018 09:33:05 GMT
+      - Thu, 18 Oct 2018 11:08:27 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -445,37 +585,40 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1",
-         "name": "Test @ 2018-10-18 09:33:02 UTC",
+         "id": "1XMWfIeKiaOsQVY_TKMSSUg8IlHJFCcOc",
+         "name": "6 Tanngrisnir (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
          "thumbnailVersion": "0",
          "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
           {
            "kind": "drive#permission",
            "id": "13193959451567607887",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
+           "role": "reader",
            "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
            "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:33:05 GMT
+  recorded_at: Thu, 18 Oct 2018 11:08:27 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1XMWfIeKiaOsQVY_TKMSSUg8IlHJFCcOc/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -487,7 +630,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:33:05 GMT
+      - Thu, 18 Oct 2018 11:08:27 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -505,9 +648,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:33:05 GMT
+      - Thu, 18 Oct 2018 11:08:27 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:33:05 GMT
+      - Thu, 18 Oct 2018 11:08:27 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -539,10 +682,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:33:05 GMT
+  recorded_at: Thu, 18 Oct 2018 11:08:27 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files/1xStW6UOtedLYqcEaK5pRwE68KfP0D8_s?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -554,7 +697,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:33:05 GMT
+      - Thu, 18 Oct 2018 11:08:27 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -565,9 +708,157 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:33:05 GMT
+      - Thu, 18 Oct 2018 11:08:27 GMT
       Date:
-      - Thu, 18 Oct 2018 09:33:05 GMT
+      - Thu, 18 Oct 2018 11:08:27 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1xStW6UOtedLYqcEaK5pRwE68KfP0D8_s",
+         "name": "Test @ 2018-10-18 11:08:23 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:08:27 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1xStW6UOtedLYqcEaK5pRwE68KfP0D8_s/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:08:27 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:08:28 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:08:28 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:08:28 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271xStW6UOtedLYqcEaK5pRwE68KfP0D8_s%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:08:28 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:08:28 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:08:28 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -595,12 +886,12 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1ufHkbm8FPkEvOCUHOh2amIT-8hyFOnC56OWwyHP2EF8",
+           "id": "1lpqOLQDiznfD2C9DOZFQ4NkOm8cxVueKO6G5SZGWU78",
            "name": "File",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1"
+            "1xStW6UOtedLYqcEaK5pRwE68KfP0D8_s"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -627,10 +918,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:33:05 GMT
+  recorded_at: Thu, 18 Oct 2018 11:08:28 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1ufHkbm8FPkEvOCUHOh2amIT-8hyFOnC56OWwyHP2EF8/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1lpqOLQDiznfD2C9DOZFQ4NkOm8cxVueKO6G5SZGWU78/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -642,7 +933,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:33:05 GMT
+      - Thu, 18 Oct 2018 11:08:28 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -653,9 +944,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:33:05 GMT
+      - Thu, 18 Oct 2018 11:08:28 GMT
       Date:
-      - Thu, 18 Oct 2018 09:33:05 GMT
+      - Thu, 18 Oct 2018 11:08:28 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -684,13 +975,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T09:33:04.042Z"
+         "modifiedTime": "2018-10-18T11:08:25.545Z"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:33:05 GMT
+  recorded_at: Thu, 18 Oct 2018 11:08:28 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1ufHkbm8FPkEvOCUHOh2amIT-8hyFOnC56OWwyHP2EF8/permissions?fields=permissions/id,%20permissions/emailAddress
+    uri: https://www.googleapis.com/drive/v3/files/1lpqOLQDiznfD2C9DOZFQ4NkOm8cxVueKO6G5SZGWU78/permissions?fields=permissions/id,%20permissions/emailAddress
     body:
       encoding: UTF-8
       string: ''
@@ -702,7 +993,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:33:06 GMT
+      - Thu, 18 Oct 2018 11:08:28 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -713,9 +1004,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:33:06 GMT
+      - Thu, 18 Oct 2018 11:08:28 GMT
       Date:
-      - Thu, 18 Oct 2018 09:33:06 GMT
+      - Thu, 18 Oct 2018 11:08:28 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -753,10 +1044,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:33:06 GMT
+  recorded_at: Thu, 18 Oct 2018 11:08:28 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1ufHkbm8FPkEvOCUHOh2amIT-8hyFOnC56OWwyHP2EF8/permissions/11673017242486491425
+    uri: https://www.googleapis.com/drive/v3/files/1lpqOLQDiznfD2C9DOZFQ4NkOm8cxVueKO6G5SZGWU78/permissions/11673017242486491425
     body:
       encoding: UTF-8
       string: ''
@@ -768,7 +1059,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:33:06 GMT
+      - Thu, 18 Oct 2018 11:08:28 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -785,7 +1076,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:33:06 GMT
+      - Thu, 18 Oct 2018 11:08:29 GMT
       Vary:
       - Origin
       - X-Origin
@@ -797,10 +1088,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:33:06 GMT
+  recorded_at: Thu, 18 Oct 2018 11:08:29 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9342
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9534
     body:
       encoding: UTF-8
       string: ''
@@ -812,7 +1103,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:34:06 GMT
+      - Thu, 18 Oct 2018 11:09:29 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -823,9 +1114,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:34:07 GMT
+      - Thu, 18 Oct 2018 11:09:29 GMT
       Date:
-      - Thu, 18 Oct 2018 09:34:07 GMT
+      - Thu, 18 Oct 2018 11:09:29 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -851,21 +1142,24 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "9345",
+         "newStartPageToken": "9539",
          "changes": [
           {
-           "fileId": "1r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1"
+           "fileId": "1XMWfIeKiaOsQVY_TKMSSUg8IlHJFCcOc"
           },
           {
-           "fileId": "1ufHkbm8FPkEvOCUHOh2amIT-8hyFOnC56OWwyHP2EF8"
+           "fileId": "1lpqOLQDiznfD2C9DOZFQ4NkOm8cxVueKO6G5SZGWU78"
+          },
+          {
+           "fileId": "1xStW6UOtedLYqcEaK5pRwE68KfP0D8_s"
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:34:07 GMT
+  recorded_at: Thu, 18 Oct 2018 11:09:29 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1XMWfIeKiaOsQVY_TKMSSUg8IlHJFCcOc?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -877,7 +1171,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:34:07 GMT
+      - Thu, 18 Oct 2018 11:09:29 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -888,9 +1182,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:34:07 GMT
+      - Thu, 18 Oct 2018 11:09:29 GMT
       Date:
-      - Thu, 18 Oct 2018 09:34:07 GMT
+      - Thu, 18 Oct 2018 11:09:29 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -916,37 +1210,40 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1",
-         "name": "Test @ 2018-10-18 09:33:02 UTC",
+         "id": "1XMWfIeKiaOsQVY_TKMSSUg8IlHJFCcOc",
+         "name": "6 Tanngrisnir (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
          "thumbnailVersion": "0",
          "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
           {
            "kind": "drive#permission",
            "id": "13193959451567607887",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
+           "role": "reader",
            "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
            "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:34:07 GMT
+  recorded_at: Thu, 18 Oct 2018 11:09:29 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1XMWfIeKiaOsQVY_TKMSSUg8IlHJFCcOc/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -958,7 +1255,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:34:07 GMT
+      - Thu, 18 Oct 2018 11:09:29 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -976,9 +1273,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:34:07 GMT
+      - Thu, 18 Oct 2018 11:09:29 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:34:07 GMT
+      - Thu, 18 Oct 2018 11:09:29 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1010,10 +1307,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:34:07 GMT
+  recorded_at: Thu, 18 Oct 2018 11:09:29 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1ufHkbm8FPkEvOCUHOh2amIT-8hyFOnC56OWwyHP2EF8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1lpqOLQDiznfD2C9DOZFQ4NkOm8cxVueKO6G5SZGWU78?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1025,7 +1322,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:34:07 GMT
+      - Thu, 18 Oct 2018 11:09:29 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1043,9 +1340,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:34:07 GMT
+      - Thu, 18 Oct 2018 11:09:29 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:34:07 GMT
+      - Thu, 18 Oct 2018 11:09:29 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1069,20 +1366,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1ufHkbm8FPkEvOCUHOh2amIT-8hyFOnC56OWwyHP2EF8.",
+            "message": "File not found: 1lpqOLQDiznfD2C9DOZFQ4NkOm8cxVueKO6G5SZGWU78.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1ufHkbm8FPkEvOCUHOh2amIT-8hyFOnC56OWwyHP2EF8."
+          "message": "File not found: 1lpqOLQDiznfD2C9DOZFQ4NkOm8cxVueKO6G5SZGWU78."
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:34:07 GMT
+  recorded_at: Thu, 18 Oct 2018 11:09:29 GMT
 - request:
-    method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1r0ohY5rrq4YgZ_PiO2RU6HXs_How5zg1
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1xStW6UOtedLYqcEaK5pRwE68KfP0D8_s?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1094,7 +1391,155 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:34:08 GMT
+      - Thu, 18 Oct 2018 11:09:29 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:09:30 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:09:30 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1xStW6UOtedLYqcEaK5pRwE68KfP0D8_s",
+         "name": "Test @ 2018-10-18 11:08:23 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:09:30 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1xStW6UOtedLYqcEaK5pRwE68KfP0D8_s/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:09:30 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:09:30 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:09:30 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:09:30 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1xStW6UOtedLYqcEaK5pRwE68KfP0D8_s
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:09:30 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1111,7 +1556,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:34:08 GMT
+      - Thu, 18 Oct 2018 11:09:30 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1123,5 +1568,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:34:08 GMT
+  recorded_at: Thu, 18 Oct 2018 11:09:30 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_trashes_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_trashes_file.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 11:06:06 GMT
+      - Sat, 20 Oct 2018 20:15:49 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:06:06 GMT
+  recorded_at: Sat, 20 Oct 2018 20:15:49 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 11:06:06 GMT
+      - Sat, 20 Oct 2018 20:15:49 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:06:06 GMT
+  recorded_at: Sat, 20 Oct 2018 20:15:49 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        11:06:06 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-20
+        20:15:49 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:06:06 GMT
+      - Sat, 20 Oct 2018 20:15:49 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:06:06 GMT
+      - Sat, 20 Oct 2018 20:15:49 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t",
-         "name": "Test @ 2018-10-18 11:06:06 UTC",
+         "id": "11TFG8nM7giT7v4U9hCeih3cVGEhHW2yS",
+         "name": "Test @ 2018-10-20 20:15:49 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:06:07 GMT
+  recorded_at: Sat, 20 Oct 2018 20:15:49 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/11TFG8nM7giT7v4U9hCeih3cVGEhHW2yS/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:06:07 GMT
+      - Sat, 20 Oct 2018 20:15:49 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:06:07 GMT
+      - Sat, 20 Oct 2018 20:15:50 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:06:07 GMT
+  recorded_at: Sat, 20 Oct 2018 20:15:50 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:06:07 GMT
+      - Sat, 20 Oct 2018 20:15:50 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:06:07 GMT
+      - Sat, 20 Oct 2018 20:15:50 GMT
       Date:
-      - Thu, 18 Oct 2018 11:06:07 GMT
+      - Sat, 20 Oct 2018 20:15:50 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,17 +302,17 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "9517"
+         "startPageToken": "10542"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:06:07 GMT
+  recorded_at: Sat, 20 Oct 2018 20:15:50 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.document","name":"File To
-        Trash","parents":["1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t"]}'
+        Trash","parents":["11TFG8nM7giT7v4U9hCeih3cVGEhHW2yS"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -321,7 +321,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:06:07 GMT
+      - Sat, 20 Oct 2018 20:15:50 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -338,7 +338,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:06:09 GMT
+      - Sat, 20 Oct 2018 20:15:51 GMT
       Vary:
       - Origin
       - X-Origin
@@ -362,12 +362,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1ghQKU6LqrubhsC0OCfOcGF333QMbsGxXLlAqzaPJK8k",
+         "id": "16cEqt2OVZYu-bmAqwG0_GTQQkkxQpGJlSPg-pKSwPqA",
          "name": "File To Trash",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t"
+          "11TFG8nM7giT7v4U9hCeih3cVGEhHW2yS"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -392,14 +392,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:06:09 GMT
+  recorded_at: Sat, 20 Oct 2018 20:15:51 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"4 Krikkit
-        One (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"2 Billion
+        Year Bunker (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -408,7 +408,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:06:09 GMT
+      - Sat, 20 Oct 2018 20:15:51 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -425,7 +425,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:06:09 GMT
+      - Sat, 20 Oct 2018 20:15:52 GMT
       Vary:
       - Origin
       - X-Origin
@@ -449,8 +449,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1dfGDut-cOB8lypjPBd02V2V1IyolEmSd",
-         "name": "4 Krikkit One (Archive)",
+         "id": "1LMz6-q1jj0qRVrLV3P6H6yh6xybTlZW_",
+         "name": "2 Billion Year Bunker (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -470,10 +470,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:06:09 GMT
+  recorded_at: Sat, 20 Oct 2018 20:15:52 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1dfGDut-cOB8lypjPBd02V2V1IyolEmSd/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1LMz6-q1jj0qRVrLV3P6H6yh6xybTlZW_/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -485,7 +485,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:06:09 GMT
+      - Sat, 20 Oct 2018 20:15:52 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -502,7 +502,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:06:10 GMT
+      - Sat, 20 Oct 2018 20:15:52 GMT
       Vary:
       - Origin
       - X-Origin
@@ -532,10 +532,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:06:10 GMT
+  recorded_at: Sat, 20 Oct 2018 20:15:53 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1dfGDut-cOB8lypjPBd02V2V1IyolEmSd?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1LMz6-q1jj0qRVrLV3P6H6yh6xybTlZW_?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -547,7 +547,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:06:10 GMT
+      - Sat, 20 Oct 2018 20:15:53 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -558,9 +558,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:06:10 GMT
+      - Sat, 20 Oct 2018 20:15:53 GMT
       Date:
-      - Thu, 18 Oct 2018 11:06:10 GMT
+      - Sat, 20 Oct 2018 20:15:53 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -586,8 +586,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1dfGDut-cOB8lypjPBd02V2V1IyolEmSd",
-         "name": "4 Krikkit One (Archive)",
+         "id": "1LMz6-q1jj0qRVrLV3P6H6yh6xybTlZW_",
+         "name": "2 Billion Year Bunker (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -616,10 +616,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:06:10 GMT
+  recorded_at: Sat, 20 Oct 2018 20:15:53 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1dfGDut-cOB8lypjPBd02V2V1IyolEmSd/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1LMz6-q1jj0qRVrLV3P6H6yh6xybTlZW_/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -631,7 +631,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:06:10 GMT
+      - Sat, 20 Oct 2018 20:15:53 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -649,9 +649,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:06:10 GMT
+      - Sat, 20 Oct 2018 20:15:53 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:06:10 GMT
+      - Sat, 20 Oct 2018 20:15:53 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -683,10 +683,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:06:10 GMT
+  recorded_at: Sat, 20 Oct 2018 20:15:53 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/11TFG8nM7giT7v4U9hCeih3cVGEhHW2yS?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -698,7 +698,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:06:10 GMT
+      - Sat, 20 Oct 2018 20:15:53 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -709,9 +709,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:06:10 GMT
+      - Sat, 20 Oct 2018 20:15:53 GMT
       Date:
-      - Thu, 18 Oct 2018 11:06:10 GMT
+      - Sat, 20 Oct 2018 20:15:53 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -737,8 +737,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t",
-         "name": "Test @ 2018-10-18 11:06:06 UTC",
+         "id": "11TFG8nM7giT7v4U9hCeih3cVGEhHW2yS",
+         "name": "Test @ 2018-10-20 20:15:49 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -764,10 +764,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:06:10 GMT
+  recorded_at: Sat, 20 Oct 2018 20:15:53 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/11TFG8nM7giT7v4U9hCeih3cVGEhHW2yS/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -779,7 +779,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:06:10 GMT
+      - Sat, 20 Oct 2018 20:15:53 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -797,9 +797,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:06:10 GMT
+      - Sat, 20 Oct 2018 20:15:53 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:06:10 GMT
+      - Sat, 20 Oct 2018 20:15:53 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -831,10 +831,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:06:11 GMT
+  recorded_at: Sat, 20 Oct 2018 20:15:53 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%2711TFG8nM7giT7v4U9hCeih3cVGEhHW2yS%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -846,7 +846,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:06:11 GMT
+      - Sat, 20 Oct 2018 20:15:53 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -857,9 +857,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:06:11 GMT
+      - Sat, 20 Oct 2018 20:15:53 GMT
       Date:
-      - Thu, 18 Oct 2018 11:06:11 GMT
+      - Sat, 20 Oct 2018 20:15:53 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -887,14 +887,15 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1ghQKU6LqrubhsC0OCfOcGF333QMbsGxXLlAqzaPJK8k",
+           "id": "16cEqt2OVZYu-bmAqwG0_GTQQkkxQpGJlSPg-pKSwPqA",
            "name": "File To Trash",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t"
+            "11TFG8nM7giT7v4U9hCeih3cVGEhHW2yS"
            ],
-           "thumbnailVersion": "0",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=16cEqt2OVZYu-bmAqwG0_GTQQkkxQpGJlSPg-pKSwPqA&v=1&s=AMedNnoAAAAAW8upGVvuM_g_7WBSrh5m6cApR_Xs9Gkp&sz=s220",
+           "thumbnailVersion": "1",
            "permissions": [
             {
              "kind": "drive#permission",
@@ -919,10 +920,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:06:11 GMT
+  recorded_at: Sat, 20 Oct 2018 20:15:53 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1ghQKU6LqrubhsC0OCfOcGF333QMbsGxXLlAqzaPJK8k/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/16cEqt2OVZYu-bmAqwG0_GTQQkkxQpGJlSPg-pKSwPqA/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -934,7 +935,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:06:11 GMT
+      - Sat, 20 Oct 2018 20:15:53 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -945,9 +946,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:06:11 GMT
+      - Sat, 20 Oct 2018 20:15:54 GMT
       Date:
-      - Thu, 18 Oct 2018 11:06:11 GMT
+      - Sat, 20 Oct 2018 20:15:54 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -976,16 +977,16 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T11:06:08.360Z"
+         "modifiedTime": "2018-10-20T20:15:50.977Z"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:06:11 GMT
+  recorded_at: Sat, 20 Oct 2018 20:15:54 GMT
 - request:
-    method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1ghQKU6LqrubhsC0OCfOcGF333QMbsGxXLlAqzaPJK8k?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=16cEqt2OVZYu-bmAqwG0_GTQQkkxQpGJlSPg-pKSwPqA&s=AMedNnoAAAAAW8upGVvuM_g_7WBSrh5m6cApR_Xs9Gkp&sz=s350&v=1
     body:
       encoding: UTF-8
-      string: '{"trashed":"true"}'
+      string: ''
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -994,11 +995,71 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:06:11 GMT
+      - Sat, 20 Oct 2018 20:15:54 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 20 Oct 2018 20:15:54 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:15:54 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/16cEqt2OVZYu-bmAqwG0_GTQQkkxQpGJlSPg-pKSwPqA/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"File To Trash","parents":["1LMz6-q1jj0qRVrLV3P6H6yh6xybTlZW_"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:15:54 GMT
       Content-Type:
       - application/json
       Authorization:
-      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
   response:
     status:
       code: 200
@@ -1011,7 +1072,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:06:11 GMT
+      - Sat, 20 Oct 2018 20:15:55 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1035,14 +1096,187 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1ghQKU6LqrubhsC0OCfOcGF333QMbsGxXLlAqzaPJK8k",
+         "id": "1os-OXm_oRCQk7qpSQz7rKthIausLRiDHCSmqceEPvE8",
+         "name": "File To Trash",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1LMz6-q1jj0qRVrLV3P6H6yh6xybTlZW_"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:15:56 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/16cEqt2OVZYu-bmAqwG0_GTQQkkxQpGJlSPg-pKSwPqA/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"File To Trash","parents":["1LMz6-q1jj0qRVrLV3P6H6yh6xybTlZW_"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:15:56 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:15:57 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1g5CjBRP3QQh-Mbv4--KDKUgGIqiqmDIxQu3KWyEJVO4",
+         "name": "File To Trash",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1LMz6-q1jj0qRVrLV3P6H6yh6xybTlZW_"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:15:57 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/drive/v3/files/16cEqt2OVZYu-bmAqwG0_GTQQkkxQpGJlSPg-pKSwPqA?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"trashed":"true"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:15:57 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:15:58 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "16cEqt2OVZYu-bmAqwG0_GTQQkkxQpGJlSPg-pKSwPqA",
          "name": "File To Trash",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": true,
          "parents": [
-          "1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t"
+          "11TFG8nM7giT7v4U9hCeih3cVGEhHW2yS"
          ],
-         "thumbnailVersion": "0",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=16cEqt2OVZYu-bmAqwG0_GTQQkkxQpGJlSPg-pKSwPqA&v=1&s=AMedNnoAAAAAW8upHrsGhQhwwmd9oM5pIsRXRLKnkJap&sz=s220",
+         "thumbnailVersion": "1",
          "permissions": [
           {
            "kind": "drive#permission",
@@ -1065,10 +1299,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:06:12 GMT
+  recorded_at: Sat, 20 Oct 2018 20:15:58 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9517
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=10542
     body:
       encoding: UTF-8
       string: ''
@@ -1080,7 +1314,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:07:12 GMT
+      - Sat, 20 Oct 2018 20:16:58 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1091,9 +1325,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:07:12 GMT
+      - Sat, 20 Oct 2018 20:16:58 GMT
       Date:
-      - Thu, 18 Oct 2018 11:07:12 GMT
+      - Sat, 20 Oct 2018 20:16:58 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1119,27 +1353,30 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "9523",
+         "newStartPageToken": "10555",
          "changes": [
           {
-           "fileId": "1dfGDut-cOB8lypjPBd02V2V1IyolEmSd"
+           "fileId": "1LMz6-q1jj0qRVrLV3P6H6yh6xybTlZW_"
           },
           {
-           "fileId": "1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM"
+           "fileId": "1g5CjBRP3QQh-Mbv4--KDKUgGIqiqmDIxQu3KWyEJVO4"
           },
           {
-           "fileId": "1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t"
+           "fileId": "1os-OXm_oRCQk7qpSQz7rKthIausLRiDHCSmqceEPvE8"
           },
           {
-           "fileId": "1ghQKU6LqrubhsC0OCfOcGF333QMbsGxXLlAqzaPJK8k"
+           "fileId": "11TFG8nM7giT7v4U9hCeih3cVGEhHW2yS"
+          },
+          {
+           "fileId": "16cEqt2OVZYu-bmAqwG0_GTQQkkxQpGJlSPg-pKSwPqA"
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:07:12 GMT
+  recorded_at: Sat, 20 Oct 2018 20:16:58 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1dfGDut-cOB8lypjPBd02V2V1IyolEmSd?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1LMz6-q1jj0qRVrLV3P6H6yh6xybTlZW_?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1151,7 +1388,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:07:12 GMT
+      - Sat, 20 Oct 2018 20:16:58 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1162,9 +1399,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:07:12 GMT
+      - Sat, 20 Oct 2018 20:16:58 GMT
       Date:
-      - Thu, 18 Oct 2018 11:07:12 GMT
+      - Sat, 20 Oct 2018 20:16:58 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1190,8 +1427,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1dfGDut-cOB8lypjPBd02V2V1IyolEmSd",
-         "name": "4 Krikkit One (Archive)",
+         "id": "1LMz6-q1jj0qRVrLV3P6H6yh6xybTlZW_",
+         "name": "2 Billion Year Bunker (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -1220,10 +1457,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:07:12 GMT
+  recorded_at: Sat, 20 Oct 2018 20:16:58 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1dfGDut-cOB8lypjPBd02V2V1IyolEmSd/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1LMz6-q1jj0qRVrLV3P6H6yh6xybTlZW_/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1235,7 +1472,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:07:12 GMT
+      - Sat, 20 Oct 2018 20:16:58 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1253,9 +1490,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:07:12 GMT
+      - Sat, 20 Oct 2018 20:16:58 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:07:12 GMT
+      - Sat, 20 Oct 2018 20:16:58 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1287,10 +1524,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:07:12 GMT
+  recorded_at: Sat, 20 Oct 2018 20:16:58 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1g5CjBRP3QQh-Mbv4--KDKUgGIqiqmDIxQu3KWyEJVO4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1302,76 +1539,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:07:12 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 18 Oct 2018 11:07:12 GMT
-      Expires:
-      - Thu, 18 Oct 2018 11:07:12 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "notFound",
-            "message": "File not found: 1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM.",
-            "locationType": "parameter",
-            "location": "fileId"
-           }
-          ],
-          "code": 404,
-          "message": "File not found: 1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM."
-         }
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:07:12 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:07:12 GMT
+      - Sat, 20 Oct 2018 20:16:58 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1382,9 +1550,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:07:13 GMT
+      - Sat, 20 Oct 2018 20:16:58 GMT
       Date:
-      - Thu, 18 Oct 2018 11:07:13 GMT
+      - Sat, 20 Oct 2018 20:16:58 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1410,8 +1578,418 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t",
-         "name": "Test @ 2018-10-18 11:06:06 UTC",
+         "id": "1g5CjBRP3QQh-Mbv4--KDKUgGIqiqmDIxQu3KWyEJVO4",
+         "name": "File To Trash",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1LMz6-q1jj0qRVrLV3P6H6yh6xybTlZW_"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1g5CjBRP3QQh-Mbv4--KDKUgGIqiqmDIxQu3KWyEJVO4&v=1&s=AMedNnoAAAAAW8upWommGO2O4nuaPBdYafkTMyudA1Ra&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:16:58 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1g5CjBRP3QQh-Mbv4--KDKUgGIqiqmDIxQu3KWyEJVO4/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:16:58 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:16:59 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:16:59 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-20T20:15:56.963Z"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:16:59 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1g5CjBRP3QQh-Mbv4--KDKUgGIqiqmDIxQu3KWyEJVO4&s=AMedNnoAAAAAW8upWommGO2O4nuaPBdYafkTMyudA1Ra&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:16:59 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 20 Oct 2018 20:16:59 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:16:59 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1os-OXm_oRCQk7qpSQz7rKthIausLRiDHCSmqceEPvE8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:16:59 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:16:59 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:16:59 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1os-OXm_oRCQk7qpSQz7rKthIausLRiDHCSmqceEPvE8",
+         "name": "File To Trash",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1LMz6-q1jj0qRVrLV3P6H6yh6xybTlZW_"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1os-OXm_oRCQk7qpSQz7rKthIausLRiDHCSmqceEPvE8&v=1&s=AMedNnoAAAAAW8upWyGfeAcjUQ6L25UI57SyFnqAtwwx&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:16:59 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1os-OXm_oRCQk7qpSQz7rKthIausLRiDHCSmqceEPvE8/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:16:59 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:16:59 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:16:59 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-20T20:15:55.323Z"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:16:59 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1os-OXm_oRCQk7qpSQz7rKthIausLRiDHCSmqceEPvE8&s=AMedNnoAAAAAW8upWyGfeAcjUQ6L25UI57SyFnqAtwwx&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:16:59 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 20 Oct 2018 20:16:59 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sat, 20 Oct 2018 20:16:59 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/11TFG8nM7giT7v4U9hCeih3cVGEhHW2yS?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 20 Oct 2018 20:16:59 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 20 Oct 2018 20:17:00 GMT
+      Date:
+      - Sat, 20 Oct 2018 20:17:00 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "11TFG8nM7giT7v4U9hCeih3cVGEhHW2yS",
+         "name": "Test @ 2018-10-20 20:15:49 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -1437,10 +2015,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:07:13 GMT
+  recorded_at: Sat, 20 Oct 2018 20:17:00 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/11TFG8nM7giT7v4U9hCeih3cVGEhHW2yS/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1452,7 +2030,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:07:13 GMT
+      - Sat, 20 Oct 2018 20:17:00 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1470,9 +2048,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:07:13 GMT
+      - Sat, 20 Oct 2018 20:17:00 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:07:13 GMT
+      - Sat, 20 Oct 2018 20:17:00 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1504,10 +2082,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:07:13 GMT
+  recorded_at: Sat, 20 Oct 2018 20:17:00 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1ghQKU6LqrubhsC0OCfOcGF333QMbsGxXLlAqzaPJK8k?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/16cEqt2OVZYu-bmAqwG0_GTQQkkxQpGJlSPg-pKSwPqA?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1519,7 +2097,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:07:13 GMT
+      - Sat, 20 Oct 2018 20:17:00 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1530,9 +2108,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:07:13 GMT
+      - Sat, 20 Oct 2018 20:17:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:07:13 GMT
+      - Sat, 20 Oct 2018 20:17:00 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1558,14 +2136,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1ghQKU6LqrubhsC0OCfOcGF333QMbsGxXLlAqzaPJK8k",
+         "id": "16cEqt2OVZYu-bmAqwG0_GTQQkkxQpGJlSPg-pKSwPqA",
          "name": "File To Trash",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": true,
          "parents": [
-          "1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t"
+          "11TFG8nM7giT7v4U9hCeih3cVGEhHW2yS"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1ghQKU6LqrubhsC0OCfOcGF333QMbsGxXLlAqzaPJK8k&v=1&s=AMedNnoAAAAAW8iFgdSEJ1W_aBUCNIbyfw5g1fmEIUKZ&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=16cEqt2OVZYu-bmAqwG0_GTQQkkxQpGJlSPg-pKSwPqA&v=1&s=AMedNnoAAAAAW8upXJ0BkRCYWFDrpdKs-HQrWNUhrWOK&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -1589,10 +2167,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:07:13 GMT
+  recorded_at: Sat, 20 Oct 2018 20:17:00 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t
+    uri: https://www.googleapis.com/drive/v3/files/11TFG8nM7giT7v4U9hCeih3cVGEhHW2yS
     body:
       encoding: UTF-8
       string: ''
@@ -1604,7 +2182,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:07:13 GMT
+      - Sat, 20 Oct 2018 20:17:00 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1621,7 +2199,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:07:13 GMT
+      - Sat, 20 Oct 2018 20:17:01 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1633,5 +2211,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:07:14 GMT
+  recorded_at: Sat, 20 Oct 2018 20:17:01 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_trashes_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_trashes_file.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,42 +21,39 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:32:51 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:36:22 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:32:52 GMT
+  recorded_at: Thu, 18 Oct 2018 09:36:22 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -66,7 +63,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -78,49 +75,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:32:52 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:36:23 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:32:52 GMT
+  recorded_at: Thu, 18 Oct 2018 09:36:23 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        21:32:52 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:36:23 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -129,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:32:52 GMT
+      - Thu, 18 Oct 2018 09:36:23 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -146,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:32:53 GMT
+      - Thu, 18 Oct 2018 09:36:23 GMT
       Vary:
       - Origin
       - X-Origin
@@ -163,28 +157,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1hXMK5MtEBv0JdPGn98b7nAzbbh9RMW56",
-         "name": "Test @ 2018-03-18 21:32:52 UTC",
+         "id": "1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f",
+         "name": "Test @ 2018-10-18 09:36:23 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AEIi2L68pCuiUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:32:53 GMT
+  recorded_at: Thu, 18 Oct 2018 09:36:23 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1hXMK5MtEBv0JdPGn98b7nAzbbh9RMW56/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -196,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:32:53 GMT
+      - Thu, 18 Oct 2018 09:36:23 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -213,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:32:54 GMT
+      - Thu, 18 Oct 2018 09:36:24 GMT
       Vary:
       - Origin
       - X-Origin
@@ -230,8 +234,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -244,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:32:54 GMT
+  recorded_at: Thu, 18 Oct 2018 09:36:24 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -259,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:32:54 GMT
+      - Thu, 18 Oct 2018 09:36:24 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -270,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:32:54 GMT
+      - Thu, 18 Oct 2018 09:36:24 GMT
       Date:
-      - Sun, 18 Mar 2018 21:32:54 GMT
+      - Thu, 18 Oct 2018 09:36:24 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -291,8 +294,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -300,17 +302,17 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "7176"
+         "startPageToken": "9357"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:32:54 GMT
+  recorded_at: Thu, 18 Oct 2018 09:36:24 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.document","name":"File To
-        Trash","parents":["1hXMK5MtEBv0JdPGn98b7nAzbbh9RMW56"]}'
+        Trash","parents":["1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -319,7 +321,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:32:54 GMT
+      - Thu, 18 Oct 2018 09:36:24 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -336,7 +338,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:32:55 GMT
+      - Thu, 18 Oct 2018 09:36:25 GMT
       Vary:
       - Origin
       - X-Origin
@@ -353,28 +355,47 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1jqjMm4nEGjUB54A0mUOJtalJoYwoAxUGzao_M_p8fxU",
+         "id": "1u9EVYrOHeQaLt0YC6uXhApTnsx5KxTgnKPzQUp_bvlw",
          "name": "File To Trash",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1hXMK5MtEBv0JdPGn98b7nAzbbh9RMW56"
+          "1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:32:55 GMT
+  recorded_at: Thu, 18 Oct 2018 09:36:25 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1hXMK5MtEBv0JdPGn98b7nAzbbh9RMW56?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -386,7 +407,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:32:55 GMT
+      - Thu, 18 Oct 2018 09:36:25 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -397,9 +418,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:32:55 GMT
+      - Thu, 18 Oct 2018 09:36:25 GMT
       Date:
-      - Sun, 18 Mar 2018 21:32:55 GMT
+      - Thu, 18 Oct 2018 09:36:25 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -418,25 +439,44 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1hXMK5MtEBv0JdPGn98b7nAzbbh9RMW56",
-         "name": "Test @ 2018-03-18 21:32:52 UTC",
+         "id": "1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f",
+         "name": "Test @ 2018-10-18 09:36:23 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:32:55 GMT
+  recorded_at: Thu, 18 Oct 2018 09:36:25 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1hXMK5MtEBv0JdPGn98b7nAzbbh9RMW56/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -448,7 +488,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:32:55 GMT
+      - Thu, 18 Oct 2018 09:36:25 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -466,9 +506,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:32:55 GMT
+      - Thu, 18 Oct 2018 09:36:25 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:32:55 GMT
+      - Thu, 18 Oct 2018 09:36:25 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -480,8 +520,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -501,10 +540,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:32:55 GMT
+  recorded_at: Thu, 18 Oct 2018 09:36:25 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271hXMK5MtEBv0JdPGn98b7nAzbbh9RMW56%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -516,7 +555,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:32:56 GMT
+      - Thu, 18 Oct 2018 09:36:25 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -527,9 +566,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:32:56 GMT
+      - Thu, 18 Oct 2018 09:36:26 GMT
       Date:
-      - Sun, 18 Mar 2018 21:32:56 GMT
+      - Thu, 18 Oct 2018 09:36:26 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -548,8 +587,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -558,22 +596,42 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1jqjMm4nEGjUB54A0mUOJtalJoYwoAxUGzao_M_p8fxU",
+           "id": "1u9EVYrOHeQaLt0YC6uXhApTnsx5KxTgnKPzQUp_bvlw",
            "name": "File To Trash",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1hXMK5MtEBv0JdPGn98b7nAzbbh9RMW56"
+            "1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f"
            ],
-           "thumbnailVersion": "0"
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "writer",
+             "displayName": "Upshift One",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "13193959451567607887",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+             "role": "owner",
+             "displayName": "Testuser Upshift One",
+             "deleted": false
+            }
+           ]
           }
          ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:32:56 GMT
+  recorded_at: Thu, 18 Oct 2018 09:36:26 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1jqjMm4nEGjUB54A0mUOJtalJoYwoAxUGzao_M_p8fxU/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1u9EVYrOHeQaLt0YC6uXhApTnsx5KxTgnKPzQUp_bvlw/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -585,7 +643,221 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:32:56 GMT
+      - Thu, 18 Oct 2018 09:36:26 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 09:36:26 GMT
+      Date:
+      - Thu, 18 Oct 2018 09:36:26 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-18T09:36:24.867Z"
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 09:36:26 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/drive/v3/files/1u9EVYrOHeQaLt0YC6uXhApTnsx5KxTgnKPzQUp_bvlw?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"trashed":"true"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 09:36:26 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 09:36:26 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1u9EVYrOHeQaLt0YC6uXhApTnsx5KxTgnKPzQUp_bvlw",
+         "name": "File To Trash",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": true,
+         "parents": [
+          "1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 09:36:26 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9357
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 09:37:26 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 09:37:27 GMT
+      Date:
+      - Thu, 18 Oct 2018 09:37:27 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "newStartPageToken": "9362",
+         "changes": [
+          {
+           "fileId": "1iB2qfWA_iDp8FYz9jYFRRzFfTTRLERrw7mFQheUbF4Q"
+          },
+          {
+           "fileId": "1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f"
+          },
+          {
+           "fileId": "1u9EVYrOHeQaLt0YC6uXhApTnsx5KxTgnKPzQUp_bvlw"
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 09:37:27 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1iB2qfWA_iDp8FYz9jYFRRzFfTTRLERrw7mFQheUbF4Q?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 09:37:27 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -603,9 +875,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:32:56 GMT
+      - Thu, 18 Oct 2018 09:37:27 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:32:56 GMT
+      - Thu, 18 Oct 2018 09:37:27 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -617,8 +889,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -630,87 +901,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "Revision not found: head.",
+            "message": "File not found: 1iB2qfWA_iDp8FYz9jYFRRzFfTTRLERrw7mFQheUbF4Q.",
             "locationType": "parameter",
-            "location": "revisionId"
+            "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "Revision not found: head."
+          "message": "File not found: 1iB2qfWA_iDp8FYz9jYFRRzFfTTRLERrw7mFQheUbF4Q."
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:32:56 GMT
-- request:
-    method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1jqjMm4nEGjUB54A0mUOJtalJoYwoAxUGzao_M_p8fxU?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: '{"trashed":"true"}'
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sun, 18 Mar 2018 21:32:56 GMT
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:32:56 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1jqjMm4nEGjUB54A0mUOJtalJoYwoAxUGzao_M_p8fxU",
-         "name": "File To Trash",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": true,
-         "parents": [
-          "1hXMK5MtEBv0JdPGn98b7nAzbbh9RMW56"
-         ],
-         "thumbnailVersion": "0"
-        }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:32:56 GMT
+  recorded_at: Thu, 18 Oct 2018 09:37:27 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=7176
+    uri: https://www.googleapis.com/drive/v3/files/1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -722,7 +926,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:33:56 GMT
+      - Thu, 18 Oct 2018 09:37:27 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -733,9 +937,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:33:57 GMT
+      - Thu, 18 Oct 2018 09:37:27 GMT
       Date:
-      - Sun, 18 Mar 2018 21:33:57 GMT
+      - Thu, 18 Oct 2018 09:37:27 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -754,29 +958,44 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "7179",
-         "changes": [
+         "id": "1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f",
+         "name": "Test @ 2018-10-18 09:36:23 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
           {
-           "fileId": "1hXMK5MtEBv0JdPGn98b7nAzbbh9RMW56"
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
           },
           {
-           "fileId": "1jqjMm4nEGjUB54A0mUOJtalJoYwoAxUGzao_M_p8fxU"
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:33:57 GMT
+  recorded_at: Thu, 18 Oct 2018 09:37:27 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1hXMK5MtEBv0JdPGn98b7nAzbbh9RMW56?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -788,69 +1007,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:33:57 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sun, 18 Mar 2018 21:33:57 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:33:57 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1hXMK5MtEBv0JdPGn98b7nAzbbh9RMW56",
-         "name": "Test @ 2018-03-18 21:32:52 UTC",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "thumbnailVersion": "0"
-        }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:33:57 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1hXMK5MtEBv0JdPGn98b7nAzbbh9RMW56/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sun, 18 Mar 2018 21:33:57 GMT
+      - Thu, 18 Oct 2018 09:37:27 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -868,9 +1025,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:33:57 GMT
+      - Thu, 18 Oct 2018 09:37:27 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:33:57 GMT
+      - Thu, 18 Oct 2018 09:37:27 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -882,8 +1039,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -903,10 +1059,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:33:57 GMT
+  recorded_at: Thu, 18 Oct 2018 09:37:27 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1jqjMm4nEGjUB54A0mUOJtalJoYwoAxUGzao_M_p8fxU?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1u9EVYrOHeQaLt0YC6uXhApTnsx5KxTgnKPzQUp_bvlw?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -918,7 +1074,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:33:57 GMT
+      - Thu, 18 Oct 2018 09:37:27 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -929,9 +1085,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:33:59 GMT
+      - Thu, 18 Oct 2018 09:37:27 GMT
       Date:
-      - Sun, 18 Mar 2018 21:33:59 GMT
+      - Thu, 18 Oct 2018 09:37:27 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -950,29 +1106,48 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1jqjMm4nEGjUB54A0mUOJtalJoYwoAxUGzao_M_p8fxU",
+         "id": "1u9EVYrOHeQaLt0YC6uXhApTnsx5KxTgnKPzQUp_bvlw",
          "name": "File To Trash",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": true,
          "parents": [
-          "1hXMK5MtEBv0JdPGn98b7nAzbbh9RMW56"
+          "1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1jqjMm4nEGjUB54A0mUOJtalJoYwoAxUGzao_M_p8fxU&v=1&s=AMedNnoAAAAAWq73Zx1jNggqvUV44bbo6EKEiYGr8Bos&sz=s220",
-         "thumbnailVersion": "1"
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1u9EVYrOHeQaLt0YC6uXhApTnsx5KxTgnKPzQUp_bvlw&v=1&s=AMedNnoAAAAAW8hwd0Rseix96nJKnot9AUk5D1-E5jur&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:33:59 GMT
+  recorded_at: Thu, 18 Oct 2018 09:37:27 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1hXMK5MtEBv0JdPGn98b7nAzbbh9RMW56
+    uri: https://www.googleapis.com/drive/v3/files/1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f
     body:
       encoding: UTF-8
       string: ''
@@ -984,7 +1159,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:33:59 GMT
+      - Thu, 18 Oct 2018 09:37:28 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1001,18 +1176,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:34:00 GMT
+      - Thu, 18 Oct 2018 09:37:28 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:34:00 GMT
+  recorded_at: Thu, 18 Oct 2018 09:37:28 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_trashes_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_trashes_file.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:36:22 GMT
+      - Thu, 18 Oct 2018 11:06:06 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:36:22 GMT
+  recorded_at: Thu, 18 Oct 2018 11:06:06 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:36:23 GMT
+      - Thu, 18 Oct 2018 11:06:06 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:36:23 GMT
+  recorded_at: Thu, 18 Oct 2018 11:06:06 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        09:36:23 UTC","parents":["root"]}'
+        11:06:06 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:36:23 GMT
+      - Thu, 18 Oct 2018 11:06:06 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:36:23 GMT
+      - Thu, 18 Oct 2018 11:06:06 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f",
-         "name": "Test @ 2018-10-18 09:36:23 UTC",
+         "id": "1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t",
+         "name": "Test @ 2018-10-18 11:06:06 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:36:23 GMT
+  recorded_at: Thu, 18 Oct 2018 11:06:07 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:36:23 GMT
+      - Thu, 18 Oct 2018 11:06:07 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:36:24 GMT
+      - Thu, 18 Oct 2018 11:06:07 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:36:24 GMT
+  recorded_at: Thu, 18 Oct 2018 11:06:07 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:36:24 GMT
+      - Thu, 18 Oct 2018 11:06:07 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:36:24 GMT
+      - Thu, 18 Oct 2018 11:06:07 GMT
       Date:
-      - Thu, 18 Oct 2018 09:36:24 GMT
+      - Thu, 18 Oct 2018 11:06:07 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,17 +302,17 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "9357"
+         "startPageToken": "9517"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:36:24 GMT
+  recorded_at: Thu, 18 Oct 2018 11:06:07 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.document","name":"File To
-        Trash","parents":["1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f"]}'
+        Trash","parents":["1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -321,7 +321,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:36:24 GMT
+      - Thu, 18 Oct 2018 11:06:07 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -338,7 +338,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:36:25 GMT
+      - Thu, 18 Oct 2018 11:06:09 GMT
       Vary:
       - Origin
       - X-Origin
@@ -362,12 +362,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1u9EVYrOHeQaLt0YC6uXhApTnsx5KxTgnKPzQUp_bvlw",
+         "id": "1ghQKU6LqrubhsC0OCfOcGF333QMbsGxXLlAqzaPJK8k",
          "name": "File To Trash",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f"
+          "1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -392,10 +392,150 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:36:25 GMT
+  recorded_at: Thu, 18 Oct 2018 11:06:09 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"4 Krikkit
+        One (Archive)","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:06:09 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:06:09 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1dfGDut-cOB8lypjPBd02V2V1IyolEmSd",
+         "name": "4 Krikkit One (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:06:09 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1dfGDut-cOB8lypjPBd02V2V1IyolEmSd/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:06:09 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:06:10 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "13193959451567607887",
+         "type": "user",
+         "role": "reader"
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:06:10 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1dfGDut-cOB8lypjPBd02V2V1IyolEmSd?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -407,7 +547,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:36:25 GMT
+      - Thu, 18 Oct 2018 11:06:10 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -418,9 +558,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:36:25 GMT
+      - Thu, 18 Oct 2018 11:06:10 GMT
       Date:
-      - Thu, 18 Oct 2018 09:36:25 GMT
+      - Thu, 18 Oct 2018 11:06:10 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -446,37 +586,40 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f",
-         "name": "Test @ 2018-10-18 09:36:23 UTC",
+         "id": "1dfGDut-cOB8lypjPBd02V2V1IyolEmSd",
+         "name": "4 Krikkit One (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
          "thumbnailVersion": "0",
          "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
           {
            "kind": "drive#permission",
            "id": "13193959451567607887",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
+           "role": "reader",
            "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
            "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:36:25 GMT
+  recorded_at: Thu, 18 Oct 2018 11:06:10 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1dfGDut-cOB8lypjPBd02V2V1IyolEmSd/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -488,7 +631,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:36:25 GMT
+      - Thu, 18 Oct 2018 11:06:10 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -506,9 +649,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:36:25 GMT
+      - Thu, 18 Oct 2018 11:06:10 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:36:25 GMT
+      - Thu, 18 Oct 2018 11:06:10 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -540,10 +683,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:36:25 GMT
+  recorded_at: Thu, 18 Oct 2018 11:06:10 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files/1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -555,7 +698,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:36:25 GMT
+      - Thu, 18 Oct 2018 11:06:10 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -566,9 +709,157 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:36:26 GMT
+      - Thu, 18 Oct 2018 11:06:10 GMT
       Date:
-      - Thu, 18 Oct 2018 09:36:26 GMT
+      - Thu, 18 Oct 2018 11:06:10 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t",
+         "name": "Test @ 2018-10-18 11:06:06 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:06:10 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:06:10 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:06:10 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:06:10 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:06:11 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:06:11 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:06:11 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:06:11 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -596,12 +887,12 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1u9EVYrOHeQaLt0YC6uXhApTnsx5KxTgnKPzQUp_bvlw",
+           "id": "1ghQKU6LqrubhsC0OCfOcGF333QMbsGxXLlAqzaPJK8k",
            "name": "File To Trash",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f"
+            "1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -628,10 +919,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:36:26 GMT
+  recorded_at: Thu, 18 Oct 2018 11:06:11 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1u9EVYrOHeQaLt0YC6uXhApTnsx5KxTgnKPzQUp_bvlw/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1ghQKU6LqrubhsC0OCfOcGF333QMbsGxXLlAqzaPJK8k/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -643,7 +934,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:36:26 GMT
+      - Thu, 18 Oct 2018 11:06:11 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -654,9 +945,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:36:26 GMT
+      - Thu, 18 Oct 2018 11:06:11 GMT
       Date:
-      - Thu, 18 Oct 2018 09:36:26 GMT
+      - Thu, 18 Oct 2018 11:06:11 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -685,13 +976,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T09:36:24.867Z"
+         "modifiedTime": "2018-10-18T11:06:08.360Z"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:36:26 GMT
+  recorded_at: Thu, 18 Oct 2018 11:06:11 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1u9EVYrOHeQaLt0YC6uXhApTnsx5KxTgnKPzQUp_bvlw?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ghQKU6LqrubhsC0OCfOcGF333QMbsGxXLlAqzaPJK8k?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"trashed":"true"}'
@@ -703,7 +994,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:36:26 GMT
+      - Thu, 18 Oct 2018 11:06:11 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -720,7 +1011,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:36:26 GMT
+      - Thu, 18 Oct 2018 11:06:11 GMT
       Vary:
       - Origin
       - X-Origin
@@ -744,12 +1035,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1u9EVYrOHeQaLt0YC6uXhApTnsx5KxTgnKPzQUp_bvlw",
+         "id": "1ghQKU6LqrubhsC0OCfOcGF333QMbsGxXLlAqzaPJK8k",
          "name": "File To Trash",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": true,
          "parents": [
-          "1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f"
+          "1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -774,10 +1065,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:36:26 GMT
+  recorded_at: Thu, 18 Oct 2018 11:06:12 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9357
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9517
     body:
       encoding: UTF-8
       string: ''
@@ -789,7 +1080,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:37:26 GMT
+      - Thu, 18 Oct 2018 11:07:12 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -800,9 +1091,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:37:27 GMT
+      - Thu, 18 Oct 2018 11:07:12 GMT
       Date:
-      - Thu, 18 Oct 2018 09:37:27 GMT
+      - Thu, 18 Oct 2018 11:07:12 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -828,24 +1119,27 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "9362",
+         "newStartPageToken": "9523",
          "changes": [
           {
-           "fileId": "1iB2qfWA_iDp8FYz9jYFRRzFfTTRLERrw7mFQheUbF4Q"
+           "fileId": "1dfGDut-cOB8lypjPBd02V2V1IyolEmSd"
           },
           {
-           "fileId": "1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f"
+           "fileId": "1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM"
           },
           {
-           "fileId": "1u9EVYrOHeQaLt0YC6uXhApTnsx5KxTgnKPzQUp_bvlw"
+           "fileId": "1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t"
+          },
+          {
+           "fileId": "1ghQKU6LqrubhsC0OCfOcGF333QMbsGxXLlAqzaPJK8k"
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:37:27 GMT
+  recorded_at: Thu, 18 Oct 2018 11:07:12 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1iB2qfWA_iDp8FYz9jYFRRzFfTTRLERrw7mFQheUbF4Q?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1dfGDut-cOB8lypjPBd02V2V1IyolEmSd?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -857,76 +1151,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:37:27 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 18 Oct 2018 09:37:27 GMT
-      Expires:
-      - Thu, 18 Oct 2018 09:37:27 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "notFound",
-            "message": "File not found: 1iB2qfWA_iDp8FYz9jYFRRzFfTTRLERrw7mFQheUbF4Q.",
-            "locationType": "parameter",
-            "location": "fileId"
-           }
-          ],
-          "code": 404,
-          "message": "File not found: 1iB2qfWA_iDp8FYz9jYFRRzFfTTRLERrw7mFQheUbF4Q."
-         }
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:37:27 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 09:37:27 GMT
+      - Thu, 18 Oct 2018 11:07:12 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -937,9 +1162,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:37:27 GMT
+      - Thu, 18 Oct 2018 11:07:12 GMT
       Date:
-      - Thu, 18 Oct 2018 09:37:27 GMT
+      - Thu, 18 Oct 2018 11:07:12 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -965,37 +1190,40 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f",
-         "name": "Test @ 2018-10-18 09:36:23 UTC",
+         "id": "1dfGDut-cOB8lypjPBd02V2V1IyolEmSd",
+         "name": "4 Krikkit One (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
          "thumbnailVersion": "0",
          "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
           {
            "kind": "drive#permission",
            "id": "13193959451567607887",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
+           "role": "reader",
            "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
            "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:37:27 GMT
+  recorded_at: Thu, 18 Oct 2018 11:07:12 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1dfGDut-cOB8lypjPBd02V2V1IyolEmSd/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1007,7 +1235,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:37:27 GMT
+      - Thu, 18 Oct 2018 11:07:12 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1025,9 +1253,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:37:27 GMT
+      - Thu, 18 Oct 2018 11:07:12 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:37:27 GMT
+      - Thu, 18 Oct 2018 11:07:12 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1059,10 +1287,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:37:27 GMT
+  recorded_at: Thu, 18 Oct 2018 11:07:12 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1u9EVYrOHeQaLt0YC6uXhApTnsx5KxTgnKPzQUp_bvlw?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1074,7 +1302,76 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:37:27 GMT
+      - Thu, 18 Oct 2018 11:07:12 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:07:12 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:07:12 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "notFound",
+            "message": "File not found: 1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM.",
+            "locationType": "parameter",
+            "location": "fileId"
+           }
+          ],
+          "code": 404,
+          "message": "File not found: 1Xa3gRYNYOUK1jEk8jtBK7xmLd1ysmKRHqUGSLQr66vM."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:07:12 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:07:12 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1085,9 +1382,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:37:27 GMT
+      - Thu, 18 Oct 2018 11:07:13 GMT
       Date:
-      - Thu, 18 Oct 2018 09:37:27 GMT
+      - Thu, 18 Oct 2018 11:07:13 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1113,14 +1410,162 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1u9EVYrOHeQaLt0YC6uXhApTnsx5KxTgnKPzQUp_bvlw",
+         "id": "1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t",
+         "name": "Test @ 2018-10-18 11:06:06 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:07:13 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:07:13 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:07:13 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:07:13 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:07:13 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1ghQKU6LqrubhsC0OCfOcGF333QMbsGxXLlAqzaPJK8k?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:07:13 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:07:13 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:07:13 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1ghQKU6LqrubhsC0OCfOcGF333QMbsGxXLlAqzaPJK8k",
          "name": "File To Trash",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": true,
          "parents": [
-          "1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f"
+          "1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1u9EVYrOHeQaLt0YC6uXhApTnsx5KxTgnKPzQUp_bvlw&v=1&s=AMedNnoAAAAAW8hwd0Rseix96nJKnot9AUk5D1-E5jur&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1ghQKU6LqrubhsC0OCfOcGF333QMbsGxXLlAqzaPJK8k&v=1&s=AMedNnoAAAAAW8iFgdSEJ1W_aBUCNIbyfw5g1fmEIUKZ&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -1144,10 +1589,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:37:27 GMT
+  recorded_at: Thu, 18 Oct 2018 11:07:13 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1eZ0Owx19-a8VDhLlF6f6Jy6cGkfThi5f
+    uri: https://www.googleapis.com/drive/v3/files/1HHa9sxcd5rva_WRQPDcwI_OwiEhGAe5t
     body:
       encoding: UTF-8
       string: ''
@@ -1159,7 +1604,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:37:28 GMT
+      - Thu, 18 Oct 2018 11:07:13 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1176,7 +1621,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:37:28 GMT
+      - Thu, 18 Oct 2018 11:07:13 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1188,5 +1633,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:37:28 GMT
+  recorded_at: Thu, 18 Oct 2018 11:07:14 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_updates_file_content.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_updates_file_content.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,42 +21,39 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:37:23 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:41:56 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:37:23 GMT
+  recorded_at: Thu, 18 Oct 2018 09:41:56 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -66,7 +63,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -78,49 +75,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:37:23 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:41:56 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:37:23 GMT
+  recorded_at: Thu, 18 Oct 2018 09:41:56 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        21:37:23 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:41:56 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -129,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:37:23 GMT
+      - Thu, 18 Oct 2018 09:41:56 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -146,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:37:24 GMT
+      - Thu, 18 Oct 2018 09:41:57 GMT
       Vary:
       - Origin
       - X-Origin
@@ -163,28 +157,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1rPXw4vYFpXD7G9eut0_2DRHHRc3iRpOd",
-         "name": "Test @ 2018-03-18 21:37:23 UTC",
+         "id": "1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50",
+         "name": "Test @ 2018-10-18 09:41:56 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AEIi2L68pCuiUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:37:24 GMT
+  recorded_at: Thu, 18 Oct 2018 09:41:57 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1rPXw4vYFpXD7G9eut0_2DRHHRc3iRpOd/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -196,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:37:24 GMT
+      - Thu, 18 Oct 2018 09:41:57 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -213,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:37:25 GMT
+      - Thu, 18 Oct 2018 09:41:57 GMT
       Vary:
       - Origin
       - X-Origin
@@ -230,8 +234,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -244,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:37:25 GMT
+  recorded_at: Thu, 18 Oct 2018 09:41:57 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -259,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:37:25 GMT
+      - Thu, 18 Oct 2018 09:41:57 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -270,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:37:25 GMT
+      - Thu, 18 Oct 2018 09:41:57 GMT
       Date:
-      - Sun, 18 Mar 2018 21:37:25 GMT
+      - Thu, 18 Oct 2018 09:41:57 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -291,8 +294,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -300,16 +302,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "7197"
+         "startPageToken": "9387"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:37:25 GMT
+  recorded_at: Thu, 18 Oct 2018 09:41:57 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1rPXw4vYFpXD7G9eut0_2DRHHRc3iRpOd"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -318,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:37:25 GMT
+      - Thu, 18 Oct 2018 09:41:58 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -335,7 +337,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:37:26 GMT
+      - Thu, 18 Oct 2018 09:41:59 GMT
       Vary:
       - Origin
       - X-Origin
@@ -352,28 +354,47 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1OGV9dFWw1nhyctVh0SO015vmXuKSK64UidROOVvpo-8",
+         "id": "1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1rPXw4vYFpXD7G9eut0_2DRHHRc3iRpOd"
+          "1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:37:26 GMT
+  recorded_at: Thu, 18 Oct 2018 09:41:59 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1rPXw4vYFpXD7G9eut0_2DRHHRc3iRpOd?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -385,7 +406,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:37:26 GMT
+      - Thu, 18 Oct 2018 09:41:59 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -396,9 +417,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:37:26 GMT
+      - Thu, 18 Oct 2018 09:41:59 GMT
       Date:
-      - Sun, 18 Mar 2018 21:37:26 GMT
+      - Thu, 18 Oct 2018 09:41:59 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -417,25 +438,44 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1rPXw4vYFpXD7G9eut0_2DRHHRc3iRpOd",
-         "name": "Test @ 2018-03-18 21:37:23 UTC",
+         "id": "1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50",
+         "name": "Test @ 2018-10-18 09:41:56 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:37:26 GMT
+  recorded_at: Thu, 18 Oct 2018 09:41:59 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1rPXw4vYFpXD7G9eut0_2DRHHRc3iRpOd/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -447,7 +487,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:37:26 GMT
+      - Thu, 18 Oct 2018 09:41:59 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -465,9 +505,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:37:27 GMT
+      - Thu, 18 Oct 2018 09:41:59 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:37:27 GMT
+      - Thu, 18 Oct 2018 09:41:59 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -479,8 +519,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -500,10 +539,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:37:27 GMT
+  recorded_at: Thu, 18 Oct 2018 09:41:59 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271rPXw4vYFpXD7G9eut0_2DRHHRc3iRpOd%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -515,7 +554,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:37:27 GMT
+      - Thu, 18 Oct 2018 09:41:59 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -526,9 +565,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:37:27 GMT
+      - Thu, 18 Oct 2018 09:41:59 GMT
       Date:
-      - Sun, 18 Mar 2018 21:37:27 GMT
+      - Thu, 18 Oct 2018 09:41:59 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -547,8 +586,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -557,22 +595,42 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1OGV9dFWw1nhyctVh0SO015vmXuKSK64UidROOVvpo-8",
+           "id": "1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE",
            "name": "File",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1rPXw4vYFpXD7G9eut0_2DRHHRc3iRpOd"
+            "1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50"
            ],
-           "thumbnailVersion": "0"
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "writer",
+             "displayName": "Upshift One",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "13193959451567607887",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+             "role": "owner",
+             "displayName": "Testuser Upshift One",
+             "deleted": false
+            }
+           ]
           }
          ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:37:27 GMT
+  recorded_at: Thu, 18 Oct 2018 09:41:59 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1OGV9dFWw1nhyctVh0SO015vmXuKSK64UidROOVvpo-8/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -584,16 +642,22 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:37:27 GMT
+      - Thu, 18 Oct 2018 09:41:59 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
       - application/x-www-form-urlencoded
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 200
+      message: OK
     headers:
+      Expires:
+      - Thu, 18 Oct 2018 09:42:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 09:42:00 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
       Vary:
       - Origin
       - X-Origin
@@ -601,12 +665,6 @@ http_interactions:
       - application/json; charset=UTF-8
       Content-Encoding:
       - gzip
-      Date:
-      - Sun, 18 Mar 2018 21:37:27 GMT
-      Expires:
-      - Sun, 18 Mar 2018 21:37:27 GMT
-      Cache-Control:
-      - private, max-age=0
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -616,33 +674,23 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "notFound",
-            "message": "Revision not found: head.",
-            "locationType": "parameter",
-            "location": "revisionId"
-           }
-          ],
-          "code": 404,
-          "message": "Revision not found: head."
-         }
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-18T09:41:58.333Z"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:37:27 GMT
+  recorded_at: Thu, 18 Oct 2018 09:42:00 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/upload/drive/v3/files/1OGV9dFWw1nhyctVh0SO015vmXuKSK64UidROOVvpo-8
+    uri: https://www.googleapis.com/upload/drive/v3/files/1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE
     body:
       encoding: UTF-8
       string: ''
@@ -654,7 +702,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:37:27 GMT
+      - Thu, 18 Oct 2018 09:42:00 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       X-Goog-Upload-Protocol:
@@ -673,22 +721,22 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2Uq-L3_mUbx9DZnYTGtEYvx7OGc3U-FCzitxYSDkZr3fWpKw8BDKCc4J8EhJMbDy6LmGr-HQWJedP2MscLf5G0opNDfhlw
+      - AEnB2Uq5GHR5UWrAOMb7wzAByG33zH2Ma-NlJfyykPU6sU2eOIIMoh6M06tNFRIPaorRHTh3d5K7TKwnzQuuEKg8uCFQ2Y-qqDE-C9dvPGgabTTzzayjqyc
       X-Goog-Upload-Status:
       - active
       X-Goog-Upload-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1OGV9dFWw1nhyctVh0SO015vmXuKSK64UidROOVvpo-8?upload_id=AEnB2Uq-L3_mUbx9DZnYTGtEYvx7OGc3U-FCzitxYSDkZr3fWpKw8BDKCc4J8EhJMbDy6LmGr-HQWJedP2MscLf5G0opNDfhlw&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE?upload_id=AEnB2Uq5GHR5UWrAOMb7wzAByG33zH2Ma-NlJfyykPU6sU2eOIIMoh6M06tNFRIPaorRHTh3d5K7TKwnzQuuEKg8uCFQ2Y-qqDE-C9dvPGgabTTzzayjqyc&upload_protocol=resumable
       X-Goog-Upload-Control-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1OGV9dFWw1nhyctVh0SO015vmXuKSK64UidROOVvpo-8?upload_id=AEnB2Uq-L3_mUbx9DZnYTGtEYvx7OGc3U-FCzitxYSDkZr3fWpKw8BDKCc4J8EhJMbDy6LmGr-HQWJedP2MscLf5G0opNDfhlw&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE?upload_id=AEnB2Uq5GHR5UWrAOMb7wzAByG33zH2Ma-NlJfyykPU6sU2eOIIMoh6M06tNFRIPaorRHTh3d5K7TKwnzQuuEKg8uCFQ2Y-qqDE-C9dvPGgabTTzzayjqyc&upload_protocol=resumable
       X-Goog-Upload-Chunk-Granularity:
       - '262144'
       X-Goog-Upload-Header-Vary:
       - Origin
       - X-Origin
       X-Goog-Upload-Header-X-Google-Backends:
-      - ioj69:4624
+      - iox123:4257
       X-Goog-Upload-Header-X-Google-Session-Info:
-      - CKeBxoimHBoCGAY6bwoPZHJpdmUtcm9zeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqYARKEAXlhMjkuR2wyQ0JZQmdndkN6RExyUUF0RDU1MGdzYm41RDY3SXlBQjhmSkxwWndYUWVJUDUyYVE2M0JJZ1hlWG42QzNtRnBlTVJMMlFYYWlvZ0t1NHllMG5GRVhUOEZ4R1RBZUVMd0E0a3F0VmpjdldKM3pvWkd4bFRXNkpYblBuOXZlZzAEOg0xL1N4M0NoLWFKdTJ-
+      - CKeBxoimHBoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqVARKBAXlhMjkuR2xzNkJ0V0VMdGtMZUliWWYydjYwWi11c3lqaXNxR2hCQkgtNUlxay1aZUdUZU5ic3M2bXdza2RXUVB2WHdDNEc2ckpiYkJUcjRTcWphTWxET2dYWUdORnY4TnJjbVVTRTdtc2VVd0k1S19CMjhBS2RpdGRqM1hRX2N4YjAEOg0xL0lhblFma3d0NE1-
       X-Goog-Upload-Header-Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       X-Goog-Upload-Header-Pragma:
@@ -696,26 +744,25 @@ http_interactions:
       X-Goog-Upload-Header-Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       X-Goog-Upload-Header-Date:
-      - Sun, 18 Mar 2018 21:37:27 GMT
+      - Thu, 18 Oct 2018 09:42:00 GMT
       Content-Length:
       - '0'
       Date:
-      - Sun, 18 Mar 2018 21:37:27 GMT
+      - Thu, 18 Oct 2018 09:42:00 GMT
       Server:
       - UploadServer
       Content-Type:
       - text/html; charset=UTF-8
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:37:27 GMT
+  recorded_at: Thu, 18 Oct 2018 09:42:00 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/upload/drive/v3/files/1OGV9dFWw1nhyctVh0SO015vmXuKSK64UidROOVvpo-8?upload_id=AEnB2Uq-L3_mUbx9DZnYTGtEYvx7OGc3U-FCzitxYSDkZr3fWpKw8BDKCc4J8EhJMbDy6LmGr-HQWJedP2MscLf5G0opNDfhlw&upload_protocol=resumable
+    uri: https://www.googleapis.com/upload/drive/v3/files/1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE?upload_id=AEnB2Uq5GHR5UWrAOMb7wzAByG33zH2Ma-NlJfyykPU6sU2eOIIMoh6M06tNFRIPaorRHTh3d5K7TKwnzQuuEKg8uCFQ2Y-qqDE-C9dvPGgabTTzzayjqyc&upload_protocol=resumable
     body:
       encoding: UTF-8
       string: new file content
@@ -727,7 +774,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:37:27 GMT
+      - Thu, 18 Oct 2018 09:42:00 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       X-Goog-Upload-Command:
@@ -742,7 +789,7 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2Uq-L3_mUbx9DZnYTGtEYvx7OGc3U-FCzitxYSDkZr3fWpKw8BDKCc4J8EhJMbDy6LmGr-HQWJedP2MscLf5G0opNDfhlw
+      - AEnB2Uq5GHR5UWrAOMb7wzAByG33zH2Ma-NlJfyykPU6sU2eOIIMoh6M06tNFRIPaorRHTh3d5K7TKwnzQuuEKg8uCFQ2Y-qqDE-C9dvPGgabTTzzayjqyc
       X-Goog-Upload-Status:
       - final
       Vary:
@@ -757,28 +804,27 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:37:28 GMT
+      - Thu, 18 Oct 2018 09:42:01 GMT
       Content-Length:
       - '151'
       Server:
       - UploadServer
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: |
         {
          "kind": "drive#file",
-         "id": "1OGV9dFWw1nhyctVh0SO015vmXuKSK64UidROOVvpo-8",
+         "id": "1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:37:28 GMT
+  recorded_at: Thu, 18 Oct 2018 09:42:01 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=7197
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9387
     body:
       encoding: UTF-8
       string: ''
@@ -790,7 +836,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:38:28 GMT
+      - Thu, 18 Oct 2018 09:43:01 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -801,9 +847,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:38:29 GMT
+      - Thu, 18 Oct 2018 09:43:01 GMT
       Date:
-      - Sun, 18 Mar 2018 21:38:29 GMT
+      - Thu, 18 Oct 2018 09:43:01 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -822,29 +868,34 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "7200",
+         "newStartPageToken": "9392",
          "changes": [
           {
-           "fileId": "1rPXw4vYFpXD7G9eut0_2DRHHRc3iRpOd"
+           "fileId": "1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws"
           },
           {
-           "fileId": "1OGV9dFWw1nhyctVh0SO015vmXuKSK64UidROOVvpo-8"
+           "fileId": "1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj"
+          },
+          {
+           "fileId": "1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50"
+          },
+          {
+           "fileId": "1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE"
           }
          ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:38:29 GMT
+  recorded_at: Thu, 18 Oct 2018 09:43:01 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1rPXw4vYFpXD7G9eut0_2DRHHRc3iRpOd?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -856,7 +907,145 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:38:29 GMT
+      - Thu, 18 Oct 2018 09:43:01 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 09:43:01 GMT
+      Expires:
+      - Thu, 18 Oct 2018 09:43:01 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "notFound",
+            "message": "File not found: 1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws.",
+            "locationType": "parameter",
+            "location": "fileId"
+           }
+          ],
+          "code": 404,
+          "message": "File not found: 1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 09:43:02 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 09:43:02 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 09:43:02 GMT
+      Expires:
+      - Thu, 18 Oct 2018 09:43:02 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "notFound",
+            "message": "File not found: 1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj.",
+            "locationType": "parameter",
+            "location": "fileId"
+           }
+          ],
+          "code": 404,
+          "message": "File not found: 1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 09:43:02 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 09:43:02 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -867,9 +1056,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:38:29 GMT
+      - Thu, 18 Oct 2018 09:43:02 GMT
       Date:
-      - Sun, 18 Mar 2018 21:38:29 GMT
+      - Thu, 18 Oct 2018 09:43:02 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -888,25 +1077,44 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1rPXw4vYFpXD7G9eut0_2DRHHRc3iRpOd",
-         "name": "Test @ 2018-03-18 21:37:23 UTC",
+         "id": "1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50",
+         "name": "Test @ 2018-10-18 09:41:56 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:38:29 GMT
+  recorded_at: Thu, 18 Oct 2018 09:43:02 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1rPXw4vYFpXD7G9eut0_2DRHHRc3iRpOd/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -918,7 +1126,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:38:29 GMT
+      - Thu, 18 Oct 2018 09:43:02 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -936,9 +1144,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:38:29 GMT
+      - Thu, 18 Oct 2018 09:43:02 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:38:29 GMT
+      - Thu, 18 Oct 2018 09:43:02 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -950,8 +1158,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -971,10 +1178,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:38:29 GMT
+  recorded_at: Thu, 18 Oct 2018 09:43:02 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1OGV9dFWw1nhyctVh0SO015vmXuKSK64UidROOVvpo-8?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -986,7 +1193,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:38:29 GMT
+      - Thu, 18 Oct 2018 09:43:02 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -997,9 +1204,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:38:29 GMT
+      - Thu, 18 Oct 2018 09:43:02 GMT
       Date:
-      - Sun, 18 Mar 2018 21:38:29 GMT
+      - Thu, 18 Oct 2018 09:43:02 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1018,29 +1225,48 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1OGV9dFWw1nhyctVh0SO015vmXuKSK64UidROOVvpo-8",
+         "id": "1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1rPXw4vYFpXD7G9eut0_2DRHHRc3iRpOd"
+          "1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1OGV9dFWw1nhyctVh0SO015vmXuKSK64UidROOVvpo-8&v=1&s=AMedNnoAAAAAWq74dYx8OXCfv88sRaGV52MNws6KKMU-&sz=s220",
-         "thumbnailVersion": "1"
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE&v=1&s=AMedNnoAAAAAW8hxxpMLNE2UgAuBKTLE9sTBiCFROBd9&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:38:29 GMT
+  recorded_at: Thu, 18 Oct 2018 09:43:02 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1OGV9dFWw1nhyctVh0SO015vmXuKSK64UidROOVvpo-8/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1052,7 +1278,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:38:29 GMT
+      - Thu, 18 Oct 2018 09:43:02 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1063,9 +1289,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:38:29 GMT
+      - Thu, 18 Oct 2018 09:43:02 GMT
       Date:
-      - Sun, 18 Mar 2018 21:38:29 GMT
+      - Thu, 18 Oct 2018 09:43:02 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1084,8 +1310,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -1095,13 +1320,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "3",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-03-18T21:37:28.253Z"
+         "modifiedTime": "2018-10-18T09:42:00.895Z"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:38:29 GMT
+  recorded_at: Thu, 18 Oct 2018 09:43:02 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1OGV9dFWw1nhyctVh0SO015vmXuKSK64UidROOVvpo-8&s=AMedNnoAAAAAWq74dYx8OXCfv88sRaGV52MNws6KKMU-&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE&s=AMedNnoAAAAAW8hxxpMLNE2UgAuBKTLE9sTBiCFROBd9&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1113,7 +1338,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:38:29 GMT
+      - Thu, 18 Oct 2018 09:43:02 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1144,7 +1369,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Sun, 18 Mar 2018 21:38:30 GMT
+      - Thu, 18 Oct 2018 09:43:03 GMT
       Server:
       - fife
       Content-Length:
@@ -1152,17 +1377,16 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:38:30 GMT
+  recorded_at: Thu, 18 Oct 2018 09:43:03 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1rPXw4vYFpXD7G9eut0_2DRHHRc3iRpOd
+    uri: https://www.googleapis.com/drive/v3/files/1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50
     body:
       encoding: UTF-8
       string: ''
@@ -1174,7 +1398,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:38:30 GMT
+      - Thu, 18 Oct 2018 09:43:03 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1191,18 +1415,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:38:31 GMT
+      - Thu, 18 Oct 2018 09:43:03 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:38:31 GMT
+  recorded_at: Thu, 18 Oct 2018 09:43:03 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_updates_file_content.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_updates_file_content.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:41:56 GMT
+      - Thu, 18 Oct 2018 11:09:31 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:41:56 GMT
+  recorded_at: Thu, 18 Oct 2018 11:09:31 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:41:56 GMT
+      - Thu, 18 Oct 2018 11:09:31 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:41:56 GMT
+  recorded_at: Thu, 18 Oct 2018 11:09:31 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        09:41:56 UTC","parents":["root"]}'
+        11:09:31 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:41:56 GMT
+      - Thu, 18 Oct 2018 11:09:31 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:41:57 GMT
+      - Thu, 18 Oct 2018 11:09:32 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50",
-         "name": "Test @ 2018-10-18 09:41:56 UTC",
+         "id": "194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX",
+         "name": "Test @ 2018-10-18 11:09:31 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:41:57 GMT
+  recorded_at: Thu, 18 Oct 2018 11:09:32 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:41:57 GMT
+      - Thu, 18 Oct 2018 11:09:32 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:41:57 GMT
+      - Thu, 18 Oct 2018 11:09:33 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:41:57 GMT
+  recorded_at: Thu, 18 Oct 2018 11:09:33 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:41:57 GMT
+      - Thu, 18 Oct 2018 11:09:33 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:41:57 GMT
+      - Thu, 18 Oct 2018 11:09:33 GMT
       Date:
-      - Thu, 18 Oct 2018 09:41:57 GMT
+      - Thu, 18 Oct 2018 11:09:33 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,16 +302,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "9387"
+         "startPageToken": "9541"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:41:57 GMT
+  recorded_at: Thu, 18 Oct 2018 11:09:33 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -320,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:41:58 GMT
+      - Thu, 18 Oct 2018 11:09:33 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -337,7 +337,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:41:59 GMT
+      - Thu, 18 Oct 2018 11:09:34 GMT
       Vary:
       - Origin
       - X-Origin
@@ -361,12 +361,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE",
+         "id": "1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50"
+          "194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -391,10 +391,150 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:41:59 GMT
+  recorded_at: Thu, 18 Oct 2018 11:09:34 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"7 Tanngrisnir
+        (Archive)","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:09:34 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:09:35 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "17bVTCBGxnpJQqBa8jMstUrAfpH5-vucQ",
+         "name": "7 Tanngrisnir (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:09:35 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/17bVTCBGxnpJQqBa8jMstUrAfpH5-vucQ/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:09:35 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:09:35 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "13193959451567607887",
+         "type": "user",
+         "role": "reader"
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:09:36 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/17bVTCBGxnpJQqBa8jMstUrAfpH5-vucQ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -406,7 +546,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:41:59 GMT
+      - Thu, 18 Oct 2018 11:09:36 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -417,9 +557,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:41:59 GMT
+      - Thu, 18 Oct 2018 11:09:36 GMT
       Date:
-      - Thu, 18 Oct 2018 09:41:59 GMT
+      - Thu, 18 Oct 2018 11:09:36 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -445,37 +585,40 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50",
-         "name": "Test @ 2018-10-18 09:41:56 UTC",
+         "id": "17bVTCBGxnpJQqBa8jMstUrAfpH5-vucQ",
+         "name": "7 Tanngrisnir (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
          "thumbnailVersion": "0",
          "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
           {
            "kind": "drive#permission",
            "id": "13193959451567607887",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
+           "role": "reader",
            "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
            "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:41:59 GMT
+  recorded_at: Thu, 18 Oct 2018 11:09:36 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/17bVTCBGxnpJQqBa8jMstUrAfpH5-vucQ/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -487,7 +630,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:41:59 GMT
+      - Thu, 18 Oct 2018 11:09:36 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -505,9 +648,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:41:59 GMT
+      - Thu, 18 Oct 2018 11:09:36 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:41:59 GMT
+      - Thu, 18 Oct 2018 11:09:36 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -539,10 +682,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:41:59 GMT
+  recorded_at: Thu, 18 Oct 2018 11:09:36 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files/194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -554,7 +697,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:41:59 GMT
+      - Thu, 18 Oct 2018 11:09:36 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -565,9 +708,157 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:41:59 GMT
+      - Thu, 18 Oct 2018 11:09:36 GMT
       Date:
-      - Thu, 18 Oct 2018 09:41:59 GMT
+      - Thu, 18 Oct 2018 11:09:36 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX",
+         "name": "Test @ 2018-10-18 11:09:31 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:09:36 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:09:36 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:09:36 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:09:36 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:09:36 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%27194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:09:36 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:09:37 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:09:37 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -595,12 +886,12 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE",
+           "id": "1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s",
            "name": "File",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50"
+            "194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -627,10 +918,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:41:59 GMT
+  recorded_at: Thu, 18 Oct 2018 11:09:37 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -642,7 +933,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:41:59 GMT
+      - Thu, 18 Oct 2018 11:09:37 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -653,9 +944,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:42:00 GMT
+      - Thu, 18 Oct 2018 11:09:37 GMT
       Date:
-      - Thu, 18 Oct 2018 09:42:00 GMT
+      - Thu, 18 Oct 2018 11:09:37 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -684,13 +975,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T09:41:58.333Z"
+         "modifiedTime": "2018-10-18T11:09:33.742Z"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:42:00 GMT
+  recorded_at: Thu, 18 Oct 2018 11:09:37 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/upload/drive/v3/files/1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE
+    uri: https://www.googleapis.com/upload/drive/v3/files/1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s
     body:
       encoding: UTF-8
       string: ''
@@ -702,7 +993,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:42:00 GMT
+      - Thu, 18 Oct 2018 11:09:37 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       X-Goog-Upload-Protocol:
@@ -721,22 +1012,22 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2Uq5GHR5UWrAOMb7wzAByG33zH2Ma-NlJfyykPU6sU2eOIIMoh6M06tNFRIPaorRHTh3d5K7TKwnzQuuEKg8uCFQ2Y-qqDE-C9dvPGgabTTzzayjqyc
+      - AEnB2UqT6yRb2ZrGac62EplvN6fVJ_DgvcmOwmwDNomsSsbjXEybe9Z7hSQTRz6aCG_hEFlR0xvlo4zUKhFq2vevTyoyJsNfiw
       X-Goog-Upload-Status:
       - active
       X-Goog-Upload-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE?upload_id=AEnB2Uq5GHR5UWrAOMb7wzAByG33zH2Ma-NlJfyykPU6sU2eOIIMoh6M06tNFRIPaorRHTh3d5K7TKwnzQuuEKg8uCFQ2Y-qqDE-C9dvPGgabTTzzayjqyc&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s?upload_id=AEnB2UqT6yRb2ZrGac62EplvN6fVJ_DgvcmOwmwDNomsSsbjXEybe9Z7hSQTRz6aCG_hEFlR0xvlo4zUKhFq2vevTyoyJsNfiw&upload_protocol=resumable
       X-Goog-Upload-Control-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE?upload_id=AEnB2Uq5GHR5UWrAOMb7wzAByG33zH2Ma-NlJfyykPU6sU2eOIIMoh6M06tNFRIPaorRHTh3d5K7TKwnzQuuEKg8uCFQ2Y-qqDE-C9dvPGgabTTzzayjqyc&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s?upload_id=AEnB2UqT6yRb2ZrGac62EplvN6fVJ_DgvcmOwmwDNomsSsbjXEybe9Z7hSQTRz6aCG_hEFlR0xvlo4zUKhFq2vevTyoyJsNfiw&upload_protocol=resumable
       X-Goog-Upload-Chunk-Granularity:
       - '262144'
       X-Goog-Upload-Header-Vary:
       - Origin
       - X-Origin
       X-Goog-Upload-Header-X-Google-Backends:
-      - iox123:4257
+      - iohc20:4132
       X-Goog-Upload-Header-X-Google-Session-Info:
-      - CKeBxoimHBoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqVARKBAXlhMjkuR2xzNkJ0V0VMdGtMZUliWWYydjYwWi11c3lqaXNxR2hCQkgtNUlxay1aZUdUZU5ic3M2bXdza2RXUVB2WHdDNEc2ckpiYkJUcjRTcWphTWxET2dYWUdORnY4TnJjbVVTRTdtc2VVd0k1S19CMjhBS2RpdGRqM1hRX2N4YjAEOg0xL0lhblFma3d0NE1-
+      - CKeBxoimHBoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqVARKBAXlhMjkuR2xzNkJuMDRZWnZrQlFadUpGbGdoQkhsdHI4a2VBNE1tX1ZpSFJxMG5uY0RIV0lTdlNFQVlWZjFSQUZ2cHU5ZDMteVd1bVcyVDZHWTlnNE5SSEx1enJadjJFZ1RJT1VONjVsUWJaVWJtWVFWVkRzYmg2X1J5c0dHdUR6eTAEOg0xL0lhblFma3d0NE1-
       X-Goog-Upload-Header-Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       X-Goog-Upload-Header-Pragma:
@@ -744,11 +1035,11 @@ http_interactions:
       X-Goog-Upload-Header-Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       X-Goog-Upload-Header-Date:
-      - Thu, 18 Oct 2018 09:42:00 GMT
+      - Thu, 18 Oct 2018 11:09:37 GMT
       Content-Length:
       - '0'
       Date:
-      - Thu, 18 Oct 2018 09:42:00 GMT
+      - Thu, 18 Oct 2018 11:09:37 GMT
       Server:
       - UploadServer
       Content-Type:
@@ -759,10 +1050,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:42:00 GMT
+  recorded_at: Thu, 18 Oct 2018 11:09:37 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/upload/drive/v3/files/1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE?upload_id=AEnB2Uq5GHR5UWrAOMb7wzAByG33zH2Ma-NlJfyykPU6sU2eOIIMoh6M06tNFRIPaorRHTh3d5K7TKwnzQuuEKg8uCFQ2Y-qqDE-C9dvPGgabTTzzayjqyc&upload_protocol=resumable
+    uri: https://www.googleapis.com/upload/drive/v3/files/1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s?upload_id=AEnB2UqT6yRb2ZrGac62EplvN6fVJ_DgvcmOwmwDNomsSsbjXEybe9Z7hSQTRz6aCG_hEFlR0xvlo4zUKhFq2vevTyoyJsNfiw&upload_protocol=resumable
     body:
       encoding: UTF-8
       string: new file content
@@ -774,7 +1065,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:42:00 GMT
+      - Thu, 18 Oct 2018 11:09:37 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       X-Goog-Upload-Command:
@@ -789,7 +1080,7 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2Uq5GHR5UWrAOMb7wzAByG33zH2Ma-NlJfyykPU6sU2eOIIMoh6M06tNFRIPaorRHTh3d5K7TKwnzQuuEKg8uCFQ2Y-qqDE-C9dvPGgabTTzzayjqyc
+      - AEnB2UqT6yRb2ZrGac62EplvN6fVJ_DgvcmOwmwDNomsSsbjXEybe9Z7hSQTRz6aCG_hEFlR0xvlo4zUKhFq2vevTyoyJsNfiw
       X-Goog-Upload-Status:
       - final
       Vary:
@@ -804,7 +1095,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:42:01 GMT
+      - Thu, 18 Oct 2018 11:09:38 GMT
       Content-Length:
       - '151'
       Server:
@@ -816,15 +1107,15 @@ http_interactions:
       string: |
         {
          "kind": "drive#file",
-         "id": "1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE",
+         "id": "1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:42:01 GMT
+  recorded_at: Thu, 18 Oct 2018 11:09:38 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9387
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9541
     body:
       encoding: UTF-8
       string: ''
@@ -836,7 +1127,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:43:01 GMT
+      - Thu, 18 Oct 2018 11:10:38 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -847,9 +1138,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:43:01 GMT
+      - Thu, 18 Oct 2018 11:10:38 GMT
       Date:
-      - Thu, 18 Oct 2018 09:43:01 GMT
+      - Thu, 18 Oct 2018 11:10:38 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -875,27 +1166,24 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "9392",
+         "newStartPageToken": "9546",
          "changes": [
           {
-           "fileId": "1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws"
+           "fileId": "17bVTCBGxnpJQqBa8jMstUrAfpH5-vucQ"
           },
           {
-           "fileId": "1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj"
+           "fileId": "194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX"
           },
           {
-           "fileId": "1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50"
-          },
-          {
-           "fileId": "1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE"
+           "fileId": "1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s"
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:43:01 GMT
+  recorded_at: Thu, 18 Oct 2018 11:10:38 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/17bVTCBGxnpJQqBa8jMstUrAfpH5-vucQ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -907,145 +1195,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:43:01 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 18 Oct 2018 09:43:01 GMT
-      Expires:
-      - Thu, 18 Oct 2018 09:43:01 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "notFound",
-            "message": "File not found: 1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws.",
-            "locationType": "parameter",
-            "location": "fileId"
-           }
-          ],
-          "code": 404,
-          "message": "File not found: 1mo7THMXEo9RIT57_-CObiXd9eZ68F1jDXazWTZg5nws."
-         }
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:43:02 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 09:43:02 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 18 Oct 2018 09:43:02 GMT
-      Expires:
-      - Thu, 18 Oct 2018 09:43:02 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "notFound",
-            "message": "File not found: 1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj.",
-            "locationType": "parameter",
-            "location": "fileId"
-           }
-          ],
-          "code": 404,
-          "message": "File not found: 1n8ZV-F-22tUz3XwAMoccIO7XNpTF98Kj."
-         }
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:43:02 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 09:43:02 GMT
+      - Thu, 18 Oct 2018 11:10:38 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1056,9 +1206,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:43:02 GMT
+      - Thu, 18 Oct 2018 11:10:39 GMT
       Date:
-      - Thu, 18 Oct 2018 09:43:02 GMT
+      - Thu, 18 Oct 2018 11:10:39 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1084,37 +1234,40 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50",
-         "name": "Test @ 2018-10-18 09:41:56 UTC",
+         "id": "17bVTCBGxnpJQqBa8jMstUrAfpH5-vucQ",
+         "name": "7 Tanngrisnir (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
          "thumbnailVersion": "0",
          "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
           {
            "kind": "drive#permission",
            "id": "13193959451567607887",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
+           "role": "reader",
            "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
            "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:43:02 GMT
+  recorded_at: Thu, 18 Oct 2018 11:10:39 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/17bVTCBGxnpJQqBa8jMstUrAfpH5-vucQ/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1126,7 +1279,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:43:02 GMT
+      - Thu, 18 Oct 2018 11:10:39 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1144,9 +1297,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:43:02 GMT
+      - Thu, 18 Oct 2018 11:10:39 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:43:02 GMT
+      - Thu, 18 Oct 2018 11:10:39 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1178,10 +1331,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:43:02 GMT
+  recorded_at: Thu, 18 Oct 2018 11:10:39 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1193,7 +1346,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:43:02 GMT
+      - Thu, 18 Oct 2018 11:10:39 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1204,9 +1357,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:43:02 GMT
+      - Thu, 18 Oct 2018 11:10:39 GMT
       Date:
-      - Thu, 18 Oct 2018 09:43:02 GMT
+      - Thu, 18 Oct 2018 11:10:39 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1232,14 +1385,162 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE",
+         "id": "194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX",
+         "name": "Test @ 2018-10-18 11:09:31 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:10:39 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:10:39 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:10:39 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:10:39 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:10:39 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:10:39 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:10:39 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:10:39 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50"
+          "194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE&v=1&s=AMedNnoAAAAAW8hxxpMLNE2UgAuBKTLE9sTBiCFROBd9&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s&v=1&s=AMedNnoAAAAAW8iGTyKw_OTZ5D4jTR7opByKcSVJ0qNJ&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -1263,10 +1564,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:43:02 GMT
+  recorded_at: Thu, 18 Oct 2018 11:10:39 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1278,7 +1579,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:43:02 GMT
+      - Thu, 18 Oct 2018 11:10:39 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1289,9 +1590,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:43:02 GMT
+      - Thu, 18 Oct 2018 11:10:40 GMT
       Date:
-      - Thu, 18 Oct 2018 09:43:02 GMT
+      - Thu, 18 Oct 2018 11:10:40 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1320,13 +1621,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "3",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T09:42:00.895Z"
+         "modifiedTime": "2018-10-18T11:09:38.097Z"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:43:02 GMT
+  recorded_at: Thu, 18 Oct 2018 11:10:40 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1jVMlI98wJlLJlBy0wkKDb3_nivFQlQe_1HsX4z9uXlE&s=AMedNnoAAAAAW8hxxpMLNE2UgAuBKTLE9sTBiCFROBd9&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s&s=AMedNnoAAAAAW8iGTyKw_OTZ5D4jTR7opByKcSVJ0qNJ&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1338,7 +1639,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:43:02 GMT
+      - Thu, 18 Oct 2018 11:10:40 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1369,7 +1670,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 18 Oct 2018 09:43:03 GMT
+      - Thu, 18 Oct 2018 11:10:40 GMT
       Server:
       - fife
       Content-Length:
@@ -1383,10 +1684,10 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:43:03 GMT
+  recorded_at: Thu, 18 Oct 2018 11:10:40 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1Ev6tY2nxk4VeY1JeShBluy4Nx3Qz-v50
+    uri: https://www.googleapis.com/drive/v3/files/194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX
     body:
       encoding: UTF-8
       string: ''
@@ -1398,7 +1699,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:43:03 GMT
+      - Thu, 18 Oct 2018 11:10:40 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1415,7 +1716,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:43:03 GMT
+      - Thu, 18 Oct 2018 11:10:40 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1427,5 +1728,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:43:03 GMT
+  recorded_at: Thu, 18 Oct 2018 11:10:41 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_updates_file_content.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_updates_file_content.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 11:09:31 GMT
+      - Sun, 21 Oct 2018 16:20:20 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:09:31 GMT
+  recorded_at: Sun, 21 Oct 2018 16:20:20 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 11:09:31 GMT
+      - Sun, 21 Oct 2018 16:20:20 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:09:31 GMT
+  recorded_at: Sun, 21 Oct 2018 16:20:20 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        11:09:31 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-21
+        16:20:20 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:09:31 GMT
+      - Sun, 21 Oct 2018 16:20:20 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:09:32 GMT
+      - Sun, 21 Oct 2018 16:20:21 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX",
-         "name": "Test @ 2018-10-18 11:09:31 UTC",
+         "id": "1M20Juh3uxwkszNJ8rvDwujWMEd2GRTNO",
+         "name": "Test @ 2018-10-21 16:20:20 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:09:32 GMT
+  recorded_at: Sun, 21 Oct 2018 16:20:21 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1M20Juh3uxwkszNJ8rvDwujWMEd2GRTNO/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:09:32 GMT
+      - Sun, 21 Oct 2018 16:20:21 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:09:33 GMT
+      - Sun, 21 Oct 2018 16:20:22 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:09:33 GMT
+  recorded_at: Sun, 21 Oct 2018 16:20:22 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:09:33 GMT
+      - Sun, 21 Oct 2018 16:20:22 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:09:33 GMT
+      - Sun, 21 Oct 2018 16:20:22 GMT
       Date:
-      - Thu, 18 Oct 2018 11:09:33 GMT
+      - Sun, 21 Oct 2018 16:20:22 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,16 +302,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "9541"
+         "startPageToken": "10862"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:09:33 GMT
+  recorded_at: Sun, 21 Oct 2018 16:20:22 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1M20Juh3uxwkszNJ8rvDwujWMEd2GRTNO"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -320,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:09:33 GMT
+      - Sun, 21 Oct 2018 16:20:22 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -337,7 +337,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:09:34 GMT
+      - Sun, 21 Oct 2018 16:20:23 GMT
       Vary:
       - Origin
       - X-Origin
@@ -361,12 +361,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s",
+         "id": "1d9_0JjS1WbEFKbvYgb9cxOlTD9BI8jY3DnmPZzC86dg",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX"
+          "1M20Juh3uxwkszNJ8rvDwujWMEd2GRTNO"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -391,13 +391,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:09:34 GMT
+  recorded_at: Sun, 21 Oct 2018 16:20:23 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"7 Tanngrisnir
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"6 Tanngrisnir
         (Archive)","parents":["root"]}'
     headers:
       User-Agent:
@@ -407,7 +407,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:09:34 GMT
+      - Sun, 21 Oct 2018 16:20:23 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -424,7 +424,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:09:35 GMT
+      - Sun, 21 Oct 2018 16:20:24 GMT
       Vary:
       - Origin
       - X-Origin
@@ -448,8 +448,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "17bVTCBGxnpJQqBa8jMstUrAfpH5-vucQ",
-         "name": "7 Tanngrisnir (Archive)",
+         "id": "1XWaLoeGG0uTzd6nX_PWTZ6VXz4zvu1Xv",
+         "name": "6 Tanngrisnir (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -469,10 +469,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:09:35 GMT
+  recorded_at: Sun, 21 Oct 2018 16:20:24 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/17bVTCBGxnpJQqBa8jMstUrAfpH5-vucQ/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1XWaLoeGG0uTzd6nX_PWTZ6VXz4zvu1Xv/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -484,7 +484,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:09:35 GMT
+      - Sun, 21 Oct 2018 16:20:24 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -501,7 +501,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:09:35 GMT
+      - Sun, 21 Oct 2018 16:20:25 GMT
       Vary:
       - Origin
       - X-Origin
@@ -531,10 +531,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:09:36 GMT
+  recorded_at: Sun, 21 Oct 2018 16:20:25 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/17bVTCBGxnpJQqBa8jMstUrAfpH5-vucQ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1XWaLoeGG0uTzd6nX_PWTZ6VXz4zvu1Xv?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -546,7 +546,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:09:36 GMT
+      - Sun, 21 Oct 2018 16:20:25 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -557,9 +557,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:09:36 GMT
+      - Sun, 21 Oct 2018 16:20:25 GMT
       Date:
-      - Thu, 18 Oct 2018 11:09:36 GMT
+      - Sun, 21 Oct 2018 16:20:25 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -585,8 +585,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "17bVTCBGxnpJQqBa8jMstUrAfpH5-vucQ",
-         "name": "7 Tanngrisnir (Archive)",
+         "id": "1XWaLoeGG0uTzd6nX_PWTZ6VXz4zvu1Xv",
+         "name": "6 Tanngrisnir (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -615,10 +615,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:09:36 GMT
+  recorded_at: Sun, 21 Oct 2018 16:20:25 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/17bVTCBGxnpJQqBa8jMstUrAfpH5-vucQ/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1XWaLoeGG0uTzd6nX_PWTZ6VXz4zvu1Xv/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -630,7 +630,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:09:36 GMT
+      - Sun, 21 Oct 2018 16:20:25 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -648,9 +648,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:09:36 GMT
+      - Sun, 21 Oct 2018 16:20:25 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:09:36 GMT
+      - Sun, 21 Oct 2018 16:20:25 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -682,10 +682,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:09:36 GMT
+  recorded_at: Sun, 21 Oct 2018 16:20:25 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1M20Juh3uxwkszNJ8rvDwujWMEd2GRTNO?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -697,7 +697,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:09:36 GMT
+      - Sun, 21 Oct 2018 16:20:25 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -708,9 +708,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:09:36 GMT
+      - Sun, 21 Oct 2018 16:20:25 GMT
       Date:
-      - Thu, 18 Oct 2018 11:09:36 GMT
+      - Sun, 21 Oct 2018 16:20:25 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -736,8 +736,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX",
-         "name": "Test @ 2018-10-18 11:09:31 UTC",
+         "id": "1M20Juh3uxwkszNJ8rvDwujWMEd2GRTNO",
+         "name": "Test @ 2018-10-21 16:20:20 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -763,10 +763,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:09:36 GMT
+  recorded_at: Sun, 21 Oct 2018 16:20:25 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1M20Juh3uxwkszNJ8rvDwujWMEd2GRTNO/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -778,7 +778,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:09:36 GMT
+      - Sun, 21 Oct 2018 16:20:25 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -796,9 +796,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:09:36 GMT
+      - Sun, 21 Oct 2018 16:20:25 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:09:36 GMT
+      - Sun, 21 Oct 2018 16:20:25 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -830,10 +830,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:09:36 GMT
+  recorded_at: Sun, 21 Oct 2018 16:20:25 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%27194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271M20Juh3uxwkszNJ8rvDwujWMEd2GRTNO%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -845,7 +845,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:09:36 GMT
+      - Sun, 21 Oct 2018 16:20:25 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -856,9 +856,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:09:37 GMT
+      - Sun, 21 Oct 2018 16:20:26 GMT
       Date:
-      - Thu, 18 Oct 2018 11:09:37 GMT
+      - Sun, 21 Oct 2018 16:20:26 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -886,14 +886,15 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s",
+           "id": "1d9_0JjS1WbEFKbvYgb9cxOlTD9BI8jY3DnmPZzC86dg",
            "name": "File",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX"
+            "1M20Juh3uxwkszNJ8rvDwujWMEd2GRTNO"
            ],
-           "thumbnailVersion": "0",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1d9_0JjS1WbEFKbvYgb9cxOlTD9BI8jY3DnmPZzC86dg&v=1&s=AMedNnoAAAAAW8zDantfTvx6Jn4zoL1Wwy-5-jql25nM&sz=s220",
+           "thumbnailVersion": "1",
            "permissions": [
             {
              "kind": "drive#permission",
@@ -918,10 +919,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:09:37 GMT
+  recorded_at: Sun, 21 Oct 2018 16:20:26 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1d9_0JjS1WbEFKbvYgb9cxOlTD9BI8jY3DnmPZzC86dg/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -933,7 +934,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:09:37 GMT
+      - Sun, 21 Oct 2018 16:20:26 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -944,9 +945,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:09:37 GMT
+      - Sun, 21 Oct 2018 16:20:26 GMT
       Date:
-      - Thu, 18 Oct 2018 11:09:37 GMT
+      - Sun, 21 Oct 2018 16:20:26 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -975,147 +976,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T11:09:33.742Z"
+         "modifiedTime": "2018-10-21T16:20:22.661Z"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:09:37 GMT
-- request:
-    method: patch
-    uri: https://www.googleapis.com/upload/drive/v3/files/1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:09:37 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
-      X-Goog-Upload-Protocol:
-      - resumable
-      X-Goog-Upload-Command:
-      - start
-      X-Goog-Upload-Header-Content-Length:
-      - '16'
-      X-Goog-Upload-Header-Content-Type:
-      - application/octet-stream
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Guploader-Uploadid:
-      - AEnB2UqT6yRb2ZrGac62EplvN6fVJ_DgvcmOwmwDNomsSsbjXEybe9Z7hSQTRz6aCG_hEFlR0xvlo4zUKhFq2vevTyoyJsNfiw
-      X-Goog-Upload-Status:
-      - active
-      X-Goog-Upload-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s?upload_id=AEnB2UqT6yRb2ZrGac62EplvN6fVJ_DgvcmOwmwDNomsSsbjXEybe9Z7hSQTRz6aCG_hEFlR0xvlo4zUKhFq2vevTyoyJsNfiw&upload_protocol=resumable
-      X-Goog-Upload-Control-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s?upload_id=AEnB2UqT6yRb2ZrGac62EplvN6fVJ_DgvcmOwmwDNomsSsbjXEybe9Z7hSQTRz6aCG_hEFlR0xvlo4zUKhFq2vevTyoyJsNfiw&upload_protocol=resumable
-      X-Goog-Upload-Chunk-Granularity:
-      - '262144'
-      X-Goog-Upload-Header-Vary:
-      - Origin
-      - X-Origin
-      X-Goog-Upload-Header-X-Google-Backends:
-      - iohc20:4132
-      X-Goog-Upload-Header-X-Google-Session-Info:
-      - CKeBxoimHBoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqVARKBAXlhMjkuR2xzNkJuMDRZWnZrQlFadUpGbGdoQkhsdHI4a2VBNE1tX1ZpSFJxMG5uY0RIV0lTdlNFQVlWZjFSQUZ2cHU5ZDMteVd1bVcyVDZHWTlnNE5SSEx1enJadjJFZ1RJT1VONjVsUWJaVWJtWVFWVkRzYmg2X1J5c0dHdUR6eTAEOg0xL0lhblFma3d0NE1-
-      X-Goog-Upload-Header-Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      X-Goog-Upload-Header-Pragma:
-      - no-cache
-      X-Goog-Upload-Header-Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      X-Goog-Upload-Header-Date:
-      - Thu, 18 Oct 2018 11:09:37 GMT
-      Content-Length:
-      - '0'
-      Date:
-      - Thu, 18 Oct 2018 11:09:37 GMT
-      Server:
-      - UploadServer
-      Content-Type:
-      - text/html; charset=UTF-8
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:09:37 GMT
-- request:
-    method: post
-    uri: https://www.googleapis.com/upload/drive/v3/files/1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s?upload_id=AEnB2UqT6yRb2ZrGac62EplvN6fVJ_DgvcmOwmwDNomsSsbjXEybe9Z7hSQTRz6aCG_hEFlR0xvlo4zUKhFq2vevTyoyJsNfiw&upload_protocol=resumable
-    body:
-      encoding: UTF-8
-      string: new file content
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:09:37 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
-      X-Goog-Upload-Command:
-      - upload, finalize
-      X-Goog-Upload-Offset:
-      - '0'
-      Content-Type:
-      - application/octet-stream
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Guploader-Uploadid:
-      - AEnB2UqT6yRb2ZrGac62EplvN6fVJ_DgvcmOwmwDNomsSsbjXEybe9Z7hSQTRz6aCG_hEFlR0xvlo4zUKhFq2vevTyoyJsNfiw
-      X-Goog-Upload-Status:
-      - final
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Thu, 18 Oct 2018 11:09:38 GMT
-      Content-Length:
-      - '151'
-      Server:
-      - UploadServer
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "kind": "drive#file",
-         "id": "1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s",
-         "name": "File",
-         "mimeType": "application/vnd.google-apps.document"
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:09:38 GMT
+  recorded_at: Sun, 21 Oct 2018 16:20:26 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=9541
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1d9_0JjS1WbEFKbvYgb9cxOlTD9BI8jY3DnmPZzC86dg&s=AMedNnoAAAAAW8zDantfTvx6Jn4zoL1Wwy-5-jql25nM&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1127,519 +994,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:10:38 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Thu, 18 Oct 2018 11:10:38 GMT
-      Date:
-      - Thu, 18 Oct 2018 11:10:38 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "newStartPageToken": "9546",
-         "changes": [
-          {
-           "fileId": "17bVTCBGxnpJQqBa8jMstUrAfpH5-vucQ"
-          },
-          {
-           "fileId": "194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX"
-          },
-          {
-           "fileId": "1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s"
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:10:38 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/17bVTCBGxnpJQqBa8jMstUrAfpH5-vucQ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:10:38 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Thu, 18 Oct 2018 11:10:39 GMT
-      Date:
-      - Thu, 18 Oct 2018 11:10:39 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "17bVTCBGxnpJQqBa8jMstUrAfpH5-vucQ",
-         "name": "7 Tanngrisnir (Archive)",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:10:39 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/17bVTCBGxnpJQqBa8jMstUrAfpH5-vucQ/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:10:39 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 18 Oct 2018 11:10:39 GMT
-      Expires:
-      - Thu, 18 Oct 2018 11:10:39 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:10:39 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:10:39 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Thu, 18 Oct 2018 11:10:39 GMT
-      Date:
-      - Thu, 18 Oct 2018 11:10:39 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX",
-         "name": "Test @ 2018-10-18 11:09:31 UTC",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:10:39 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:10:39 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 18 Oct 2018 11:10:39 GMT
-      Expires:
-      - Thu, 18 Oct 2018 11:10:39 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:10:39 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:10:39 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Thu, 18 Oct 2018 11:10:39 GMT
-      Date:
-      - Thu, 18 Oct 2018 11:10:39 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s",
-         "name": "File",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s&v=1&s=AMedNnoAAAAAW8iGTyKw_OTZ5D4jTR7opByKcSVJ0qNJ&sz=s220",
-         "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:10:39 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:10:39 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Thu, 18 Oct 2018 11:10:40 GMT
-      Date:
-      - Thu, 18 Oct 2018 11:10:40 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "kind": "drive#revision",
-         "id": "3",
-         "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T11:09:38.097Z"
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:10:40 GMT
-- request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1Ad94qDpLGFZQGqDu24NAD1RnpKXoCXIRD8BTvroFz_s&s=AMedNnoAAAAAW8iGTyKw_OTZ5D4jTR7opByKcSVJ0qNJ&sz=s350&v=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 11:10:40 GMT
+      - Sun, 21 Oct 2018 16:20:26 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1670,7 +1025,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 18 Oct 2018 11:10:40 GMT
+      - Sun, 21 Oct 2018 16:20:26 GMT
       Server:
       - fife
       Content-Length:
@@ -1684,10 +1039,96 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:10:40 GMT
+  recorded_at: Sun, 21 Oct 2018 16:20:26 GMT
 - request:
-    method: delete
-    uri: https://www.googleapis.com/drive/v3/files/194uzjY6WzNt1DIFvSQ5lKcYgG4182SZX
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1d9_0JjS1WbEFKbvYgb9cxOlTD9BI8jY3DnmPZzC86dg/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"File","parents":["1XWaLoeGG0uTzd6nX_PWTZ6VXz4zvu1Xv"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:20:26 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:20:28 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1ZckdlkeE6RX4l6u-0AMPv6sXTojwHU5DnWAG03yFSMA",
+         "name": "File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1XWaLoeGG0uTzd6nX_PWTZ6VXz4zvu1Xv"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:20:28 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/upload/drive/v3/files/1d9_0JjS1WbEFKbvYgb9cxOlTD9BI8jY3DnmPZzC86dg
     body:
       encoding: UTF-8
       string: ''
@@ -1699,7 +1140,1116 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:10:40 GMT
+      - Sun, 21 Oct 2018 16:20:28 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+      X-Goog-Upload-Protocol:
+      - resumable
+      X-Goog-Upload-Command:
+      - start
+      X-Goog-Upload-Header-Content-Length:
+      - '16'
+      X-Goog-Upload-Header-Content-Type:
+      - application/octet-stream
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Guploader-Uploadid:
+      - AEnB2UrDGy4bMNRMuYrrORvTalisvgZt9l9yPAgz2BezCEVIFZimh7pvbRmKjuBfJdGUDM5bu0GhjCrBcFEKJT_bwutaq2fL5w2K4cJ5rdDskc2CR7LNPsI
+      X-Goog-Upload-Status:
+      - active
+      X-Goog-Upload-Url:
+      - https://www.googleapis.com/upload/drive/v3/files/1d9_0JjS1WbEFKbvYgb9cxOlTD9BI8jY3DnmPZzC86dg?upload_id=AEnB2UrDGy4bMNRMuYrrORvTalisvgZt9l9yPAgz2BezCEVIFZimh7pvbRmKjuBfJdGUDM5bu0GhjCrBcFEKJT_bwutaq2fL5w2K4cJ5rdDskc2CR7LNPsI&upload_protocol=resumable
+      X-Goog-Upload-Control-Url:
+      - https://www.googleapis.com/upload/drive/v3/files/1d9_0JjS1WbEFKbvYgb9cxOlTD9BI8jY3DnmPZzC86dg?upload_id=AEnB2UrDGy4bMNRMuYrrORvTalisvgZt9l9yPAgz2BezCEVIFZimh7pvbRmKjuBfJdGUDM5bu0GhjCrBcFEKJT_bwutaq2fL5w2K4cJ5rdDskc2CR7LNPsI&upload_protocol=resumable
+      X-Goog-Upload-Chunk-Granularity:
+      - '262144'
+      X-Goog-Upload-Header-Vary:
+      - Origin
+      - X-Origin
+      X-Goog-Upload-Header-X-Google-Backends:
+      - oobs27:4348
+      X-Goog-Upload-Header-X-Google-Session-Info:
+      - CKeBxoimHBoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x3OUJ0R0pwVnpxNkdRQTlSNmJDLUg3RWtLMWRwU1hUWGpkQW15M1pkYTh0czV5bi1XSUVNMmhiVFBsdE4zYjJvdW96Q3h3WHBYcjlxVHhNdHhONDk2eHBSSHpMcEgwSDg3YnhidDAzZWpVRkdLX0ZKeVd5YkJMLXFuRjlBMAQ6DTEvSWFuUWZrd3Q0TX4
+      X-Goog-Upload-Header-Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      X-Goog-Upload-Header-Pragma:
+      - no-cache
+      X-Goog-Upload-Header-Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      X-Goog-Upload-Header-Date:
+      - Sun, 21 Oct 2018 16:20:29 GMT
+      Content-Length:
+      - '0'
+      Date:
+      - Sun, 21 Oct 2018 16:20:29 GMT
+      Server:
+      - UploadServer
+      Content-Type:
+      - text/html; charset=UTF-8
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:20:29 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/upload/drive/v3/files/1d9_0JjS1WbEFKbvYgb9cxOlTD9BI8jY3DnmPZzC86dg?upload_id=AEnB2UrDGy4bMNRMuYrrORvTalisvgZt9l9yPAgz2BezCEVIFZimh7pvbRmKjuBfJdGUDM5bu0GhjCrBcFEKJT_bwutaq2fL5w2K4cJ5rdDskc2CR7LNPsI&upload_protocol=resumable
+    body:
+      encoding: UTF-8
+      string: new file content
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:20:29 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+      X-Goog-Upload-Command:
+      - upload, finalize
+      X-Goog-Upload-Offset:
+      - '0'
+      Content-Type:
+      - application/octet-stream
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Guploader-Uploadid:
+      - AEnB2UrDGy4bMNRMuYrrORvTalisvgZt9l9yPAgz2BezCEVIFZimh7pvbRmKjuBfJdGUDM5bu0GhjCrBcFEKJT_bwutaq2fL5w2K4cJ5rdDskc2CR7LNPsI
+      X-Goog-Upload-Status:
+      - final
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:20:30 GMT
+      Content-Length:
+      - '151'
+      Server:
+      - UploadServer
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#file",
+         "id": "1d9_0JjS1WbEFKbvYgb9cxOlTD9BI8jY3DnmPZzC86dg",
+         "name": "File",
+         "mimeType": "application/vnd.google-apps.document"
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:20:30 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=10862
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:21:30 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 21 Oct 2018 16:21:30 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:21:30 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "newStartPageToken": "10871",
+         "changes": [
+          {
+           "fileId": "1XWaLoeGG0uTzd6nX_PWTZ6VXz4zvu1Xv"
+          },
+          {
+           "fileId": "1ZckdlkeE6RX4l6u-0AMPv6sXTojwHU5DnWAG03yFSMA"
+          },
+          {
+           "fileId": "1M20Juh3uxwkszNJ8rvDwujWMEd2GRTNO"
+          },
+          {
+           "fileId": "1d9_0JjS1WbEFKbvYgb9cxOlTD9BI8jY3DnmPZzC86dg"
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:21:31 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1XWaLoeGG0uTzd6nX_PWTZ6VXz4zvu1Xv?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:21:31 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 21 Oct 2018 16:21:31 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:21:31 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1XWaLoeGG0uTzd6nX_PWTZ6VXz4zvu1Xv",
+         "name": "6 Tanngrisnir (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:21:31 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1XWaLoeGG0uTzd6nX_PWTZ6VXz4zvu1Xv/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:21:31 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Sun, 21 Oct 2018 16:21:31 GMT
+      Expires:
+      - Sun, 21 Oct 2018 16:21:31 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:21:31 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1ZckdlkeE6RX4l6u-0AMPv6sXTojwHU5DnWAG03yFSMA?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:21:31 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 21 Oct 2018 16:21:31 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:21:31 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1ZckdlkeE6RX4l6u-0AMPv6sXTojwHU5DnWAG03yFSMA",
+         "name": "File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1XWaLoeGG0uTzd6nX_PWTZ6VXz4zvu1Xv"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1ZckdlkeE6RX4l6u-0AMPv6sXTojwHU5DnWAG03yFSMA&v=1&s=AMedNnoAAAAAW8zDqz4_4IPO4z6IUd2c_JAJLibweO64&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:21:31 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1ZckdlkeE6RX4l6u-0AMPv6sXTojwHU5DnWAG03yFSMA/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:21:31 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 21 Oct 2018 16:21:31 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:21:31 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-21T16:20:27.811Z"
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:21:31 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1ZckdlkeE6RX4l6u-0AMPv6sXTojwHU5DnWAG03yFSMA&s=AMedNnoAAAAAW8zDqz4_4IPO4z6IUd2c_JAJLibweO64&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:21:31 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sun, 21 Oct 2018 16:21:31 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:21:31 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1M20Juh3uxwkszNJ8rvDwujWMEd2GRTNO?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:21:32 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 21 Oct 2018 16:21:32 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:21:32 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1M20Juh3uxwkszNJ8rvDwujWMEd2GRTNO",
+         "name": "Test @ 2018-10-21 16:20:20 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:21:32 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1M20Juh3uxwkszNJ8rvDwujWMEd2GRTNO/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:21:32 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Sun, 21 Oct 2018 16:21:32 GMT
+      Expires:
+      - Sun, 21 Oct 2018 16:21:32 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:21:32 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1d9_0JjS1WbEFKbvYgb9cxOlTD9BI8jY3DnmPZzC86dg?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:21:32 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 21 Oct 2018 16:21:32 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:21:32 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1d9_0JjS1WbEFKbvYgb9cxOlTD9BI8jY3DnmPZzC86dg",
+         "name": "File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1M20Juh3uxwkszNJ8rvDwujWMEd2GRTNO"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1d9_0JjS1WbEFKbvYgb9cxOlTD9BI8jY3DnmPZzC86dg&v=1&s=AMedNnoAAAAAW8zDrPurIG-CcQM10htQEOYE31fQGjgQ&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:21:32 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1d9_0JjS1WbEFKbvYgb9cxOlTD9BI8jY3DnmPZzC86dg/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:21:32 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 21 Oct 2018 16:21:32 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:21:32 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "3",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-21T16:20:30.028Z"
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:21:32 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1d9_0JjS1WbEFKbvYgb9cxOlTD9BI8jY3DnmPZzC86dg/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"File","parents":["1XWaLoeGG0uTzd6nX_PWTZ6VXz4zvu1Xv"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:21:32 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:21:34 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1A1qU12TtQNaNFFrxzIBbhPJ-FWg2n016RM2VY1JrWN0",
+         "name": "File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1XWaLoeGG0uTzd6nX_PWTZ6VXz4zvu1Xv"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:21:34 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1A1qU12TtQNaNFFrxzIBbhPJ-FWg2n016RM2VY1JrWN0?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:21:34 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 21 Oct 2018 16:21:34 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:21:34 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1A1qU12TtQNaNFFrxzIBbhPJ-FWg2n016RM2VY1JrWN0",
+         "name": "File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1XWaLoeGG0uTzd6nX_PWTZ6VXz4zvu1Xv"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:21:34 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1ZckdlkeE6RX4l6u-0AMPv6sXTojwHU5DnWAG03yFSMA?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:21:34 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 21 Oct 2018 16:21:34 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:21:34 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1ZckdlkeE6RX4l6u-0AMPv6sXTojwHU5DnWAG03yFSMA",
+         "name": "File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1XWaLoeGG0uTzd6nX_PWTZ6VXz4zvu1Xv"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1ZckdlkeE6RX4l6u-0AMPv6sXTojwHU5DnWAG03yFSMA&v=1&s=AMedNnoAAAAAW8zDru3_YDji7R88BbsKr2jNpOcWBOHP&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:21:34 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1M20Juh3uxwkszNJ8rvDwujWMEd2GRTNO
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:21:34 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1716,7 +2266,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:10:40 GMT
+      - Sun, 21 Oct 2018 16:21:35 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1728,5 +2278,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:10:41 GMT
+  recorded_at: Sun, 21 Oct 2018 16:21:35 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Folder_Import/Files_are_imported.yml
+++ b/spec/support/fixtures/vcr_cassettes/Folder_Import/Files_are_imported.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,42 +21,39 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:27:50 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:44:32 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:27:51 GMT
+  recorded_at: Thu, 18 Oct 2018 09:44:32 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -66,7 +63,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -78,49 +75,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:27:51 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:44:32 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:27:51 GMT
+  recorded_at: Thu, 18 Oct 2018 09:44:32 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        21:27:51 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:44:32 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -129,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:27:51 GMT
+      - Thu, 18 Oct 2018 09:44:32 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -146,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:27:52 GMT
+      - Thu, 18 Oct 2018 09:44:33 GMT
       Vary:
       - Origin
       - X-Origin
@@ -163,31 +157,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1cjj97kfqsrwjFn2fbpq1vtr9Z7yOQadg",
-         "name": "Test @ 2018-03-18 21:27:51 UTC",
+         "id": "1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1",
+         "name": "Test @ 2018-10-18 09:44:32 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AEIi2L68pCuiUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:27:52 GMT
+  recorded_at: Thu, 18 Oct 2018 09:44:33 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"veniam.png","parents":["1cjj97kfqsrwjFn2fbpq1vtr9Z7yOQadg"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"voluptatem.ods","parents":["1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -196,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:27:52 GMT
+      - Thu, 18 Oct 2018 09:44:33 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -213,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:27:53 GMT
+      - Thu, 18 Oct 2018 09:44:34 GMT
       Vary:
       - Origin
       - X-Origin
@@ -230,31 +234,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "12rj0S1ZnIyEZS2fhrwoIPZPsfFGXPjncWtEwOrdSFJc",
-         "name": "veniam.png",
+         "id": "1znewTbDi01fA_vqvTri4vgg45CHXp2jvzdfA2SaP7z4",
+         "name": "voluptatem.ods",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1cjj97kfqsrwjFn2fbpq1vtr9Z7yOQadg"
+          "1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:27:53 GMT
+  recorded_at: Thu, 18 Oct 2018 09:44:34 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"dolores.css","parents":["1cjj97kfqsrwjFn2fbpq1vtr9Z7yOQadg"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"voluptates.ods","parents":["1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -263,7 +277,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:27:53 GMT
+      - Thu, 18 Oct 2018 09:44:34 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -280,7 +294,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:27:54 GMT
+      - Thu, 18 Oct 2018 09:44:36 GMT
       Vary:
       - Origin
       - X-Origin
@@ -297,31 +311,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1Z9VzbUFySJoNR9X_jIwHvHcXOCBVrlHgmvYzHcm0dGg",
-         "name": "dolores.css",
+         "id": "1gP1JrPi_6IVdMzmYC8sx24pw_NMhLX2SsJcVti1qGrI",
+         "name": "voluptates.ods",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1cjj97kfqsrwjFn2fbpq1vtr9Z7yOQadg"
+          "1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:27:55 GMT
+  recorded_at: Thu, 18 Oct 2018 09:44:36 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"blanditiis.avi","parents":["1cjj97kfqsrwjFn2fbpq1vtr9Z7yOQadg"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"ducimus.mp3","parents":["1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -330,7 +354,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:27:55 GMT
+      - Thu, 18 Oct 2018 09:44:36 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -347,7 +371,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:27:56 GMT
+      - Thu, 18 Oct 2018 09:44:37 GMT
       Vary:
       - Origin
       - X-Origin
@@ -364,28 +388,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1hh3rztCm5Tb9WEP08LOyWAABntmioUVjJ2qthUa6TZs",
-         "name": "blanditiis.avi",
+         "id": "1ej9P4gtwHysu7_KM5jBDInoBXJVS_LmC9VZC2Lw-ViA",
+         "name": "ducimus.mp3",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1cjj97kfqsrwjFn2fbpq1vtr9Z7yOQadg"
+          "1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:27:56 GMT
+  recorded_at: Thu, 18 Oct 2018 09:44:37 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1cjj97kfqsrwjFn2fbpq1vtr9Z7yOQadg/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"reader","type":"user"}'
@@ -397,7 +431,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:27:56 GMT
+      - Thu, 18 Oct 2018 09:44:37 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -414,7 +448,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:27:57 GMT
+      - Thu, 18 Oct 2018 09:44:38 GMT
       Vary:
       - Origin
       - X-Origin
@@ -431,8 +465,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -445,10 +478,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:27:57 GMT
+  recorded_at: Thu, 18 Oct 2018 09:44:38 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1cjj97kfqsrwjFn2fbpq1vtr9Z7yOQadg?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -460,7 +493,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:28:02 GMT
+      - Thu, 18 Oct 2018 09:44:43 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -471,9 +504,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:28:02 GMT
+      - Thu, 18 Oct 2018 09:44:43 GMT
       Date:
-      - Sun, 18 Mar 2018 21:28:02 GMT
+      - Thu, 18 Oct 2018 09:44:43 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -492,25 +525,24 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1cjj97kfqsrwjFn2fbpq1vtr9Z7yOQadg",
-         "name": "Test @ 2018-03-18 21:27:51 UTC",
+         "id": "1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1",
+         "name": "Test @ 2018-10-18 09:44:32 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:28:02 GMT
+  recorded_at: Thu, 18 Oct 2018 09:44:43 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1cjj97kfqsrwjFn2fbpq1vtr9Z7yOQadg/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -522,7 +554,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:28:02 GMT
+      - Thu, 18 Oct 2018 09:44:43 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -540,9 +572,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:28:02 GMT
+      - Thu, 18 Oct 2018 09:44:43 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:28:02 GMT
+      - Thu, 18 Oct 2018 09:44:43 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -554,8 +586,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -575,10 +606,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:28:02 GMT
+  recorded_at: Thu, 18 Oct 2018 09:44:43 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271cjj97kfqsrwjFn2fbpq1vtr9Z7yOQadg%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -590,7 +621,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:28:02 GMT
+      - Thu, 18 Oct 2018 09:44:43 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -601,9 +632,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:28:03 GMT
+      - Thu, 18 Oct 2018 09:44:43 GMT
       Date:
-      - Sun, 18 Mar 2018 21:28:03 GMT
+      - Thu, 18 Oct 2018 09:44:43 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -622,8 +653,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -632,45 +662,45 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1hh3rztCm5Tb9WEP08LOyWAABntmioUVjJ2qthUa6TZs",
-           "name": "blanditiis.avi",
+           "id": "1ej9P4gtwHysu7_KM5jBDInoBXJVS_LmC9VZC2Lw-ViA",
+           "name": "ducimus.mp3",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1cjj97kfqsrwjFn2fbpq1vtr9Z7yOQadg"
+            "1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1hh3rztCm5Tb9WEP08LOyWAABntmioUVjJ2qthUa6TZs&v=1&s=AMedNnoAAAAAWq72AyaFVs7DHrIDwAxoOiZcJ_eBjcnj&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1ej9P4gtwHysu7_KM5jBDInoBXJVS_LmC9VZC2Lw-ViA&v=1&s=AMedNnoAAAAAW8hyK9MlkHkvShKrCxS7ogrcFXaW5HVJ&sz=s220",
            "thumbnailVersion": "1"
           },
           {
-           "id": "1Z9VzbUFySJoNR9X_jIwHvHcXOCBVrlHgmvYzHcm0dGg",
-           "name": "dolores.css",
+           "id": "1gP1JrPi_6IVdMzmYC8sx24pw_NMhLX2SsJcVti1qGrI",
+           "name": "voluptates.ods",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1cjj97kfqsrwjFn2fbpq1vtr9Z7yOQadg"
+            "1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Z9VzbUFySJoNR9X_jIwHvHcXOCBVrlHgmvYzHcm0dGg&v=1&s=AMedNnoAAAAAWq72A8XcZUMFzjSpeVFzufuDtRnjdkOD&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1gP1JrPi_6IVdMzmYC8sx24pw_NMhLX2SsJcVti1qGrI&v=1&s=AMedNnoAAAAAW8hyK9x12-VrB0ktqy5xfd7pme6YH0DD&sz=s220",
            "thumbnailVersion": "1"
           },
           {
-           "id": "12rj0S1ZnIyEZS2fhrwoIPZPsfFGXPjncWtEwOrdSFJc",
-           "name": "veniam.png",
+           "id": "1znewTbDi01fA_vqvTri4vgg45CHXp2jvzdfA2SaP7z4",
+           "name": "voluptatem.ods",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1cjj97kfqsrwjFn2fbpq1vtr9Z7yOQadg"
+            "1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=12rj0S1ZnIyEZS2fhrwoIPZPsfFGXPjncWtEwOrdSFJc&v=1&s=AMedNnoAAAAAWq72AzstJ-h7BEQPIx6fVxhAneN8-6l3&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1znewTbDi01fA_vqvTri4vgg45CHXp2jvzdfA2SaP7z4&v=1&s=AMedNnoAAAAAW8hyKxhAAhUQiu8476imsQAIAsmc_Rtc&sz=s220",
            "thumbnailVersion": "1"
           }
          ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:28:03 GMT
+  recorded_at: Thu, 18 Oct 2018 09:44:44 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1hh3rztCm5Tb9WEP08LOyWAABntmioUVjJ2qthUa6TZs/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1ej9P4gtwHysu7_KM5jBDInoBXJVS_LmC9VZC2Lw-ViA/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -682,7 +712,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:28:03 GMT
+      - Thu, 18 Oct 2018 09:44:44 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -700,9 +730,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:28:03 GMT
+      - Thu, 18 Oct 2018 09:44:44 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:28:03 GMT
+      - Thu, 18 Oct 2018 09:44:44 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -714,8 +744,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -727,20 +756,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "insufficientFilePermissions",
-            "message": "The user does not have sufficient permissions for file 1hh3rztCm5Tb9WEP08LOyWAABntmioUVjJ2qthUa6TZs.",
+            "message": "The user does not have sufficient permissions for file 1ej9P4gtwHysu7_KM5jBDInoBXJVS_LmC9VZC2Lw-ViA.",
             "locationType": "header",
             "location": "Authorization"
            }
           ],
           "code": 403,
-          "message": "The user does not have sufficient permissions for file 1hh3rztCm5Tb9WEP08LOyWAABntmioUVjJ2qthUa6TZs."
+          "message": "The user does not have sufficient permissions for file 1ej9P4gtwHysu7_KM5jBDInoBXJVS_LmC9VZC2Lw-ViA."
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:28:03 GMT
+  recorded_at: Thu, 18 Oct 2018 09:44:44 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1hh3rztCm5Tb9WEP08LOyWAABntmioUVjJ2qthUa6TZs&s=AMedNnoAAAAAWq72AyaFVs7DHrIDwAxoOiZcJ_eBjcnj&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1ej9P4gtwHysu7_KM5jBDInoBXJVS_LmC9VZC2Lw-ViA&s=AMedNnoAAAAAW8hyK9MlkHkvShKrCxS7ogrcFXaW5HVJ&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -752,7 +781,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:28:03 GMT
+      - Thu, 18 Oct 2018 09:44:44 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -783,7 +812,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Sun, 18 Mar 2018 21:28:03 GMT
+      - Thu, 18 Oct 2018 09:44:44 GMT
       Server:
       - fife
       Content-Length:
@@ -791,17 +820,16 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:28:03 GMT
+  recorded_at: Thu, 18 Oct 2018 09:44:44 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Z9VzbUFySJoNR9X_jIwHvHcXOCBVrlHgmvYzHcm0dGg/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1gP1JrPi_6IVdMzmYC8sx24pw_NMhLX2SsJcVti1qGrI/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -813,7 +841,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:28:04 GMT
+      - Thu, 18 Oct 2018 09:44:44 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -831,9 +859,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:28:04 GMT
+      - Thu, 18 Oct 2018 09:44:44 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:28:04 GMT
+      - Thu, 18 Oct 2018 09:44:44 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -845,8 +873,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -858,20 +885,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "insufficientFilePermissions",
-            "message": "The user does not have sufficient permissions for file 1Z9VzbUFySJoNR9X_jIwHvHcXOCBVrlHgmvYzHcm0dGg.",
+            "message": "The user does not have sufficient permissions for file 1gP1JrPi_6IVdMzmYC8sx24pw_NMhLX2SsJcVti1qGrI.",
             "locationType": "header",
             "location": "Authorization"
            }
           ],
           "code": 403,
-          "message": "The user does not have sufficient permissions for file 1Z9VzbUFySJoNR9X_jIwHvHcXOCBVrlHgmvYzHcm0dGg."
+          "message": "The user does not have sufficient permissions for file 1gP1JrPi_6IVdMzmYC8sx24pw_NMhLX2SsJcVti1qGrI."
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:28:04 GMT
+  recorded_at: Thu, 18 Oct 2018 09:44:44 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1Z9VzbUFySJoNR9X_jIwHvHcXOCBVrlHgmvYzHcm0dGg&s=AMedNnoAAAAAWq72A8XcZUMFzjSpeVFzufuDtRnjdkOD&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1gP1JrPi_6IVdMzmYC8sx24pw_NMhLX2SsJcVti1qGrI&s=AMedNnoAAAAAW8hyK9x12-VrB0ktqy5xfd7pme6YH0DD&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -883,7 +910,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:28:04 GMT
+      - Thu, 18 Oct 2018 09:44:44 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -914,7 +941,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Sun, 18 Mar 2018 21:28:04 GMT
+      - Thu, 18 Oct 2018 09:44:44 GMT
       Server:
       - fife
       Content-Length:
@@ -922,17 +949,16 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:28:04 GMT
+  recorded_at: Thu, 18 Oct 2018 09:44:44 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/12rj0S1ZnIyEZS2fhrwoIPZPsfFGXPjncWtEwOrdSFJc/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1znewTbDi01fA_vqvTri4vgg45CHXp2jvzdfA2SaP7z4/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -944,7 +970,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:28:04 GMT
+      - Thu, 18 Oct 2018 09:44:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -962,9 +988,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:28:04 GMT
+      - Thu, 18 Oct 2018 09:44:45 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:28:04 GMT
+      - Thu, 18 Oct 2018 09:44:45 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -976,8 +1002,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -989,20 +1014,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "insufficientFilePermissions",
-            "message": "The user does not have sufficient permissions for file 12rj0S1ZnIyEZS2fhrwoIPZPsfFGXPjncWtEwOrdSFJc.",
+            "message": "The user does not have sufficient permissions for file 1znewTbDi01fA_vqvTri4vgg45CHXp2jvzdfA2SaP7z4.",
             "locationType": "header",
             "location": "Authorization"
            }
           ],
           "code": 403,
-          "message": "The user does not have sufficient permissions for file 12rj0S1ZnIyEZS2fhrwoIPZPsfFGXPjncWtEwOrdSFJc."
+          "message": "The user does not have sufficient permissions for file 1znewTbDi01fA_vqvTri4vgg45CHXp2jvzdfA2SaP7z4."
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:28:04 GMT
+  recorded_at: Thu, 18 Oct 2018 09:44:45 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=12rj0S1ZnIyEZS2fhrwoIPZPsfFGXPjncWtEwOrdSFJc&s=AMedNnoAAAAAWq72AzstJ-h7BEQPIx6fVxhAneN8-6l3&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1znewTbDi01fA_vqvTri4vgg45CHXp2jvzdfA2SaP7z4&s=AMedNnoAAAAAW8hyKxhAAhUQiu8476imsQAIAsmc_Rtc&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1014,7 +1039,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:28:04 GMT
+      - Thu, 18 Oct 2018 09:44:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1045,7 +1070,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Sun, 18 Mar 2018 21:28:05 GMT
+      - Thu, 18 Oct 2018 09:44:45 GMT
       Server:
       - fife
       Content-Length:
@@ -1053,17 +1078,16 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:28:05 GMT
+  recorded_at: Thu, 18 Oct 2018 09:44:45 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1cjj97kfqsrwjFn2fbpq1vtr9Z7yOQadg
+    uri: https://www.googleapis.com/drive/v3/files/1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1
     body:
       encoding: UTF-8
       string: ''
@@ -1075,7 +1099,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:28:05 GMT
+      - Thu, 18 Oct 2018 09:44:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1092,18 +1116,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:28:06 GMT
+      - Thu, 18 Oct 2018 09:44:46 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:28:06 GMT
+  recorded_at: Thu, 18 Oct 2018 09:44:46 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Folder_Import/Files_are_imported.yml
+++ b/spec/support/fixtures/vcr_cassettes/Folder_Import/Files_are_imported.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 11:00:46 GMT
+      - Sun, 21 Oct 2018 15:58:20 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:00:46 GMT
+  recorded_at: Sun, 21 Oct 2018 15:58:20 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 11:00:47 GMT
+      - Sun, 21 Oct 2018 15:58:20 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:00:47 GMT
+  recorded_at: Sun, 21 Oct 2018 15:58:20 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        11:00:47 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-21
+        15:58:20 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:00:47 GMT
+      - Sun, 21 Oct 2018 15:58:20 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:00:47 GMT
+      - Sun, 21 Oct 2018 15:58:21 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1905pde17G2_nJYWqXsy64jcpK2b89XQJ",
-         "name": "Test @ 2018-10-18 11:00:47 UTC",
+         "id": "17Y6XDsTRQlu336rPyx4ur0TDbfqaFqNz",
+         "name": "Test @ 2018-10-21 15:58:20 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,7 +185,7 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:00:48 GMT
+  recorded_at: Sun, 21 Oct 2018 15:58:21 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
@@ -201,7 +201,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:00:48 GMT
+      - Sun, 21 Oct 2018 15:58:21 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -218,7 +218,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:00:49 GMT
+      - Sun, 21 Oct 2018 15:58:22 GMT
       Vary:
       - Origin
       - X-Origin
@@ -242,7 +242,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1VOVe6JxC3F2MGnW8S5j8RxVnQlbuCK3Q",
+         "id": "1IRhsXvXYDT1NTUEMTYvrFj8s54AhTtgA",
          "name": "My Awesome New Project! (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
@@ -263,10 +263,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:00:49 GMT
+  recorded_at: Sun, 21 Oct 2018 15:58:22 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1VOVe6JxC3F2MGnW8S5j8RxVnQlbuCK3Q/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1IRhsXvXYDT1NTUEMTYvrFj8s54AhTtgA/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -278,7 +278,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:00:49 GMT
+      - Sun, 21 Oct 2018 15:58:22 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -295,7 +295,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:00:50 GMT
+      - Sun, 21 Oct 2018 15:58:23 GMT
       Vary:
       - Origin
       - X-Origin
@@ -325,10 +325,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:00:50 GMT
+  recorded_at: Sun, 21 Oct 2018 15:58:23 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1VOVe6JxC3F2MGnW8S5j8RxVnQlbuCK3Q?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1IRhsXvXYDT1NTUEMTYvrFj8s54AhTtgA?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -340,7 +340,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:00:50 GMT
+      - Sun, 21 Oct 2018 15:58:23 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -351,9 +351,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:00:50 GMT
+      - Sun, 21 Oct 2018 15:58:23 GMT
       Date:
-      - Thu, 18 Oct 2018 11:00:50 GMT
+      - Sun, 21 Oct 2018 15:58:23 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -379,7 +379,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1VOVe6JxC3F2MGnW8S5j8RxVnQlbuCK3Q",
+         "id": "1IRhsXvXYDT1NTUEMTYvrFj8s54AhTtgA",
          "name": "My Awesome New Project! (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
@@ -409,10 +409,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:00:50 GMT
+  recorded_at: Sun, 21 Oct 2018 15:58:23 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1VOVe6JxC3F2MGnW8S5j8RxVnQlbuCK3Q/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1IRhsXvXYDT1NTUEMTYvrFj8s54AhTtgA/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -424,7 +424,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:00:50 GMT
+      - Sun, 21 Oct 2018 15:58:23 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -442,9 +442,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:00:50 GMT
+      - Sun, 21 Oct 2018 15:58:23 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:00:50 GMT
+      - Sun, 21 Oct 2018 15:58:23 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -476,13 +476,13 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:00:50 GMT
+  recorded_at: Sun, 21 Oct 2018 15:58:23 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"doloremque.webm","parents":["1905pde17G2_nJYWqXsy64jcpK2b89XQJ"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"dolore.jpeg","parents":["17Y6XDsTRQlu336rPyx4ur0TDbfqaFqNz"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -491,7 +491,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:00:50 GMT
+      - Sun, 21 Oct 2018 15:58:23 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -508,7 +508,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:00:51 GMT
+      - Sun, 21 Oct 2018 15:58:25 GMT
       Vary:
       - Origin
       - X-Origin
@@ -532,12 +532,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1TUjqvPmPNDSbVQaOKGBtXkjfoPHjxLxTprsKlVPQwEI",
-         "name": "doloremque.webm",
+         "id": "10hVU--NK_c_l8W4GkWOdJaUNXgMKbtUyrflMBlSI7Xo",
+         "name": "dolore.jpeg",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1905pde17G2_nJYWqXsy64jcpK2b89XQJ"
+          "17Y6XDsTRQlu336rPyx4ur0TDbfqaFqNz"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -553,13 +553,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:00:51 GMT
+  recorded_at: Sun, 21 Oct 2018 15:58:25 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"sapiente.xls","parents":["1905pde17G2_nJYWqXsy64jcpK2b89XQJ"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"sit.doc","parents":["17Y6XDsTRQlu336rPyx4ur0TDbfqaFqNz"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -568,7 +568,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:00:51 GMT
+      - Sun, 21 Oct 2018 15:58:25 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -585,7 +585,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:00:53 GMT
+      - Sun, 21 Oct 2018 15:58:26 GMT
       Vary:
       - Origin
       - X-Origin
@@ -609,12 +609,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1bAHxKSlX-zqgKDgbhDjvmDqvYbINw2hccSf_F6RhG1I",
-         "name": "sapiente.xls",
+         "id": "1usJTcuEAh0VU-E8_8Wg21nFnfp-tz75a3IswwjyKW-s",
+         "name": "sit.doc",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1905pde17G2_nJYWqXsy64jcpK2b89XQJ"
+          "17Y6XDsTRQlu336rPyx4ur0TDbfqaFqNz"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -630,13 +630,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:00:53 GMT
+  recorded_at: Sun, 21 Oct 2018 15:58:26 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"amet.xlsx","parents":["1905pde17G2_nJYWqXsy64jcpK2b89XQJ"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"cum.flac","parents":["17Y6XDsTRQlu336rPyx4ur0TDbfqaFqNz"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -645,7 +645,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:00:53 GMT
+      - Sun, 21 Oct 2018 15:58:26 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -662,7 +662,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:00:54 GMT
+      - Sun, 21 Oct 2018 15:58:28 GMT
       Vary:
       - Origin
       - X-Origin
@@ -686,12 +686,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1Jgt4OkPeifewSTVcIAa4F8ogR5vhXG9S-oYY6PQAhqI",
-         "name": "amet.xlsx",
+         "id": "14Af8lDObLX0OMlm7_YtgGEL1GgUq7DqCzSzbZo94YiQ",
+         "name": "cum.flac",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1905pde17G2_nJYWqXsy64jcpK2b89XQJ"
+          "17Y6XDsTRQlu336rPyx4ur0TDbfqaFqNz"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -707,10 +707,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:00:54 GMT
+  recorded_at: Sun, 21 Oct 2018 15:58:28 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1905pde17G2_nJYWqXsy64jcpK2b89XQJ/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/17Y6XDsTRQlu336rPyx4ur0TDbfqaFqNz/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"reader","type":"user"}'
@@ -722,7 +722,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:00:54 GMT
+      - Sun, 21 Oct 2018 15:58:28 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -739,7 +739,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:00:55 GMT
+      - Sun, 21 Oct 2018 15:58:29 GMT
       Vary:
       - Origin
       - X-Origin
@@ -769,10 +769,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:00:55 GMT
+  recorded_at: Sun, 21 Oct 2018 15:58:29 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1905pde17G2_nJYWqXsy64jcpK2b89XQJ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/17Y6XDsTRQlu336rPyx4ur0TDbfqaFqNz?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -784,7 +784,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:01:01 GMT
+      - Sun, 21 Oct 2018 15:58:34 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -795,9 +795,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:01:01 GMT
+      - Sun, 21 Oct 2018 15:58:35 GMT
       Date:
-      - Thu, 18 Oct 2018 11:01:01 GMT
+      - Sun, 21 Oct 2018 15:58:35 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -823,17 +823,17 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1905pde17G2_nJYWqXsy64jcpK2b89XQJ",
-         "name": "Test @ 2018-10-18 11:00:47 UTC",
+         "id": "17Y6XDsTRQlu336rPyx4ur0TDbfqaFqNz",
+         "name": "Test @ 2018-10-21 15:58:20 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:01:01 GMT
+  recorded_at: Sun, 21 Oct 2018 15:58:35 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1905pde17G2_nJYWqXsy64jcpK2b89XQJ/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/17Y6XDsTRQlu336rPyx4ur0TDbfqaFqNz/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -845,7 +845,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:01:01 GMT
+      - Sun, 21 Oct 2018 15:58:35 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -863,9 +863,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:01:01 GMT
+      - Sun, 21 Oct 2018 15:58:35 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:01:01 GMT
+      - Sun, 21 Oct 2018 15:58:35 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -897,10 +897,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:01:01 GMT
+  recorded_at: Sun, 21 Oct 2018 15:58:35 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271905pde17G2_nJYWqXsy64jcpK2b89XQJ%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%2717Y6XDsTRQlu336rPyx4ur0TDbfqaFqNz%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -912,7 +912,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:01:01 GMT
+      - Sun, 21 Oct 2018 15:58:35 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -923,9 +923,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:01:01 GMT
+      - Sun, 21 Oct 2018 15:58:35 GMT
       Date:
-      - Thu, 18 Oct 2018 11:01:01 GMT
+      - Sun, 21 Oct 2018 15:58:35 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -953,45 +953,45 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1Jgt4OkPeifewSTVcIAa4F8ogR5vhXG9S-oYY6PQAhqI",
-           "name": "amet.xlsx",
+           "id": "14Af8lDObLX0OMlm7_YtgGEL1GgUq7DqCzSzbZo94YiQ",
+           "name": "cum.flac",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1905pde17G2_nJYWqXsy64jcpK2b89XQJ"
+            "17Y6XDsTRQlu336rPyx4ur0TDbfqaFqNz"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Jgt4OkPeifewSTVcIAa4F8ogR5vhXG9S-oYY6PQAhqI&v=1&s=AMedNnoAAAAAW8iEDe7u4Yz6FKiucBnP0Ge4ZC0fQVD5&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=14Af8lDObLX0OMlm7_YtgGEL1GgUq7DqCzSzbZo94YiQ&v=1&s=AMedNnoAAAAAW8y-S6ggEILtnGQc1Zd4RmSpwfFUko8R&sz=s220",
            "thumbnailVersion": "1"
           },
           {
-           "id": "1bAHxKSlX-zqgKDgbhDjvmDqvYbINw2hccSf_F6RhG1I",
-           "name": "sapiente.xls",
+           "id": "1usJTcuEAh0VU-E8_8Wg21nFnfp-tz75a3IswwjyKW-s",
+           "name": "sit.doc",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1905pde17G2_nJYWqXsy64jcpK2b89XQJ"
+            "17Y6XDsTRQlu336rPyx4ur0TDbfqaFqNz"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1bAHxKSlX-zqgKDgbhDjvmDqvYbINw2hccSf_F6RhG1I&v=1&s=AMedNnoAAAAAW8iEDS_aWza-d3x0xbDtmiPZxgjvyFfA&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1usJTcuEAh0VU-E8_8Wg21nFnfp-tz75a3IswwjyKW-s&v=1&s=AMedNnoAAAAAW8y-S1R0BXCqOnymSLSZzUiLmasdQA15&sz=s220",
            "thumbnailVersion": "1"
           },
           {
-           "id": "1TUjqvPmPNDSbVQaOKGBtXkjfoPHjxLxTprsKlVPQwEI",
-           "name": "doloremque.webm",
+           "id": "10hVU--NK_c_l8W4GkWOdJaUNXgMKbtUyrflMBlSI7Xo",
+           "name": "dolore.jpeg",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1905pde17G2_nJYWqXsy64jcpK2b89XQJ"
+            "17Y6XDsTRQlu336rPyx4ur0TDbfqaFqNz"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1TUjqvPmPNDSbVQaOKGBtXkjfoPHjxLxTprsKlVPQwEI&v=1&s=AMedNnoAAAAAW8iEDQzgW8He34Kdlu_YjvqMPPBDOeaw&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=10hVU--NK_c_l8W4GkWOdJaUNXgMKbtUyrflMBlSI7Xo&v=1&s=AMedNnoAAAAAW8y-SyXAin_59I2k53Rf2gpR_nOae2K6&sz=s220",
            "thumbnailVersion": "1"
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:01:01 GMT
+  recorded_at: Sun, 21 Oct 2018 15:58:35 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Jgt4OkPeifewSTVcIAa4F8ogR5vhXG9S-oYY6PQAhqI/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/14Af8lDObLX0OMlm7_YtgGEL1GgUq7DqCzSzbZo94YiQ/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1003,7 +1003,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:01:01 GMT
+      - Sun, 21 Oct 2018 15:58:35 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1021,9 +1021,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:01:02 GMT
+      - Sun, 21 Oct 2018 15:58:35 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:01:02 GMT
+      - Sun, 21 Oct 2018 15:58:35 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1047,20 +1047,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "insufficientFilePermissions",
-            "message": "The user does not have sufficient permissions for file 1Jgt4OkPeifewSTVcIAa4F8ogR5vhXG9S-oYY6PQAhqI.",
+            "message": "The user does not have sufficient permissions for file 14Af8lDObLX0OMlm7_YtgGEL1GgUq7DqCzSzbZo94YiQ.",
             "locationType": "header",
             "location": "Authorization"
            }
           ],
           "code": 403,
-          "message": "The user does not have sufficient permissions for file 1Jgt4OkPeifewSTVcIAa4F8ogR5vhXG9S-oYY6PQAhqI."
+          "message": "The user does not have sufficient permissions for file 14Af8lDObLX0OMlm7_YtgGEL1GgUq7DqCzSzbZo94YiQ."
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:01:02 GMT
+  recorded_at: Sun, 21 Oct 2018 15:58:35 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1Jgt4OkPeifewSTVcIAa4F8ogR5vhXG9S-oYY6PQAhqI&s=AMedNnoAAAAAW8iEDe7u4Yz6FKiucBnP0Ge4ZC0fQVD5&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=14Af8lDObLX0OMlm7_YtgGEL1GgUq7DqCzSzbZo94YiQ&s=AMedNnoAAAAAW8y-S6ggEILtnGQc1Zd4RmSpwfFUko8R&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1072,7 +1072,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:01:02 GMT
+      - Sun, 21 Oct 2018 15:58:35 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1103,7 +1103,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 18 Oct 2018 11:01:02 GMT
+      - Sun, 21 Oct 2018 15:58:36 GMT
       Server:
       - fife
       Content-Length:
@@ -1117,10 +1117,96 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:01:02 GMT
+  recorded_at: Sun, 21 Oct 2018 15:58:36 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/14Af8lDObLX0OMlm7_YtgGEL1GgUq7DqCzSzbZo94YiQ/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"cum.flac","parents":["1IRhsXvXYDT1NTUEMTYvrFj8s54AhTtgA"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 15:58:36 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sun, 21 Oct 2018 15:58:38 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1EymSy1I0uNaINkreAexW2rVepTKEidj8lQHc0Fn2OFU",
+         "name": "cum.flac",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1IRhsXvXYDT1NTUEMTYvrFj8s54AhTtgA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 15:58:38 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1bAHxKSlX-zqgKDgbhDjvmDqvYbINw2hccSf_F6RhG1I/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1usJTcuEAh0VU-E8_8Wg21nFnfp-tz75a3IswwjyKW-s/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1132,7 +1218,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:01:02 GMT
+      - Sun, 21 Oct 2018 15:58:38 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1150,9 +1236,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:01:02 GMT
+      - Sun, 21 Oct 2018 15:58:38 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:01:02 GMT
+      - Sun, 21 Oct 2018 15:58:38 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1176,20 +1262,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "insufficientFilePermissions",
-            "message": "The user does not have sufficient permissions for file 1bAHxKSlX-zqgKDgbhDjvmDqvYbINw2hccSf_F6RhG1I.",
+            "message": "The user does not have sufficient permissions for file 1usJTcuEAh0VU-E8_8Wg21nFnfp-tz75a3IswwjyKW-s.",
             "locationType": "header",
             "location": "Authorization"
            }
           ],
           "code": 403,
-          "message": "The user does not have sufficient permissions for file 1bAHxKSlX-zqgKDgbhDjvmDqvYbINw2hccSf_F6RhG1I."
+          "message": "The user does not have sufficient permissions for file 1usJTcuEAh0VU-E8_8Wg21nFnfp-tz75a3IswwjyKW-s."
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:01:02 GMT
+  recorded_at: Sun, 21 Oct 2018 15:58:38 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1bAHxKSlX-zqgKDgbhDjvmDqvYbINw2hccSf_F6RhG1I&s=AMedNnoAAAAAW8iEDS_aWza-d3x0xbDtmiPZxgjvyFfA&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1usJTcuEAh0VU-E8_8Wg21nFnfp-tz75a3IswwjyKW-s&s=AMedNnoAAAAAW8y-S1R0BXCqOnymSLSZzUiLmasdQA15&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1201,7 +1287,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:01:02 GMT
+      - Sun, 21 Oct 2018 15:58:38 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1232,7 +1318,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 18 Oct 2018 11:01:02 GMT
+      - Sun, 21 Oct 2018 15:58:39 GMT
       Server:
       - fife
       Content-Length:
@@ -1246,10 +1332,96 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:01:02 GMT
+  recorded_at: Sun, 21 Oct 2018 15:58:38 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1usJTcuEAh0VU-E8_8Wg21nFnfp-tz75a3IswwjyKW-s/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"sit.doc","parents":["1IRhsXvXYDT1NTUEMTYvrFj8s54AhTtgA"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 15:58:38 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sun, 21 Oct 2018 15:58:41 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "11TZS_j2zbT0XykjViiFwkC8WcjdZ-ihko4b5P5dNNRg",
+         "name": "sit.doc",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1IRhsXvXYDT1NTUEMTYvrFj8s54AhTtgA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 15:58:41 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1TUjqvPmPNDSbVQaOKGBtXkjfoPHjxLxTprsKlVPQwEI/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/10hVU--NK_c_l8W4GkWOdJaUNXgMKbtUyrflMBlSI7Xo/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1261,7 +1433,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:01:02 GMT
+      - Sun, 21 Oct 2018 15:58:41 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1279,9 +1451,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:01:03 GMT
+      - Sun, 21 Oct 2018 15:58:42 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:01:03 GMT
+      - Sun, 21 Oct 2018 15:58:42 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1305,20 +1477,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "insufficientFilePermissions",
-            "message": "The user does not have sufficient permissions for file 1TUjqvPmPNDSbVQaOKGBtXkjfoPHjxLxTprsKlVPQwEI.",
+            "message": "The user does not have sufficient permissions for file 10hVU--NK_c_l8W4GkWOdJaUNXgMKbtUyrflMBlSI7Xo.",
             "locationType": "header",
             "location": "Authorization"
            }
           ],
           "code": 403,
-          "message": "The user does not have sufficient permissions for file 1TUjqvPmPNDSbVQaOKGBtXkjfoPHjxLxTprsKlVPQwEI."
+          "message": "The user does not have sufficient permissions for file 10hVU--NK_c_l8W4GkWOdJaUNXgMKbtUyrflMBlSI7Xo."
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:01:03 GMT
+  recorded_at: Sun, 21 Oct 2018 15:58:41 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1TUjqvPmPNDSbVQaOKGBtXkjfoPHjxLxTprsKlVPQwEI&s=AMedNnoAAAAAW8iEDQzgW8He34Kdlu_YjvqMPPBDOeaw&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=10hVU--NK_c_l8W4GkWOdJaUNXgMKbtUyrflMBlSI7Xo&s=AMedNnoAAAAAW8y-SyXAin_59I2k53Rf2gpR_nOae2K6&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1330,7 +1502,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:01:03 GMT
+      - Sun, 21 Oct 2018 15:58:41 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1361,7 +1533,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 18 Oct 2018 11:01:03 GMT
+      - Sun, 21 Oct 2018 15:58:42 GMT
       Server:
       - fife
       Content-Length:
@@ -1375,10 +1547,246 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:01:03 GMT
+  recorded_at: Sun, 21 Oct 2018 15:58:42 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/10hVU--NK_c_l8W4GkWOdJaUNXgMKbtUyrflMBlSI7Xo/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"dolore.jpeg","parents":["1IRhsXvXYDT1NTUEMTYvrFj8s54AhTtgA"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 15:58:42 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sun, 21 Oct 2018 15:58:45 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1x9Op66O0gM1BU9T5im-dPnj2MamQP-IsxwWg9kzdGSg",
+         "name": "dolore.jpeg",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1IRhsXvXYDT1NTUEMTYvrFj8s54AhTtgA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 15:58:44 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271IRhsXvXYDT1NTUEMTYvrFj8s54AhTtgA%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 15:58:45 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 21 Oct 2018 15:58:45 GMT
+      Date:
+      - Sun, 21 Oct 2018 15:58:45 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "files": [
+          {
+           "id": "1x9Op66O0gM1BU9T5im-dPnj2MamQP-IsxwWg9kzdGSg",
+           "name": "dolore.jpeg",
+           "mimeType": "application/vnd.google-apps.document",
+           "trashed": false,
+           "parents": [
+            "1IRhsXvXYDT1NTUEMTYvrFj8s54AhTtgA"
+           ],
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "13193959451567607887",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+             "role": "reader",
+             "displayName": "Testuser Upshift One",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "owner",
+             "displayName": "Upshift One",
+             "deleted": false
+            }
+           ]
+          },
+          {
+           "id": "11TZS_j2zbT0XykjViiFwkC8WcjdZ-ihko4b5P5dNNRg",
+           "name": "sit.doc",
+           "mimeType": "application/vnd.google-apps.document",
+           "trashed": false,
+           "parents": [
+            "1IRhsXvXYDT1NTUEMTYvrFj8s54AhTtgA"
+           ],
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=11TZS_j2zbT0XykjViiFwkC8WcjdZ-ihko4b5P5dNNRg&v=1&s=AMedNnoAAAAAW8y-VcPIkFbLFYdqh65Gf0TVJQbT3ZVg&sz=s220",
+           "thumbnailVersion": "1",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "13193959451567607887",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+             "role": "reader",
+             "displayName": "Testuser Upshift One",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "owner",
+             "displayName": "Upshift One",
+             "deleted": false
+            }
+           ]
+          },
+          {
+           "id": "1EymSy1I0uNaINkreAexW2rVepTKEidj8lQHc0Fn2OFU",
+           "name": "cum.flac",
+           "mimeType": "application/vnd.google-apps.document",
+           "trashed": false,
+           "parents": [
+            "1IRhsXvXYDT1NTUEMTYvrFj8s54AhTtgA"
+           ],
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1EymSy1I0uNaINkreAexW2rVepTKEidj8lQHc0Fn2OFU&v=1&s=AMedNnoAAAAAW8y-VfzdkphBOExqI9DWpwMuxSLHgDWW&sz=s220",
+           "thumbnailVersion": "1",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "13193959451567607887",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+             "role": "reader",
+             "displayName": "Testuser Upshift One",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "owner",
+             "displayName": "Upshift One",
+             "deleted": false
+            }
+           ]
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 15:58:45 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1905pde17G2_nJYWqXsy64jcpK2b89XQJ
+    uri: https://www.googleapis.com/drive/v3/files/17Y6XDsTRQlu336rPyx4ur0TDbfqaFqNz
     body:
       encoding: UTF-8
       string: ''
@@ -1390,7 +1798,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:01:03 GMT
+      - Sun, 21 Oct 2018 15:58:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1407,7 +1815,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:01:04 GMT
+      - Sun, 21 Oct 2018 15:58:46 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1419,5 +1827,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:01:04 GMT
+  recorded_at: Sun, 21 Oct 2018 15:58:46 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Folder_Import/Files_are_imported.yml
+++ b/spec/support/fixtures/vcr_cassettes/Folder_Import/Files_are_imported.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:44:32 GMT
+      - Thu, 18 Oct 2018 11:00:46 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:44:32 GMT
+  recorded_at: Thu, 18 Oct 2018 11:00:46 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:44:32 GMT
+      - Thu, 18 Oct 2018 11:00:47 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:44:32 GMT
+  recorded_at: Thu, 18 Oct 2018 11:00:47 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        09:44:32 UTC","parents":["root"]}'
+        11:00:47 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:32 GMT
+      - Thu, 18 Oct 2018 11:00:47 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:44:33 GMT
+      - Thu, 18 Oct 2018 11:00:47 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1",
-         "name": "Test @ 2018-10-18 09:44:32 UTC",
+         "id": "1905pde17G2_nJYWqXsy64jcpK2b89XQJ",
+         "name": "Test @ 2018-10-18 11:00:47 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,13 +185,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:44:33 GMT
+  recorded_at: Thu, 18 Oct 2018 11:00:48 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"voluptatem.ods","parents":["1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"My Awesome
+        New Project! (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -200,11 +201,11 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:33 GMT
+      - Thu, 18 Oct 2018 11:00:48 GMT
       Content-Type:
       - application/json
       Authorization:
-      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
   response:
     status:
       code: 200
@@ -217,7 +218,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:44:34 GMT
+      - Thu, 18 Oct 2018 11:00:49 GMT
       Vary:
       - Origin
       - X-Origin
@@ -241,34 +242,34 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1znewTbDi01fA_vqvTri4vgg45CHXp2jvzdfA2SaP7z4",
-         "name": "voluptatem.ods",
-         "mimeType": "application/vnd.google-apps.document",
+         "id": "1VOVe6JxC3F2MGnW8S5j8RxVnQlbuCK3Q",
+         "name": "My Awesome New Project! (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1"
+          "0AIeK5UAEPQfeUk9PVA"
          ],
          "thumbnailVersion": "0",
          "permissions": [
           {
            "kind": "drive#permission",
-           "id": "13193959451567607887",
+           "id": "11673017242486491425",
            "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
            "role": "owner",
-           "displayName": "Testuser Upshift One",
+           "displayName": "Upshift One",
            "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:44:34 GMT
+  recorded_at: Thu, 18 Oct 2018 11:00:49 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1VOVe6JxC3F2MGnW8S5j8RxVnQlbuCK3Q/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"voluptates.ods","parents":["1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1"]}'
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -277,11 +278,11 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:34 GMT
+      - Thu, 18 Oct 2018 11:00:49 GMT
       Content-Type:
       - application/json
       Authorization:
-      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
   response:
     status:
       code: 200
@@ -294,161 +295,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:44:36 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1gP1JrPi_6IVdMzmYC8sx24pw_NMhLX2SsJcVti1qGrI",
-         "name": "voluptates.ods",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:44:36 GMT
-- request:
-    method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"ducimus.mp3","parents":["1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1"]}'
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 09:44:36 GMT
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Thu, 18 Oct 2018 09:44:37 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1ej9P4gtwHysu7_KM5jBDInoBXJVS_LmC9VZC2Lw-ViA",
-         "name": "ducimus.mp3",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:44:37 GMT
-- request:
-    method: post
-    uri: https://www.googleapis.com/drive/v3/files/1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1/permissions?sendNotificationEmail=false
-    body:
-      encoding: UTF-8
-      string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"reader","type":"user"}'
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 09:44:37 GMT
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Thu, 18 Oct 2018 09:44:38 GMT
+      - Thu, 18 Oct 2018 11:00:50 GMT
       Vary:
       - Origin
       - X-Origin
@@ -473,15 +320,15 @@ http_interactions:
       string: |
         {
          "kind": "drive#permission",
-         "id": "11673017242486491425",
+         "id": "13193959451567607887",
          "type": "user",
          "role": "reader"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:44:38 GMT
+  recorded_at: Thu, 18 Oct 2018 11:00:50 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1VOVe6JxC3F2MGnW8S5j8RxVnQlbuCK3Q?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -493,7 +340,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:43 GMT
+      - Thu, 18 Oct 2018 11:00:50 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -504,9 +351,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:44:43 GMT
+      - Thu, 18 Oct 2018 11:00:50 GMT
       Date:
-      - Thu, 18 Oct 2018 09:44:43 GMT
+      - Thu, 18 Oct 2018 11:00:50 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -532,17 +379,40 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1",
-         "name": "Test @ 2018-10-18 09:44:32 UTC",
+         "id": "1VOVe6JxC3F2MGnW8S5j8RxVnQlbuCK3Q",
+         "name": "My Awesome New Project! (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
-         "thumbnailVersion": "0"
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:44:43 GMT
+  recorded_at: Thu, 18 Oct 2018 11:00:50 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1VOVe6JxC3F2MGnW8S5j8RxVnQlbuCK3Q/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -554,7 +424,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:43 GMT
+      - Thu, 18 Oct 2018 11:00:50 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -572,9 +442,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:44:43 GMT
+      - Thu, 18 Oct 2018 11:00:50 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:44:43 GMT
+      - Thu, 18 Oct 2018 11:00:50 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -606,10 +476,303 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:44:43 GMT
+  recorded_at: Thu, 18 Oct 2018 11:00:50 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"doloremque.webm","parents":["1905pde17G2_nJYWqXsy64jcpK2b89XQJ"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:00:50 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:00:51 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1TUjqvPmPNDSbVQaOKGBtXkjfoPHjxLxTprsKlVPQwEI",
+         "name": "doloremque.webm",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1905pde17G2_nJYWqXsy64jcpK2b89XQJ"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:00:51 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"sapiente.xls","parents":["1905pde17G2_nJYWqXsy64jcpK2b89XQJ"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:00:51 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:00:53 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1bAHxKSlX-zqgKDgbhDjvmDqvYbINw2hccSf_F6RhG1I",
+         "name": "sapiente.xls",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1905pde17G2_nJYWqXsy64jcpK2b89XQJ"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:00:53 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"amet.xlsx","parents":["1905pde17G2_nJYWqXsy64jcpK2b89XQJ"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:00:53 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:00:54 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1Jgt4OkPeifewSTVcIAa4F8ogR5vhXG9S-oYY6PQAhqI",
+         "name": "amet.xlsx",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1905pde17G2_nJYWqXsy64jcpK2b89XQJ"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:00:54 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1905pde17G2_nJYWqXsy64jcpK2b89XQJ/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:00:54 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:00:55 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "11673017242486491425",
+         "type": "user",
+         "role": "reader"
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:00:55 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files/1905pde17G2_nJYWqXsy64jcpK2b89XQJ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -621,7 +784,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:43 GMT
+      - Thu, 18 Oct 2018 11:01:01 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -632,9 +795,137 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:44:43 GMT
+      - Thu, 18 Oct 2018 11:01:01 GMT
       Date:
-      - Thu, 18 Oct 2018 09:44:43 GMT
+      - Thu, 18 Oct 2018 11:01:01 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1905pde17G2_nJYWqXsy64jcpK2b89XQJ",
+         "name": "Test @ 2018-10-18 11:00:47 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0"
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:01:01 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1905pde17G2_nJYWqXsy64jcpK2b89XQJ/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:01:01 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:01:01 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:01:01 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:01:01 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271905pde17G2_nJYWqXsy64jcpK2b89XQJ%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:01:01 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:01:01 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:01:01 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -662,45 +953,45 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1ej9P4gtwHysu7_KM5jBDInoBXJVS_LmC9VZC2Lw-ViA",
-           "name": "ducimus.mp3",
+           "id": "1Jgt4OkPeifewSTVcIAa4F8ogR5vhXG9S-oYY6PQAhqI",
+           "name": "amet.xlsx",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1"
+            "1905pde17G2_nJYWqXsy64jcpK2b89XQJ"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1ej9P4gtwHysu7_KM5jBDInoBXJVS_LmC9VZC2Lw-ViA&v=1&s=AMedNnoAAAAAW8hyK9MlkHkvShKrCxS7ogrcFXaW5HVJ&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Jgt4OkPeifewSTVcIAa4F8ogR5vhXG9S-oYY6PQAhqI&v=1&s=AMedNnoAAAAAW8iEDe7u4Yz6FKiucBnP0Ge4ZC0fQVD5&sz=s220",
            "thumbnailVersion": "1"
           },
           {
-           "id": "1gP1JrPi_6IVdMzmYC8sx24pw_NMhLX2SsJcVti1qGrI",
-           "name": "voluptates.ods",
+           "id": "1bAHxKSlX-zqgKDgbhDjvmDqvYbINw2hccSf_F6RhG1I",
+           "name": "sapiente.xls",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1"
+            "1905pde17G2_nJYWqXsy64jcpK2b89XQJ"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1gP1JrPi_6IVdMzmYC8sx24pw_NMhLX2SsJcVti1qGrI&v=1&s=AMedNnoAAAAAW8hyK9x12-VrB0ktqy5xfd7pme6YH0DD&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1bAHxKSlX-zqgKDgbhDjvmDqvYbINw2hccSf_F6RhG1I&v=1&s=AMedNnoAAAAAW8iEDS_aWza-d3x0xbDtmiPZxgjvyFfA&sz=s220",
            "thumbnailVersion": "1"
           },
           {
-           "id": "1znewTbDi01fA_vqvTri4vgg45CHXp2jvzdfA2SaP7z4",
-           "name": "voluptatem.ods",
+           "id": "1TUjqvPmPNDSbVQaOKGBtXkjfoPHjxLxTprsKlVPQwEI",
+           "name": "doloremque.webm",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1"
+            "1905pde17G2_nJYWqXsy64jcpK2b89XQJ"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1znewTbDi01fA_vqvTri4vgg45CHXp2jvzdfA2SaP7z4&v=1&s=AMedNnoAAAAAW8hyKxhAAhUQiu8476imsQAIAsmc_Rtc&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1TUjqvPmPNDSbVQaOKGBtXkjfoPHjxLxTprsKlVPQwEI&v=1&s=AMedNnoAAAAAW8iEDQzgW8He34Kdlu_YjvqMPPBDOeaw&sz=s220",
            "thumbnailVersion": "1"
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:44:44 GMT
+  recorded_at: Thu, 18 Oct 2018 11:01:01 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1ej9P4gtwHysu7_KM5jBDInoBXJVS_LmC9VZC2Lw-ViA/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1Jgt4OkPeifewSTVcIAa4F8ogR5vhXG9S-oYY6PQAhqI/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -712,7 +1003,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:44 GMT
+      - Thu, 18 Oct 2018 11:01:01 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -730,9 +1021,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:44:44 GMT
+      - Thu, 18 Oct 2018 11:01:02 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:44:44 GMT
+      - Thu, 18 Oct 2018 11:01:02 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -756,20 +1047,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "insufficientFilePermissions",
-            "message": "The user does not have sufficient permissions for file 1ej9P4gtwHysu7_KM5jBDInoBXJVS_LmC9VZC2Lw-ViA.",
+            "message": "The user does not have sufficient permissions for file 1Jgt4OkPeifewSTVcIAa4F8ogR5vhXG9S-oYY6PQAhqI.",
             "locationType": "header",
             "location": "Authorization"
            }
           ],
           "code": 403,
-          "message": "The user does not have sufficient permissions for file 1ej9P4gtwHysu7_KM5jBDInoBXJVS_LmC9VZC2Lw-ViA."
+          "message": "The user does not have sufficient permissions for file 1Jgt4OkPeifewSTVcIAa4F8ogR5vhXG9S-oYY6PQAhqI."
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:44:44 GMT
+  recorded_at: Thu, 18 Oct 2018 11:01:02 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1ej9P4gtwHysu7_KM5jBDInoBXJVS_LmC9VZC2Lw-ViA&s=AMedNnoAAAAAW8hyK9MlkHkvShKrCxS7ogrcFXaW5HVJ&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1Jgt4OkPeifewSTVcIAa4F8ogR5vhXG9S-oYY6PQAhqI&s=AMedNnoAAAAAW8iEDe7u4Yz6FKiucBnP0Ge4ZC0fQVD5&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -781,7 +1072,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:44 GMT
+      - Thu, 18 Oct 2018 11:01:02 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -812,7 +1103,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 18 Oct 2018 09:44:44 GMT
+      - Thu, 18 Oct 2018 11:01:02 GMT
       Server:
       - fife
       Content-Length:
@@ -826,10 +1117,10 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:44:44 GMT
+  recorded_at: Thu, 18 Oct 2018 11:01:02 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1gP1JrPi_6IVdMzmYC8sx24pw_NMhLX2SsJcVti1qGrI/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1bAHxKSlX-zqgKDgbhDjvmDqvYbINw2hccSf_F6RhG1I/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -841,7 +1132,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:44 GMT
+      - Thu, 18 Oct 2018 11:01:02 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -859,9 +1150,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:44:44 GMT
+      - Thu, 18 Oct 2018 11:01:02 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:44:44 GMT
+      - Thu, 18 Oct 2018 11:01:02 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -885,20 +1176,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "insufficientFilePermissions",
-            "message": "The user does not have sufficient permissions for file 1gP1JrPi_6IVdMzmYC8sx24pw_NMhLX2SsJcVti1qGrI.",
+            "message": "The user does not have sufficient permissions for file 1bAHxKSlX-zqgKDgbhDjvmDqvYbINw2hccSf_F6RhG1I.",
             "locationType": "header",
             "location": "Authorization"
            }
           ],
           "code": 403,
-          "message": "The user does not have sufficient permissions for file 1gP1JrPi_6IVdMzmYC8sx24pw_NMhLX2SsJcVti1qGrI."
+          "message": "The user does not have sufficient permissions for file 1bAHxKSlX-zqgKDgbhDjvmDqvYbINw2hccSf_F6RhG1I."
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:44:44 GMT
+  recorded_at: Thu, 18 Oct 2018 11:01:02 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1gP1JrPi_6IVdMzmYC8sx24pw_NMhLX2SsJcVti1qGrI&s=AMedNnoAAAAAW8hyK9x12-VrB0ktqy5xfd7pme6YH0DD&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1bAHxKSlX-zqgKDgbhDjvmDqvYbINw2hccSf_F6RhG1I&s=AMedNnoAAAAAW8iEDS_aWza-d3x0xbDtmiPZxgjvyFfA&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -910,7 +1201,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:44 GMT
+      - Thu, 18 Oct 2018 11:01:02 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -941,7 +1232,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 18 Oct 2018 09:44:44 GMT
+      - Thu, 18 Oct 2018 11:01:02 GMT
       Server:
       - fife
       Content-Length:
@@ -955,10 +1246,10 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:44:44 GMT
+  recorded_at: Thu, 18 Oct 2018 11:01:02 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1znewTbDi01fA_vqvTri4vgg45CHXp2jvzdfA2SaP7z4/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1TUjqvPmPNDSbVQaOKGBtXkjfoPHjxLxTprsKlVPQwEI/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -970,7 +1261,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:45 GMT
+      - Thu, 18 Oct 2018 11:01:02 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -988,9 +1279,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:44:45 GMT
+      - Thu, 18 Oct 2018 11:01:03 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:44:45 GMT
+      - Thu, 18 Oct 2018 11:01:03 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1014,20 +1305,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "insufficientFilePermissions",
-            "message": "The user does not have sufficient permissions for file 1znewTbDi01fA_vqvTri4vgg45CHXp2jvzdfA2SaP7z4.",
+            "message": "The user does not have sufficient permissions for file 1TUjqvPmPNDSbVQaOKGBtXkjfoPHjxLxTprsKlVPQwEI.",
             "locationType": "header",
             "location": "Authorization"
            }
           ],
           "code": 403,
-          "message": "The user does not have sufficient permissions for file 1znewTbDi01fA_vqvTri4vgg45CHXp2jvzdfA2SaP7z4."
+          "message": "The user does not have sufficient permissions for file 1TUjqvPmPNDSbVQaOKGBtXkjfoPHjxLxTprsKlVPQwEI."
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:44:45 GMT
+  recorded_at: Thu, 18 Oct 2018 11:01:03 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1znewTbDi01fA_vqvTri4vgg45CHXp2jvzdfA2SaP7z4&s=AMedNnoAAAAAW8hyKxhAAhUQiu8476imsQAIAsmc_Rtc&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1TUjqvPmPNDSbVQaOKGBtXkjfoPHjxLxTprsKlVPQwEI&s=AMedNnoAAAAAW8iEDQzgW8He34Kdlu_YjvqMPPBDOeaw&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1039,7 +1330,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:45 GMT
+      - Thu, 18 Oct 2018 11:01:03 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1070,7 +1361,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 18 Oct 2018 09:44:45 GMT
+      - Thu, 18 Oct 2018 11:01:03 GMT
       Server:
       - fife
       Content-Length:
@@ -1084,10 +1375,10 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:44:45 GMT
+  recorded_at: Thu, 18 Oct 2018 11:01:03 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1fMysLxa_r7EsqjpIwbWhtxX5dZPRobz1
+    uri: https://www.googleapis.com/drive/v3/files/1905pde17G2_nJYWqXsy64jcpK2b89XQJ
     body:
       encoding: UTF-8
       string: ''
@@ -1099,7 +1390,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:45 GMT
+      - Thu, 18 Oct 2018 11:01:03 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1116,7 +1407,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:44:46 GMT
+      - Thu, 18 Oct 2018 11:01:04 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1128,5 +1419,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:44:46 GMT
+  recorded_at: Thu, 18 Oct 2018 11:01:04 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Force_Sync/User_can_force_sync_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/Force_Sync/User_can_force_sync_file.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 11:43:44 GMT
+      - Sun, 21 Oct 2018 16:27:32 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:43:44 GMT
+  recorded_at: Sun, 21 Oct 2018 16:27:32 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 11:43:44 GMT
+      - Sun, 21 Oct 2018 16:27:32 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:43:44 GMT
+  recorded_at: Sun, 21 Oct 2018 16:27:32 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        11:43:44 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-21
+        16:27:32 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:43:44 GMT
+      - Sun, 21 Oct 2018 16:27:32 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:43:45 GMT
+      - Sun, 21 Oct 2018 16:27:33 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h",
-         "name": "Test @ 2018-10-18 11:43:44 UTC",
+         "id": "1Vrmi82AaybnZY9_xdV3EZqJgj21L1FE_",
+         "name": "Test @ 2018-10-21 16:27:32 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:43:45 GMT
+  recorded_at: Sun, 21 Oct 2018 16:27:33 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1Vrmi82AaybnZY9_xdV3EZqJgj21L1FE_/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:43:45 GMT
+      - Sun, 21 Oct 2018 16:27:33 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:43:46 GMT
+      - Sun, 21 Oct 2018 16:27:34 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,13 +247,13 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:43:46 GMT
+  recorded_at: Sun, 21 Oct 2018 16:27:34 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1Vrmi82AaybnZY9_xdV3EZqJgj21L1FE_"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:43:46 GMT
+      - Sun, 21 Oct 2018 16:27:35 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -279,7 +279,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:43:47 GMT
+      - Sun, 21 Oct 2018 16:27:36 GMT
       Vary:
       - Origin
       - X-Origin
@@ -303,12 +303,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1Rj5AwNfHfP0Op7_FkgWhRvfwZeOQYgR5",
+         "id": "1gH5pBoEQWhAcaxo-ODBi9GRh0Q_wX194",
          "name": "Folder",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h"
+          "1Vrmi82AaybnZY9_xdV3EZqJgj21L1FE_"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -333,13 +333,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:43:47 GMT
+  recorded_at: Sun, 21 Oct 2018 16:27:36 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"Doc XYZ","parents":["1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Doc XYZ","parents":["1Vrmi82AaybnZY9_xdV3EZqJgj21L1FE_"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -348,7 +348,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:43:47 GMT
+      - Sun, 21 Oct 2018 16:27:36 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -365,7 +365,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:43:48 GMT
+      - Sun, 21 Oct 2018 16:27:38 GMT
       Vary:
       - Origin
       - X-Origin
@@ -389,12 +389,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U",
+         "id": "1lzY4T_OCvmFN45ulC6kwyU6ypHRMr9ZkdoEQiQqr7UI",
          "name": "Doc XYZ",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h"
+          "1Vrmi82AaybnZY9_xdV3EZqJgj21L1FE_"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -419,14 +419,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:43:48 GMT
+  recorded_at: Sun, 21 Oct 2018 16:27:38 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"26 Billion
-        Year Bunker (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"1 Bistromath
+        (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -435,7 +435,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:43:48 GMT
+      - Sun, 21 Oct 2018 16:27:38 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -452,7 +452,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:43:49 GMT
+      - Sun, 21 Oct 2018 16:27:38 GMT
       Vary:
       - Origin
       - X-Origin
@@ -476,8 +476,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1PuuvNUqUpPWpysi1XI4GWfdXusQMGxVw",
-         "name": "26 Billion Year Bunker (Archive)",
+         "id": "1PrFBNG6OH9-5PJYqI4cmPQvP5qmvz0de",
+         "name": "1 Bistromath (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -497,10 +497,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:43:49 GMT
+  recorded_at: Sun, 21 Oct 2018 16:27:38 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1PuuvNUqUpPWpysi1XI4GWfdXusQMGxVw/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1PrFBNG6OH9-5PJYqI4cmPQvP5qmvz0de/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -512,7 +512,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:43:49 GMT
+      - Sun, 21 Oct 2018 16:27:39 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -529,7 +529,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:43:50 GMT
+      - Sun, 21 Oct 2018 16:27:39 GMT
       Vary:
       - Origin
       - X-Origin
@@ -559,10 +559,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:43:50 GMT
+  recorded_at: Sun, 21 Oct 2018 16:27:39 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1PuuvNUqUpPWpysi1XI4GWfdXusQMGxVw?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1PrFBNG6OH9-5PJYqI4cmPQvP5qmvz0de?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -574,7 +574,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:43:50 GMT
+      - Sun, 21 Oct 2018 16:27:39 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -585,9 +585,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:43:50 GMT
+      - Sun, 21 Oct 2018 16:27:40 GMT
       Date:
-      - Thu, 18 Oct 2018 11:43:50 GMT
+      - Sun, 21 Oct 2018 16:27:40 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -613,8 +613,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1PuuvNUqUpPWpysi1XI4GWfdXusQMGxVw",
-         "name": "26 Billion Year Bunker (Archive)",
+         "id": "1PrFBNG6OH9-5PJYqI4cmPQvP5qmvz0de",
+         "name": "1 Bistromath (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -643,10 +643,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:43:50 GMT
+  recorded_at: Sun, 21 Oct 2018 16:27:40 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1PuuvNUqUpPWpysi1XI4GWfdXusQMGxVw/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1PrFBNG6OH9-5PJYqI4cmPQvP5qmvz0de/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -658,7 +658,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:43:50 GMT
+      - Sun, 21 Oct 2018 16:27:40 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -676,9 +676,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:43:50 GMT
+      - Sun, 21 Oct 2018 16:27:40 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:43:50 GMT
+      - Sun, 21 Oct 2018 16:27:40 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -710,10 +710,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:43:50 GMT
+  recorded_at: Sun, 21 Oct 2018 16:27:40 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1Vrmi82AaybnZY9_xdV3EZqJgj21L1FE_?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -725,7 +725,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:43:50 GMT
+      - Sun, 21 Oct 2018 16:27:40 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -736,9 +736,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:43:50 GMT
+      - Sun, 21 Oct 2018 16:27:41 GMT
       Date:
-      - Thu, 18 Oct 2018 11:43:50 GMT
+      - Sun, 21 Oct 2018 16:27:41 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -764,8 +764,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h",
-         "name": "Test @ 2018-10-18 11:43:44 UTC",
+         "id": "1Vrmi82AaybnZY9_xdV3EZqJgj21L1FE_",
+         "name": "Test @ 2018-10-21 16:27:32 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -791,10 +791,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:43:50 GMT
+  recorded_at: Sun, 21 Oct 2018 16:27:41 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1Vrmi82AaybnZY9_xdV3EZqJgj21L1FE_/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -806,7 +806,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:43:50 GMT
+      - Sun, 21 Oct 2018 16:27:41 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -824,9 +824,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:43:51 GMT
+      - Sun, 21 Oct 2018 16:27:41 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:43:51 GMT
+      - Sun, 21 Oct 2018 16:27:41 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -858,10 +858,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:43:51 GMT
+  recorded_at: Sun, 21 Oct 2018 16:27:41 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271Vrmi82AaybnZY9_xdV3EZqJgj21L1FE_%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -873,7 +873,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:43:51 GMT
+      - Sun, 21 Oct 2018 16:27:41 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -884,9 +884,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:43:51 GMT
+      - Sun, 21 Oct 2018 16:27:41 GMT
       Date:
-      - Thu, 18 Oct 2018 11:43:51 GMT
+      - Sun, 21 Oct 2018 16:27:41 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -914,14 +914,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U",
+           "id": "1lzY4T_OCvmFN45ulC6kwyU6ypHRMr9ZkdoEQiQqr7UI",
            "name": "Doc XYZ",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h"
+            "1Vrmi82AaybnZY9_xdV3EZqJgj21L1FE_"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U&v=1&s=AMedNnoAAAAAW8iOF7cKGzvYUB_71KuzlxXmlfHdzyTV&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1lzY4T_OCvmFN45ulC6kwyU6ypHRMr9ZkdoEQiQqr7UI&v=1&s=AMedNnoAAAAAW8zFHXIgyBs0c8tjsSHoC9r7hk7MwhMm&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -945,12 +945,12 @@ http_interactions:
            ]
           },
           {
-           "id": "1Rj5AwNfHfP0Op7_FkgWhRvfwZeOQYgR5",
+           "id": "1gH5pBoEQWhAcaxo-ODBi9GRh0Q_wX194",
            "name": "Folder",
            "mimeType": "application/vnd.google-apps.folder",
            "trashed": false,
            "parents": [
-            "1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h"
+            "1Vrmi82AaybnZY9_xdV3EZqJgj21L1FE_"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -977,10 +977,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:43:51 GMT
+  recorded_at: Sun, 21 Oct 2018 16:27:41 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1lzY4T_OCvmFN45ulC6kwyU6ypHRMr9ZkdoEQiQqr7UI/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -992,7 +992,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:43:51 GMT
+      - Sun, 21 Oct 2018 16:27:41 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1003,9 +1003,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:43:51 GMT
+      - Sun, 21 Oct 2018 16:27:42 GMT
       Date:
-      - Thu, 18 Oct 2018 11:43:51 GMT
+      - Sun, 21 Oct 2018 16:27:42 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1034,13 +1034,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T11:43:48.002Z"
+         "modifiedTime": "2018-10-21T16:27:36.832Z"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:43:51 GMT
+  recorded_at: Sun, 21 Oct 2018 16:27:42 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U&s=AMedNnoAAAAAW8iOF7cKGzvYUB_71KuzlxXmlfHdzyTV&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1lzY4T_OCvmFN45ulC6kwyU6ypHRMr9ZkdoEQiQqr7UI&s=AMedNnoAAAAAW8zFHXIgyBs0c8tjsSHoC9r7hk7MwhMm&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1052,7 +1052,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:43:51 GMT
+      - Sun, 21 Oct 2018 16:27:42 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1083,7 +1083,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 18 Oct 2018 11:43:52 GMT
+      - Sun, 21 Oct 2018 16:27:42 GMT
       Server:
       - fife
       Content-Length:
@@ -1097,10 +1097,96 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:43:52 GMT
+  recorded_at: Sun, 21 Oct 2018 16:27:42 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1lzY4T_OCvmFN45ulC6kwyU6ypHRMr9ZkdoEQiQqr7UI/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"Doc XYZ","parents":["1PrFBNG6OH9-5PJYqI4cmPQvP5qmvz0de"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:27:42 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:27:44 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "11x9uPLEMyj8Smp3f1QgM5ZpVO0Tcn_74uXQOgrykcF8",
+         "name": "Doc XYZ",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1PrFBNG6OH9-5PJYqI4cmPQvP5qmvz0de"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:27:44 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Rj5AwNfHfP0Op7_FkgWhRvfwZeOQYgR5/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1gH5pBoEQWhAcaxo-ODBi9GRh0Q_wX194/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1112,7 +1198,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:43:52 GMT
+      - Sun, 21 Oct 2018 16:27:44 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1130,9 +1216,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 11:43:52 GMT
+      - Sun, 21 Oct 2018 16:27:44 GMT
       Expires:
-      - Thu, 18 Oct 2018 11:43:52 GMT
+      - Sun, 21 Oct 2018 16:27:44 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1164,10 +1250,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:43:52 GMT
+  recorded_at: Sun, 21 Oct 2018 16:27:44 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271Rj5AwNfHfP0Op7_FkgWhRvfwZeOQYgR5%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271gH5pBoEQWhAcaxo-ODBi9GRh0Q_wX194%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -1179,7 +1265,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:43:52 GMT
+      - Sun, 21 Oct 2018 16:27:44 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1190,9 +1276,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:43:52 GMT
+      - Sun, 21 Oct 2018 16:27:44 GMT
       Date:
-      - Thu, 18 Oct 2018 11:43:52 GMT
+      - Sun, 21 Oct 2018 16:27:44 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1221,10 +1307,10 @@ http_interactions:
          "files": []
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:43:52 GMT
+  recorded_at: Sun, 21 Oct 2018 16:27:44 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1lzY4T_OCvmFN45ulC6kwyU6ypHRMr9ZkdoEQiQqr7UI?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"name":"Doc ABC"}'
@@ -1236,7 +1322,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:43:52 GMT
+      - Sun, 21 Oct 2018 16:27:44 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1253,7 +1339,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:43:53 GMT
+      - Sun, 21 Oct 2018 16:27:45 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1277,14 +1363,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U",
+         "id": "1lzY4T_OCvmFN45ulC6kwyU6ypHRMr9ZkdoEQiQqr7UI",
          "name": "Doc ABC",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h"
+          "1Vrmi82AaybnZY9_xdV3EZqJgj21L1FE_"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U&v=2&s=AMedNnoAAAAAW8iOGZuHTf8GGQO3qLesmkPBXjX7BKsz&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1lzY4T_OCvmFN45ulC6kwyU6ypHRMr9ZkdoEQiQqr7UI&v=2&s=AMedNnoAAAAAW8zFIbBNQsee_XVnuyz22P7pASjQvOXA&sz=s220",
          "thumbnailVersion": "2",
          "permissions": [
           {
@@ -1308,10 +1394,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:43:53 GMT
+  recorded_at: Sun, 21 Oct 2018 16:27:45 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U?addParents=1Rj5AwNfHfP0Op7_FkgWhRvfwZeOQYgR5&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h
+    uri: https://www.googleapis.com/drive/v3/files/1lzY4T_OCvmFN45ulC6kwyU6ypHRMr9ZkdoEQiQqr7UI?addParents=1gH5pBoEQWhAcaxo-ODBi9GRh0Q_wX194&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1Vrmi82AaybnZY9_xdV3EZqJgj21L1FE_
     body:
       encoding: UTF-8
       string: ''
@@ -1323,7 +1409,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:43:53 GMT
+      - Sun, 21 Oct 2018 16:27:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1340,7 +1426,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:43:53 GMT
+      - Sun, 21 Oct 2018 16:27:46 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1364,14 +1450,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U",
+         "id": "1lzY4T_OCvmFN45ulC6kwyU6ypHRMr9ZkdoEQiQqr7UI",
          "name": "Doc ABC",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1Rj5AwNfHfP0Op7_FkgWhRvfwZeOQYgR5"
+          "1gH5pBoEQWhAcaxo-ODBi9GRh0Q_wX194"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U&v=2&s=AMedNnoAAAAAW8iOGZuHTf8GGQO3qLesmkPBXjX7BKsz&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1lzY4T_OCvmFN45ulC6kwyU6ypHRMr9ZkdoEQiQqr7UI&v=2&s=AMedNnoAAAAAW8zFIo8Te3rL7dxvjdtIDcq25bgSHCbK&sz=s220",
          "thumbnailVersion": "2",
          "permissions": [
           {
@@ -1395,10 +1481,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:43:54 GMT
+  recorded_at: Sun, 21 Oct 2018 16:27:46 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/upload/drive/v3/files/1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U
+    uri: https://www.googleapis.com/upload/drive/v3/files/1lzY4T_OCvmFN45ulC6kwyU6ypHRMr9ZkdoEQiQqr7UI
     body:
       encoding: UTF-8
       string: ''
@@ -1410,7 +1496,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:43:54 GMT
+      - Sun, 21 Oct 2018 16:27:46 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       X-Goog-Upload-Protocol:
@@ -1429,22 +1515,22 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2UpaFu-D0HOIuyS1FFKLTaZs-Zrbu-tvakozKrCeOJg1kefrFA_Rx93KQa7wXvuwtXaZ2sEaDKK2RoBUbYef3GvowzRtcSEmhsxGNntvwoyROdArUwo
+      - AEnB2Upy7pSfDN0yngZvw-UXdSNrH60wqhweG4P46y_qPtMBnzpx7XjuqLDA6DqUPu0TtF9XV7_UNTbXsuoPFlkrBw5Bo_b6bybRXZ0K1A_YCeaoWHYERT4
       X-Goog-Upload-Status:
       - active
       X-Goog-Upload-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U?upload_id=AEnB2UpaFu-D0HOIuyS1FFKLTaZs-Zrbu-tvakozKrCeOJg1kefrFA_Rx93KQa7wXvuwtXaZ2sEaDKK2RoBUbYef3GvowzRtcSEmhsxGNntvwoyROdArUwo&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1lzY4T_OCvmFN45ulC6kwyU6ypHRMr9ZkdoEQiQqr7UI?upload_id=AEnB2Upy7pSfDN0yngZvw-UXdSNrH60wqhweG4P46y_qPtMBnzpx7XjuqLDA6DqUPu0TtF9XV7_UNTbXsuoPFlkrBw5Bo_b6bybRXZ0K1A_YCeaoWHYERT4&upload_protocol=resumable
       X-Goog-Upload-Control-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U?upload_id=AEnB2UpaFu-D0HOIuyS1FFKLTaZs-Zrbu-tvakozKrCeOJg1kefrFA_Rx93KQa7wXvuwtXaZ2sEaDKK2RoBUbYef3GvowzRtcSEmhsxGNntvwoyROdArUwo&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1lzY4T_OCvmFN45ulC6kwyU6ypHRMr9ZkdoEQiQqr7UI?upload_id=AEnB2Upy7pSfDN0yngZvw-UXdSNrH60wqhweG4P46y_qPtMBnzpx7XjuqLDA6DqUPu0TtF9XV7_UNTbXsuoPFlkrBw5Bo_b6bybRXZ0K1A_YCeaoWHYERT4&upload_protocol=resumable
       X-Goog-Upload-Chunk-Granularity:
       - '262144'
       X-Goog-Upload-Header-Vary:
       - Origin
       - X-Origin
       X-Goog-Upload-Header-X-Google-Backends:
-      - ioda22:4456
+      - ioft12:4366
       X-Goog-Upload-Header-X-Google-Session-Info:
-      - CKeBxoimHBoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqVARKBAXlhMjkuR2xzNkJtWFRwVl9ncldXZjBUdk5XTE9kN3EwdTRKUld3ZUxKYmoxSHcwMmpIei1MNTdZbzlfWXRHYjI2d1dMa3pUYmg3bWRBUThkMFRTRnZhdVUtVWVYMklTTHJfT1pGc3VBOXdrWmdDMDBQV0hrY3hhSDdtbUt0aG83YzAEOg0xL0lhblFma3d0NE1-
+      - CKeBxoimHBoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x3OUJ0QnhVUEU5MEwzbU9hM3k0MnN6Y1FYQW5JMmJSemlXQVFNVkVTcmJYdUNiUk9OelFqanlhYVgybW5EMzFjZVN0eDY4enEzaWFGbWJSZEJKTkN2STJzM1ctV3BiWmhTWDVvQkIyclRQeUI3TmlKZ2RkRGxQaVpldGJ3MAQ6DTEvSWFuUWZrd3Q0TX4
       X-Goog-Upload-Header-Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       X-Goog-Upload-Header-Pragma:
@@ -1452,11 +1538,11 @@ http_interactions:
       X-Goog-Upload-Header-Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       X-Goog-Upload-Header-Date:
-      - Thu, 18 Oct 2018 11:43:54 GMT
+      - Sun, 21 Oct 2018 16:27:46 GMT
       Content-Length:
       - '0'
       Date:
-      - Thu, 18 Oct 2018 11:43:54 GMT
+      - Sun, 21 Oct 2018 16:27:46 GMT
       Server:
       - UploadServer
       Content-Type:
@@ -1467,10 +1553,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:43:54 GMT
+  recorded_at: Sun, 21 Oct 2018 16:27:46 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/upload/drive/v3/files/1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U?upload_id=AEnB2UpaFu-D0HOIuyS1FFKLTaZs-Zrbu-tvakozKrCeOJg1kefrFA_Rx93KQa7wXvuwtXaZ2sEaDKK2RoBUbYef3GvowzRtcSEmhsxGNntvwoyROdArUwo&upload_protocol=resumable
+    uri: https://www.googleapis.com/upload/drive/v3/files/1lzY4T_OCvmFN45ulC6kwyU6ypHRMr9ZkdoEQiQqr7UI?upload_id=AEnB2Upy7pSfDN0yngZvw-UXdSNrH60wqhweG4P46y_qPtMBnzpx7XjuqLDA6DqUPu0TtF9XV7_UNTbXsuoPFlkrBw5Bo_b6bybRXZ0K1A_YCeaoWHYERT4&upload_protocol=resumable
     body:
       encoding: UTF-8
       string: new file content
@@ -1482,7 +1568,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:43:54 GMT
+      - Sun, 21 Oct 2018 16:27:46 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       X-Goog-Upload-Command:
@@ -1497,7 +1583,7 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2UpaFu-D0HOIuyS1FFKLTaZs-Zrbu-tvakozKrCeOJg1kefrFA_Rx93KQa7wXvuwtXaZ2sEaDKK2RoBUbYef3GvowzRtcSEmhsxGNntvwoyROdArUwo
+      - AEnB2Upy7pSfDN0yngZvw-UXdSNrH60wqhweG4P46y_qPtMBnzpx7XjuqLDA6DqUPu0TtF9XV7_UNTbXsuoPFlkrBw5Bo_b6bybRXZ0K1A_YCeaoWHYERT4
       X-Goog-Upload-Status:
       - final
       Vary:
@@ -1512,7 +1598,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:43:55 GMT
+      - Sun, 21 Oct 2018 16:27:47 GMT
       Content-Length:
       - '154'
       Server:
@@ -1524,15 +1610,15 @@ http_interactions:
       string: |
         {
          "kind": "drive#file",
-         "id": "1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U",
+         "id": "1lzY4T_OCvmFN45ulC6kwyU6ypHRMr9ZkdoEQiQqr7UI",
          "name": "Doc ABC",
          "mimeType": "application/vnd.google-apps.document"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:43:55 GMT
+  recorded_at: Sun, 21 Oct 2018 16:27:47 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1lzY4T_OCvmFN45ulC6kwyU6ypHRMr9ZkdoEQiQqr7UI?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1544,7 +1630,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:43:56 GMT
+      - Sun, 21 Oct 2018 16:27:47 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1555,9 +1641,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:43:56 GMT
+      - Sun, 21 Oct 2018 16:27:47 GMT
       Date:
-      - Thu, 18 Oct 2018 11:43:56 GMT
+      - Sun, 21 Oct 2018 16:27:47 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1583,14 +1669,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U",
+         "id": "1lzY4T_OCvmFN45ulC6kwyU6ypHRMr9ZkdoEQiQqr7UI",
          "name": "Doc ABC",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1Rj5AwNfHfP0Op7_FkgWhRvfwZeOQYgR5"
+          "1gH5pBoEQWhAcaxo-ODBi9GRh0Q_wX194"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U&v=2&s=AMedNnoAAAAAW8iOHHZ5G_wAh_5PEOqI2q2BFC_OPQWt&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1lzY4T_OCvmFN45ulC6kwyU6ypHRMr9ZkdoEQiQqr7UI&v=2&s=AMedNnoAAAAAW8zFI9WcLShNAr7iSo2WSPbVi_-NwoIW&sz=s220",
          "thumbnailVersion": "2",
          "permissions": [
           {
@@ -1614,10 +1700,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:43:56 GMT
+  recorded_at: Sun, 21 Oct 2018 16:27:47 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1lzY4T_OCvmFN45ulC6kwyU6ypHRMr9ZkdoEQiQqr7UI/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1629,7 +1715,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:43:56 GMT
+      - Sun, 21 Oct 2018 16:27:47 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1640,9 +1726,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 11:43:56 GMT
+      - Sun, 21 Oct 2018 16:27:47 GMT
       Date:
-      - Thu, 18 Oct 2018 11:43:56 GMT
+      - Sun, 21 Oct 2018 16:27:47 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1671,13 +1757,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "3",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T11:43:55.232Z"
+         "modifiedTime": "2018-10-21T16:27:46.914Z"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:43:56 GMT
+  recorded_at: Sun, 21 Oct 2018 16:27:47 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U&s=AMedNnoAAAAAW8iOHHZ5G_wAh_5PEOqI2q2BFC_OPQWt&sz=s350&v=2
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1lzY4T_OCvmFN45ulC6kwyU6ypHRMr9ZkdoEQiQqr7UI&s=AMedNnoAAAAAW8zFI9WcLShNAr7iSo2WSPbVi_-NwoIW&sz=s350&v=2
     body:
       encoding: UTF-8
       string: ''
@@ -1689,7 +1775,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:43:56 GMT
+      - Sun, 21 Oct 2018 16:27:47 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1720,7 +1806,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 18 Oct 2018 11:43:56 GMT
+      - Sun, 21 Oct 2018 16:27:48 GMT
       Server:
       - fife
       Content-Length:
@@ -1734,10 +1820,96 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:43:56 GMT
+  recorded_at: Sun, 21 Oct 2018 16:27:48 GMT
 - request:
-    method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1lzY4T_OCvmFN45ulC6kwyU6ypHRMr9ZkdoEQiQqr7UI/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"Doc ABC","parents":["1PrFBNG6OH9-5PJYqI4cmPQvP5qmvz0de"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:27:48 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:27:50 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "159lzsp-XZG0rOmBN_z406_-mQDOP4ly2hv4lSXpxq6Q",
+         "name": "Doc ABC",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1PrFBNG6OH9-5PJYqI4cmPQvP5qmvz0de"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:27:50 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/159lzsp-XZG0rOmBN_z406_-mQDOP4ly2hv4lSXpxq6Q?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1749,7 +1921,91 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 11:43:56 GMT
+      - Sun, 21 Oct 2018 16:27:50 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 21 Oct 2018 16:27:50 GMT
+      Date:
+      - Sun, 21 Oct 2018 16:27:50 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "159lzsp-XZG0rOmBN_z406_-mQDOP4ly2hv4lSXpxq6Q",
+         "name": "Doc ABC",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1PrFBNG6OH9-5PJYqI4cmPQvP5qmvz0de"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 21 Oct 2018 16:27:50 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1Vrmi82AaybnZY9_xdV3EZqJgj21L1FE_
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 21 Oct 2018 16:27:50 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1766,7 +2022,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 11:43:57 GMT
+      - Sun, 21 Oct 2018 16:27:50 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1778,5 +2034,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 11:43:57 GMT
+  recorded_at: Sun, 21 Oct 2018 16:27:51 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Force_Sync/User_can_force_sync_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/Force_Sync/User_can_force_sync_file.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,42 +21,39 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:40:14 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:44:21 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:14 GMT
+    http_version:
+  recorded_at: Thu, 18 Oct 2018 09:44:21 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -66,7 +63,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -78,49 +75,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:40:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:44:21 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:15 GMT
+    http_version:
+  recorded_at: Thu, 18 Oct 2018 09:44:21 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        21:40:15 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:44:21 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -129,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:40:15 GMT
+      - Thu, 18 Oct 2018 09:44:21 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -146,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:40:15 GMT
+      - Thu, 18 Oct 2018 09:44:21 GMT
       Vary:
       - Origin
       - X-Origin
@@ -163,28 +157,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1pruRnUm2XcnhIoMqvGx_3y9KNa4Spgbx",
-         "name": "Test @ 2018-03-18 21:40:15 UTC",
+         "id": "1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC",
+         "name": "Test @ 2018-10-18 09:44:21 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AEIi2L68pCuiUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:15 GMT
+    http_version:
+  recorded_at: Thu, 18 Oct 2018 09:44:22 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1pruRnUm2XcnhIoMqvGx_3y9KNa4Spgbx/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -196,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:40:15 GMT
+      - Thu, 18 Oct 2018 09:44:22 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -213,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:40:16 GMT
+      - Thu, 18 Oct 2018 09:44:22 GMT
       Vary:
       - Origin
       - X-Origin
@@ -230,8 +234,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -243,14 +246,14 @@ http_interactions:
          "type": "user",
          "role": "writer"
         }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:16 GMT
+    http_version:
+  recorded_at: Thu, 18 Oct 2018 09:44:23 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1pruRnUm2XcnhIoMqvGx_3y9KNa4Spgbx"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -259,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:40:17 GMT
+      - Thu, 18 Oct 2018 09:44:23 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -276,7 +279,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:40:17 GMT
+      - Thu, 18 Oct 2018 09:44:23 GMT
       Vary:
       - Origin
       - X-Origin
@@ -293,31 +296,50 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1XbOVqwrCcSiOflilegxSkyDKja9pb_cd",
+         "id": "1XE_AzwZoCOOOvOnauIkIvaPex2Nnu8HH",
          "name": "Folder",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1pruRnUm2XcnhIoMqvGx_3y9KNa4Spgbx"
+          "1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:17 GMT
+    http_version:
+  recorded_at: Thu, 18 Oct 2018 09:44:23 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"Doc XYZ","parents":["1pruRnUm2XcnhIoMqvGx_3y9KNa4Spgbx"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Doc XYZ","parents":["1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -326,7 +348,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:40:17 GMT
+      - Thu, 18 Oct 2018 09:44:23 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -343,7 +365,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:40:18 GMT
+      - Thu, 18 Oct 2018 09:44:25 GMT
       Vary:
       - Origin
       - X-Origin
@@ -360,28 +382,47 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1NAXL8wEfGuT4TgKQJRASPRV69-J0PvQJzxPL_NnrEfc",
+         "id": "1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60",
          "name": "Doc XYZ",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1pruRnUm2XcnhIoMqvGx_3y9KNa4Spgbx"
+          "1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:19 GMT
+    http_version:
+  recorded_at: Thu, 18 Oct 2018 09:44:25 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1pruRnUm2XcnhIoMqvGx_3y9KNa4Spgbx?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -393,7 +434,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:40:19 GMT
+      - Thu, 18 Oct 2018 09:44:25 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -404,9 +445,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:40:19 GMT
+      - Thu, 18 Oct 2018 09:44:25 GMT
       Date:
-      - Sun, 18 Mar 2018 21:40:19 GMT
+      - Thu, 18 Oct 2018 09:44:25 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -425,25 +466,44 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1pruRnUm2XcnhIoMqvGx_3y9KNa4Spgbx",
-         "name": "Test @ 2018-03-18 21:40:15 UTC",
+         "id": "1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC",
+         "name": "Test @ 2018-10-18 09:44:21 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:19 GMT
+    http_version:
+  recorded_at: Thu, 18 Oct 2018 09:44:25 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1pruRnUm2XcnhIoMqvGx_3y9KNa4Spgbx/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -455,7 +515,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:40:19 GMT
+      - Thu, 18 Oct 2018 09:44:25 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -473,9 +533,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:40:19 GMT
+      - Thu, 18 Oct 2018 09:44:25 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:40:19 GMT
+      - Thu, 18 Oct 2018 09:44:25 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -487,8 +547,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -507,11 +566,11 @@ http_interactions:
           "message": "The file does not support revisions."
          }
         }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:19 GMT
+    http_version:
+  recorded_at: Thu, 18 Oct 2018 09:44:25 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271pruRnUm2XcnhIoMqvGx_3y9KNa4Spgbx%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -523,7 +582,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:40:19 GMT
+      - Thu, 18 Oct 2018 09:44:25 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -534,9 +593,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:40:19 GMT
+      - Thu, 18 Oct 2018 09:44:25 GMT
       Date:
-      - Sun, 18 Mar 2018 21:40:19 GMT
+      - Thu, 18 Oct 2018 09:44:25 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -555,8 +614,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -565,32 +623,72 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1NAXL8wEfGuT4TgKQJRASPRV69-J0PvQJzxPL_NnrEfc",
+           "id": "1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60",
            "name": "Doc XYZ",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1pruRnUm2XcnhIoMqvGx_3y9KNa4Spgbx"
+            "1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC"
            ],
-           "thumbnailVersion": "0"
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "writer",
+             "displayName": "Upshift One",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "13193959451567607887",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+             "role": "owner",
+             "displayName": "Testuser Upshift One",
+             "deleted": false
+            }
+           ]
           },
           {
-           "id": "1XbOVqwrCcSiOflilegxSkyDKja9pb_cd",
+           "id": "1XE_AzwZoCOOOvOnauIkIvaPex2Nnu8HH",
            "name": "Folder",
            "mimeType": "application/vnd.google-apps.folder",
            "trashed": false,
            "parents": [
-            "1pruRnUm2XcnhIoMqvGx_3y9KNa4Spgbx"
+            "1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC"
            ],
-           "thumbnailVersion": "0"
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "writer",
+             "displayName": "Upshift One",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "13193959451567607887",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+             "role": "owner",
+             "displayName": "Testuser Upshift One",
+             "deleted": false
+            }
+           ]
           }
          ]
         }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:19 GMT
+    http_version:
+  recorded_at: Thu, 18 Oct 2018 09:44:25 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1NAXL8wEfGuT4TgKQJRASPRV69-J0PvQJzxPL_NnrEfc/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -602,145 +700,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:40:19 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sun, 18 Mar 2018 21:40:19 GMT
-      Expires:
-      - Sun, 18 Mar 2018 21:40:19 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "notFound",
-            "message": "Revision not found: head.",
-            "locationType": "parameter",
-            "location": "revisionId"
-           }
-          ],
-          "code": 404,
-          "message": "Revision not found: head."
-         }
-        }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:20 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1XbOVqwrCcSiOflilegxSkyDKja9pb_cd/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sun, 18 Mar 2018 21:40:20 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sun, 18 Mar 2018 21:40:20 GMT
-      Expires:
-      - Sun, 18 Mar 2018 21:40:20 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:20 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271XbOVqwrCcSiOflilegxSkyDKja9pb_cd%27%20in%20parents
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sun, 18 Mar 2018 21:40:20 GMT
+      - Thu, 18 Oct 2018 09:44:25 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -751,9 +711,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:40:20 GMT
+      - Thu, 18 Oct 2018 09:44:26 GMT
       Date:
-      - Sun, 18 Mar 2018 21:40:20 GMT
+      - Thu, 18 Oct 2018 09:44:26 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -772,8 +732,134 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-18T09:44:24.257Z"
+        }
+    http_version:
+  recorded_at: Thu, 18 Oct 2018 09:44:26 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1XE_AzwZoCOOOvOnauIkIvaPex2Nnu8HH/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 09:44:26 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 09:44:26 GMT
+      Expires:
+      - Thu, 18 Oct 2018 09:44:26 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version:
+  recorded_at: Thu, 18 Oct 2018 09:44:26 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271XE_AzwZoCOOOvOnauIkIvaPex2Nnu8HH%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 09:44:26 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 09:44:26 GMT
+      Date:
+      - Thu, 18 Oct 2018 09:44:26 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -782,11 +868,11 @@ http_interactions:
         {
          "files": []
         }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:20 GMT
+    http_version:
+  recorded_at: Thu, 18 Oct 2018 09:44:26 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1NAXL8wEfGuT4TgKQJRASPRV69-J0PvQJzxPL_NnrEfc?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"name":"Doc ABC"}'
@@ -798,7 +884,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:40:20 GMT
+      - Thu, 18 Oct 2018 09:44:26 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -815,7 +901,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:40:21 GMT
+      - Thu, 18 Oct 2018 09:44:26 GMT
       Vary:
       - Origin
       - X-Origin
@@ -832,28 +918,48 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1NAXL8wEfGuT4TgKQJRASPRV69-J0PvQJzxPL_NnrEfc",
+         "id": "1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60",
          "name": "Doc ABC",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1pruRnUm2XcnhIoMqvGx_3y9KNa4Spgbx"
+          "1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60&v=2&s=AMedNnoAAAAAW8hyGoZwOYkhxCb-7Kg6YET58pclIXEs&sz=s220",
+         "thumbnailVersion": "2",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:21 GMT
+    http_version:
+  recorded_at: Thu, 18 Oct 2018 09:44:27 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1NAXL8wEfGuT4TgKQJRASPRV69-J0PvQJzxPL_NnrEfc?addParents=1XbOVqwrCcSiOflilegxSkyDKja9pb_cd&fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion&removeParents=1pruRnUm2XcnhIoMqvGx_3y9KNa4Spgbx
+    uri: https://www.googleapis.com/drive/v3/files/1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60?addParents=1XE_AzwZoCOOOvOnauIkIvaPex2Nnu8HH&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC
     body:
       encoding: UTF-8
       string: ''
@@ -865,7 +971,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:40:21 GMT
+      - Thu, 18 Oct 2018 09:44:27 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -882,7 +988,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:40:22 GMT
+      - Thu, 18 Oct 2018 09:44:27 GMT
       Vary:
       - Origin
       - X-Origin
@@ -899,28 +1005,48 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1NAXL8wEfGuT4TgKQJRASPRV69-J0PvQJzxPL_NnrEfc",
+         "id": "1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60",
          "name": "Doc ABC",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1XbOVqwrCcSiOflilegxSkyDKja9pb_cd"
+          "1XE_AzwZoCOOOvOnauIkIvaPex2Nnu8HH"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60&v=2&s=AMedNnoAAAAAW8hyG_TIbXtZloWk23G-o3Hc4NX6tGty&sz=s220",
+         "thumbnailVersion": "2",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:22 GMT
+    http_version:
+  recorded_at: Thu, 18 Oct 2018 09:44:27 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/upload/drive/v3/files/1NAXL8wEfGuT4TgKQJRASPRV69-J0PvQJzxPL_NnrEfc
+    uri: https://www.googleapis.com/upload/drive/v3/files/1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60
     body:
       encoding: UTF-8
       string: ''
@@ -932,7 +1058,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:40:22 GMT
+      - Thu, 18 Oct 2018 09:44:27 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       X-Goog-Upload-Protocol:
@@ -951,22 +1077,22 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2Uoxal6NHXGgWd8Kz82Y7NmLFHd7D0LBNvcofbZ1xfdLHLY1aVihFKzHZhi0RuBIHfjht2DMg9SiRGv0Fc4u-jY8ZPtZRg
+      - AEnB2Up8pnk4CCaofHXI7w_wchDz1oZozu8BFEK4B4ovH6zaNYoVYiMMUe3RidNrgXz63AHSJ4jWJhnbi9GbV0X_dmD25L79Iw
       X-Goog-Upload-Status:
       - active
       X-Goog-Upload-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1NAXL8wEfGuT4TgKQJRASPRV69-J0PvQJzxPL_NnrEfc?upload_id=AEnB2Uoxal6NHXGgWd8Kz82Y7NmLFHd7D0LBNvcofbZ1xfdLHLY1aVihFKzHZhi0RuBIHfjht2DMg9SiRGv0Fc4u-jY8ZPtZRg&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60?upload_id=AEnB2Up8pnk4CCaofHXI7w_wchDz1oZozu8BFEK4B4ovH6zaNYoVYiMMUe3RidNrgXz63AHSJ4jWJhnbi9GbV0X_dmD25L79Iw&upload_protocol=resumable
       X-Goog-Upload-Control-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1NAXL8wEfGuT4TgKQJRASPRV69-J0PvQJzxPL_NnrEfc?upload_id=AEnB2Uoxal6NHXGgWd8Kz82Y7NmLFHd7D0LBNvcofbZ1xfdLHLY1aVihFKzHZhi0RuBIHfjht2DMg9SiRGv0Fc4u-jY8ZPtZRg&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60?upload_id=AEnB2Up8pnk4CCaofHXI7w_wchDz1oZozu8BFEK4B4ovH6zaNYoVYiMMUe3RidNrgXz63AHSJ4jWJhnbi9GbV0X_dmD25L79Iw&upload_protocol=resumable
       X-Goog-Upload-Chunk-Granularity:
       - '262144'
       X-Goog-Upload-Header-Vary:
       - Origin
       - X-Origin
       X-Goog-Upload-Header-X-Google-Backends:
-      - iofw139:4735
+      - iofd78:4499
       X-Goog-Upload-Header-X-Google-Session-Info:
-      - CKeBxoimHBoCGAY6bwoPZHJpdmUtcm9zeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqYARKEAXlhMjkuR2wyQ0JRcUlfNlBTbWNPUDFGN29EdmxIa0o2TW9jV2FDRElzWGlDTFc1dUFSNmhZWHNsUTdpU1dKX0NRWGpPS2dNVDJQMTl3YndEb1AzY0FhbThuYnVoMkVzUmNacFAxUVVmSGhoQWhuMWc2LXpPSWkxb2ZqdVJUdDBoM1ZYSTAEOg0xL1N4M0NoLWFKdTJ-
+      - CKeBxoimHBoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqVARKBAXlhMjkuR2xzNkJwX1JIVHN3Y3ZCRFltN28zbWxyUDNuUXVSWXM4WmxycVpLSl9LUW82U1I5bGlpOXRVTVJBQW9lZG1NaDFDNFRqTTBaUmJtM3lOLUFKMXFfMTRDeF9XaUhGRHBhbHV0aFd5NG1iQ0k2cllXQ2p0NVNCTUd2cWVxejAEOg0xL0lhblFma3d0NE1-
       X-Goog-Upload-Header-Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       X-Goog-Upload-Header-Pragma:
@@ -974,26 +1100,25 @@ http_interactions:
       X-Goog-Upload-Header-Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       X-Goog-Upload-Header-Date:
-      - Sun, 18 Mar 2018 21:40:22 GMT
+      - Thu, 18 Oct 2018 09:44:27 GMT
       Content-Length:
       - '0'
       Date:
-      - Sun, 18 Mar 2018 21:40:22 GMT
+      - Thu, 18 Oct 2018 09:44:27 GMT
       Server:
       - UploadServer
       Content-Type:
       - text/html; charset=UTF-8
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:22 GMT
+    http_version:
+  recorded_at: Thu, 18 Oct 2018 09:44:28 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/upload/drive/v3/files/1NAXL8wEfGuT4TgKQJRASPRV69-J0PvQJzxPL_NnrEfc?upload_id=AEnB2Uoxal6NHXGgWd8Kz82Y7NmLFHd7D0LBNvcofbZ1xfdLHLY1aVihFKzHZhi0RuBIHfjht2DMg9SiRGv0Fc4u-jY8ZPtZRg&upload_protocol=resumable
+    uri: https://www.googleapis.com/upload/drive/v3/files/1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60?upload_id=AEnB2Up8pnk4CCaofHXI7w_wchDz1oZozu8BFEK4B4ovH6zaNYoVYiMMUe3RidNrgXz63AHSJ4jWJhnbi9GbV0X_dmD25L79Iw&upload_protocol=resumable
     body:
       encoding: UTF-8
       string: new file content
@@ -1005,7 +1130,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:40:22 GMT
+      - Thu, 18 Oct 2018 09:44:28 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       X-Goog-Upload-Command:
@@ -1020,7 +1145,7 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2Uoxal6NHXGgWd8Kz82Y7NmLFHd7D0LBNvcofbZ1xfdLHLY1aVihFKzHZhi0RuBIHfjht2DMg9SiRGv0Fc4u-jY8ZPtZRg
+      - AEnB2Up8pnk4CCaofHXI7w_wchDz1oZozu8BFEK4B4ovH6zaNYoVYiMMUe3RidNrgXz63AHSJ4jWJhnbi9GbV0X_dmD25L79Iw
       X-Goog-Upload-Status:
       - final
       Vary:
@@ -1035,28 +1160,27 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:40:23 GMT
+      - Thu, 18 Oct 2018 09:44:28 GMT
       Content-Length:
       - '154'
       Server:
       - UploadServer
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: |
         {
          "kind": "drive#file",
-         "id": "1NAXL8wEfGuT4TgKQJRASPRV69-J0PvQJzxPL_NnrEfc",
+         "id": "1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60",
          "name": "Doc ABC",
          "mimeType": "application/vnd.google-apps.document"
         }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:23 GMT
+    http_version:
+  recorded_at: Thu, 18 Oct 2018 09:44:28 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1NAXL8wEfGuT4TgKQJRASPRV69-J0PvQJzxPL_NnrEfc?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1068,7 +1192,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:40:23 GMT
+      - Thu, 18 Oct 2018 09:44:29 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1079,9 +1203,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:40:23 GMT
+      - Thu, 18 Oct 2018 09:44:29 GMT
       Date:
-      - Sun, 18 Mar 2018 21:40:23 GMT
+      - Thu, 18 Oct 2018 09:44:29 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1100,29 +1224,48 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1NAXL8wEfGuT4TgKQJRASPRV69-J0PvQJzxPL_NnrEfc",
+         "id": "1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60",
          "name": "Doc ABC",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1XbOVqwrCcSiOflilegxSkyDKja9pb_cd"
+          "1XE_AzwZoCOOOvOnauIkIvaPex2Nnu8HH"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1NAXL8wEfGuT4TgKQJRASPRV69-J0PvQJzxPL_NnrEfc&v=1&s=AMedNnoAAAAAWq7450w72QfcjDaZm9IcyBbGScEH1SJH&sz=s220",
-         "thumbnailVersion": "1"
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60&v=2&s=AMedNnoAAAAAW8hyHWBo3osYCQqxBGIj_Lu2dmuwE4SR&sz=s220",
+         "thumbnailVersion": "2",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:23 GMT
+    http_version:
+  recorded_at: Thu, 18 Oct 2018 09:44:29 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1NAXL8wEfGuT4TgKQJRASPRV69-J0PvQJzxPL_NnrEfc/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1134,7 +1277,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:40:23 GMT
+      - Thu, 18 Oct 2018 09:44:29 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1145,9 +1288,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:40:23 GMT
+      - Thu, 18 Oct 2018 09:44:29 GMT
       Date:
-      - Sun, 18 Mar 2018 21:40:23 GMT
+      - Thu, 18 Oct 2018 09:44:29 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1166,8 +1309,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -1177,13 +1319,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "3",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-03-18T21:40:22.949Z"
+         "modifiedTime": "2018-10-18T09:44:28.395Z"
         }
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:23 GMT
+    http_version:
+  recorded_at: Thu, 18 Oct 2018 09:44:29 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1NAXL8wEfGuT4TgKQJRASPRV69-J0PvQJzxPL_NnrEfc&s=AMedNnoAAAAAWq7450w72QfcjDaZm9IcyBbGScEH1SJH&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60&s=AMedNnoAAAAAW8hyHWBo3osYCQqxBGIj_Lu2dmuwE4SR&sz=s350&v=2
     body:
       encoding: UTF-8
       string: ''
@@ -1195,7 +1337,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:40:23 GMT
+      - Thu, 18 Oct 2018 09:44:29 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1208,7 +1350,7 @@ http_interactions:
       Access-Control-Expose-Headers:
       - Content-Length
       Etag:
-      - '"v1"'
+      - '"v2"'
       Expires:
       - Fri, 01 Jan 1990 00:00:00 GMT
       Cache-Control:
@@ -1226,7 +1368,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Sun, 18 Mar 2018 21:40:24 GMT
+      - Thu, 18 Oct 2018 09:44:29 GMT
       Server:
       - fife
       Content-Length:
@@ -1234,17 +1376,16 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:24 GMT
+    http_version:
+  recorded_at: Thu, 18 Oct 2018 09:44:29 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1pruRnUm2XcnhIoMqvGx_3y9KNa4Spgbx
+    uri: https://www.googleapis.com/drive/v3/files/1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC
     body:
       encoding: UTF-8
       string: ''
@@ -1256,7 +1397,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:40:24 GMT
+      - Thu, 18 Oct 2018 09:44:29 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1273,18 +1414,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:40:25 GMT
+      - Thu, 18 Oct 2018 09:44:30 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:25 GMT
+    http_version:
+  recorded_at: Thu, 18 Oct 2018 09:44:30 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Force_Sync/User_can_force_sync_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/Force_Sync/User_can_force_sync_file.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:44:21 GMT
+      - Thu, 18 Oct 2018 11:43:44 GMT
       Server:
       - ESF
       Cache-Control:
@@ -52,8 +52,8 @@ http_interactions:
           "scope": "https://www.googleapis.com/auth/drive",
           "token_type": "Bearer"
         }
-    http_version:
-  recorded_at: Thu, 18 Oct 2018 09:44:21 GMT
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:43:44 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:44:21 GMT
+      - Thu, 18 Oct 2018 11:43:44 GMT
       Server:
       - ESF
       Cache-Control:
@@ -106,15 +106,15 @@ http_interactions:
           "scope": "https://www.googleapis.com/auth/drive",
           "token_type": "Bearer"
         }
-    http_version:
-  recorded_at: Thu, 18 Oct 2018 09:44:21 GMT
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:43:44 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        09:44:21 UTC","parents":["root"]}'
+        11:43:44 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:21 GMT
+      - Thu, 18 Oct 2018 11:43:44 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:44:21 GMT
+      - Thu, 18 Oct 2018 11:43:45 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC",
-         "name": "Test @ 2018-10-18 09:44:21 UTC",
+         "id": "1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h",
+         "name": "Test @ 2018-10-18 11:43:44 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -184,11 +184,11 @@ http_interactions:
           }
          ]
         }
-    http_version:
-  recorded_at: Thu, 18 Oct 2018 09:44:22 GMT
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:43:45 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:22 GMT
+      - Thu, 18 Oct 2018 11:43:45 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:44:22 GMT
+      - Thu, 18 Oct 2018 11:43:46 GMT
       Vary:
       - Origin
       - X-Origin
@@ -246,14 +246,14 @@ http_interactions:
          "type": "user",
          "role": "writer"
         }
-    http_version:
-  recorded_at: Thu, 18 Oct 2018 09:44:23 GMT
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:43:46 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:23 GMT
+      - Thu, 18 Oct 2018 11:43:46 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -279,7 +279,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:44:23 GMT
+      - Thu, 18 Oct 2018 11:43:47 GMT
       Vary:
       - Origin
       - X-Origin
@@ -303,12 +303,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1XE_AzwZoCOOOvOnauIkIvaPex2Nnu8HH",
+         "id": "1Rj5AwNfHfP0Op7_FkgWhRvfwZeOQYgR5",
          "name": "Folder",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC"
+          "1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -332,14 +332,14 @@ http_interactions:
           }
          ]
         }
-    http_version:
-  recorded_at: Thu, 18 Oct 2018 09:44:23 GMT
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:43:47 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"Doc XYZ","parents":["1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Doc XYZ","parents":["1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -348,7 +348,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:23 GMT
+      - Thu, 18 Oct 2018 11:43:47 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -365,7 +365,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:44:25 GMT
+      - Thu, 18 Oct 2018 11:43:48 GMT
       Vary:
       - Origin
       - X-Origin
@@ -389,12 +389,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60",
+         "id": "1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U",
          "name": "Doc XYZ",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC"
+          "1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -418,11 +418,151 @@ http_interactions:
           }
          ]
         }
-    http_version:
-  recorded_at: Thu, 18 Oct 2018 09:44:25 GMT
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:43:48 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"26 Billion
+        Year Bunker (Archive)","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:43:48 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:43:49 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1PuuvNUqUpPWpysi1XI4GWfdXusQMGxVw",
+         "name": "26 Billion Year Bunker (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:43:49 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1PuuvNUqUpPWpysi1XI4GWfdXusQMGxVw/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:43:49 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:43:50 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "13193959451567607887",
+         "type": "user",
+         "role": "reader"
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:43:50 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1PuuvNUqUpPWpysi1XI4GWfdXusQMGxVw?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -434,7 +574,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:25 GMT
+      - Thu, 18 Oct 2018 11:43:50 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -445,9 +585,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:44:25 GMT
+      - Thu, 18 Oct 2018 11:43:50 GMT
       Date:
-      - Thu, 18 Oct 2018 09:44:25 GMT
+      - Thu, 18 Oct 2018 11:43:50 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -473,37 +613,40 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC",
-         "name": "Test @ 2018-10-18 09:44:21 UTC",
+         "id": "1PuuvNUqUpPWpysi1XI4GWfdXusQMGxVw",
+         "name": "26 Billion Year Bunker (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
          "thumbnailVersion": "0",
          "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
           {
            "kind": "drive#permission",
            "id": "13193959451567607887",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
+           "role": "reader",
            "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
            "deleted": false
           }
          ]
         }
-    http_version:
-  recorded_at: Thu, 18 Oct 2018 09:44:25 GMT
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:43:50 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1PuuvNUqUpPWpysi1XI4GWfdXusQMGxVw/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -515,7 +658,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:25 GMT
+      - Thu, 18 Oct 2018 11:43:50 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -533,9 +676,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:44:25 GMT
+      - Thu, 18 Oct 2018 11:43:50 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:44:25 GMT
+      - Thu, 18 Oct 2018 11:43:50 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -566,11 +709,11 @@ http_interactions:
           "message": "The file does not support revisions."
          }
         }
-    http_version:
-  recorded_at: Thu, 18 Oct 2018 09:44:25 GMT
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:43:50 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files/1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -582,7 +725,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:25 GMT
+      - Thu, 18 Oct 2018 11:43:50 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -593,9 +736,157 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:44:25 GMT
+      - Thu, 18 Oct 2018 11:43:50 GMT
       Date:
-      - Thu, 18 Oct 2018 09:44:25 GMT
+      - Thu, 18 Oct 2018 11:43:50 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h",
+         "name": "Test @ 2018-10-18 11:43:44 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:43:50 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:43:50 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 11:43:51 GMT
+      Expires:
+      - Thu, 18 Oct 2018 11:43:51 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:43:51 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:43:51 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 11:43:51 GMT
+      Date:
+      - Thu, 18 Oct 2018 11:43:51 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -623,14 +914,15 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60",
+           "id": "1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U",
            "name": "Doc XYZ",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC"
+            "1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h"
            ],
-           "thumbnailVersion": "0",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U&v=1&s=AMedNnoAAAAAW8iOF7cKGzvYUB_71KuzlxXmlfHdzyTV&sz=s220",
+           "thumbnailVersion": "1",
            "permissions": [
             {
              "kind": "drive#permission",
@@ -653,12 +945,12 @@ http_interactions:
            ]
           },
           {
-           "id": "1XE_AzwZoCOOOvOnauIkIvaPex2Nnu8HH",
+           "id": "1Rj5AwNfHfP0Op7_FkgWhRvfwZeOQYgR5",
            "name": "Folder",
            "mimeType": "application/vnd.google-apps.folder",
            "trashed": false,
            "parents": [
-            "1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC"
+            "1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -684,11 +976,11 @@ http_interactions:
           }
          ]
         }
-    http_version:
-  recorded_at: Thu, 18 Oct 2018 09:44:25 GMT
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:43:51 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -700,7 +992,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:25 GMT
+      - Thu, 18 Oct 2018 11:43:51 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -711,9 +1003,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:44:26 GMT
+      - Thu, 18 Oct 2018 11:43:51 GMT
       Date:
-      - Thu, 18 Oct 2018 09:44:26 GMT
+      - Thu, 18 Oct 2018 11:43:51 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -742,13 +1034,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T09:44:24.257Z"
+         "modifiedTime": "2018-10-18T11:43:48.002Z"
         }
-    http_version:
-  recorded_at: Thu, 18 Oct 2018 09:44:26 GMT
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:43:51 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1XE_AzwZoCOOOvOnauIkIvaPex2Nnu8HH/revisions/head
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U&s=AMedNnoAAAAAW8iOF7cKGzvYUB_71KuzlxXmlfHdzyTV&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -760,7 +1052,67 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:26 GMT
+      - Thu, 18 Oct 2018 11:43:51 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Thu, 18 Oct 2018 11:43:52 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:43:52 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1Rj5AwNfHfP0Op7_FkgWhRvfwZeOQYgR5/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 11:43:52 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -778,9 +1130,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:44:26 GMT
+      - Thu, 18 Oct 2018 11:43:52 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:44:26 GMT
+      - Thu, 18 Oct 2018 11:43:52 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -811,11 +1163,11 @@ http_interactions:
           "message": "The file does not support revisions."
          }
         }
-    http_version:
-  recorded_at: Thu, 18 Oct 2018 09:44:26 GMT
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:43:52 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271XE_AzwZoCOOOvOnauIkIvaPex2Nnu8HH%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271Rj5AwNfHfP0Op7_FkgWhRvfwZeOQYgR5%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -827,7 +1179,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:26 GMT
+      - Thu, 18 Oct 2018 11:43:52 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -838,9 +1190,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:44:26 GMT
+      - Thu, 18 Oct 2018 11:43:52 GMT
       Date:
-      - Thu, 18 Oct 2018 09:44:26 GMT
+      - Thu, 18 Oct 2018 11:43:52 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -868,11 +1220,11 @@ http_interactions:
         {
          "files": []
         }
-    http_version:
-  recorded_at: Thu, 18 Oct 2018 09:44:26 GMT
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:43:52 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"name":"Doc ABC"}'
@@ -884,7 +1236,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:26 GMT
+      - Thu, 18 Oct 2018 11:43:52 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -901,7 +1253,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:44:26 GMT
+      - Thu, 18 Oct 2018 11:43:53 GMT
       Vary:
       - Origin
       - X-Origin
@@ -925,14 +1277,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60",
+         "id": "1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U",
          "name": "Doc ABC",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC"
+          "1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60&v=2&s=AMedNnoAAAAAW8hyGoZwOYkhxCb-7Kg6YET58pclIXEs&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U&v=2&s=AMedNnoAAAAAW8iOGZuHTf8GGQO3qLesmkPBXjX7BKsz&sz=s220",
          "thumbnailVersion": "2",
          "permissions": [
           {
@@ -955,11 +1307,11 @@ http_interactions:
           }
          ]
         }
-    http_version:
-  recorded_at: Thu, 18 Oct 2018 09:44:27 GMT
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:43:53 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60?addParents=1XE_AzwZoCOOOvOnauIkIvaPex2Nnu8HH&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC
+    uri: https://www.googleapis.com/drive/v3/files/1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U?addParents=1Rj5AwNfHfP0Op7_FkgWhRvfwZeOQYgR5&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h
     body:
       encoding: UTF-8
       string: ''
@@ -971,7 +1323,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:27 GMT
+      - Thu, 18 Oct 2018 11:43:53 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -988,7 +1340,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:44:27 GMT
+      - Thu, 18 Oct 2018 11:43:53 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1012,14 +1364,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60",
+         "id": "1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U",
          "name": "Doc ABC",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1XE_AzwZoCOOOvOnauIkIvaPex2Nnu8HH"
+          "1Rj5AwNfHfP0Op7_FkgWhRvfwZeOQYgR5"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60&v=2&s=AMedNnoAAAAAW8hyG_TIbXtZloWk23G-o3Hc4NX6tGty&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U&v=2&s=AMedNnoAAAAAW8iOGZuHTf8GGQO3qLesmkPBXjX7BKsz&sz=s220",
          "thumbnailVersion": "2",
          "permissions": [
           {
@@ -1042,11 +1394,11 @@ http_interactions:
           }
          ]
         }
-    http_version:
-  recorded_at: Thu, 18 Oct 2018 09:44:27 GMT
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:43:54 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/upload/drive/v3/files/1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60
+    uri: https://www.googleapis.com/upload/drive/v3/files/1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U
     body:
       encoding: UTF-8
       string: ''
@@ -1058,7 +1410,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:27 GMT
+      - Thu, 18 Oct 2018 11:43:54 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       X-Goog-Upload-Protocol:
@@ -1077,22 +1429,22 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2Up8pnk4CCaofHXI7w_wchDz1oZozu8BFEK4B4ovH6zaNYoVYiMMUe3RidNrgXz63AHSJ4jWJhnbi9GbV0X_dmD25L79Iw
+      - AEnB2UpaFu-D0HOIuyS1FFKLTaZs-Zrbu-tvakozKrCeOJg1kefrFA_Rx93KQa7wXvuwtXaZ2sEaDKK2RoBUbYef3GvowzRtcSEmhsxGNntvwoyROdArUwo
       X-Goog-Upload-Status:
       - active
       X-Goog-Upload-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60?upload_id=AEnB2Up8pnk4CCaofHXI7w_wchDz1oZozu8BFEK4B4ovH6zaNYoVYiMMUe3RidNrgXz63AHSJ4jWJhnbi9GbV0X_dmD25L79Iw&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U?upload_id=AEnB2UpaFu-D0HOIuyS1FFKLTaZs-Zrbu-tvakozKrCeOJg1kefrFA_Rx93KQa7wXvuwtXaZ2sEaDKK2RoBUbYef3GvowzRtcSEmhsxGNntvwoyROdArUwo&upload_protocol=resumable
       X-Goog-Upload-Control-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60?upload_id=AEnB2Up8pnk4CCaofHXI7w_wchDz1oZozu8BFEK4B4ovH6zaNYoVYiMMUe3RidNrgXz63AHSJ4jWJhnbi9GbV0X_dmD25L79Iw&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U?upload_id=AEnB2UpaFu-D0HOIuyS1FFKLTaZs-Zrbu-tvakozKrCeOJg1kefrFA_Rx93KQa7wXvuwtXaZ2sEaDKK2RoBUbYef3GvowzRtcSEmhsxGNntvwoyROdArUwo&upload_protocol=resumable
       X-Goog-Upload-Chunk-Granularity:
       - '262144'
       X-Goog-Upload-Header-Vary:
       - Origin
       - X-Origin
       X-Goog-Upload-Header-X-Google-Backends:
-      - iofd78:4499
+      - ioda22:4456
       X-Goog-Upload-Header-X-Google-Session-Info:
-      - CKeBxoimHBoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqVARKBAXlhMjkuR2xzNkJwX1JIVHN3Y3ZCRFltN28zbWxyUDNuUXVSWXM4WmxycVpLSl9LUW82U1I5bGlpOXRVTVJBQW9lZG1NaDFDNFRqTTBaUmJtM3lOLUFKMXFfMTRDeF9XaUhGRHBhbHV0aFd5NG1iQ0k2cllXQ2p0NVNCTUd2cWVxejAEOg0xL0lhblFma3d0NE1-
+      - CKeBxoimHBoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqVARKBAXlhMjkuR2xzNkJtWFRwVl9ncldXZjBUdk5XTE9kN3EwdTRKUld3ZUxKYmoxSHcwMmpIei1MNTdZbzlfWXRHYjI2d1dMa3pUYmg3bWRBUThkMFRTRnZhdVUtVWVYMklTTHJfT1pGc3VBOXdrWmdDMDBQV0hrY3hhSDdtbUt0aG83YzAEOg0xL0lhblFma3d0NE1-
       X-Goog-Upload-Header-Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       X-Goog-Upload-Header-Pragma:
@@ -1100,11 +1452,11 @@ http_interactions:
       X-Goog-Upload-Header-Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       X-Goog-Upload-Header-Date:
-      - Thu, 18 Oct 2018 09:44:27 GMT
+      - Thu, 18 Oct 2018 11:43:54 GMT
       Content-Length:
       - '0'
       Date:
-      - Thu, 18 Oct 2018 09:44:27 GMT
+      - Thu, 18 Oct 2018 11:43:54 GMT
       Server:
       - UploadServer
       Content-Type:
@@ -1114,11 +1466,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Thu, 18 Oct 2018 09:44:28 GMT
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:43:54 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/upload/drive/v3/files/1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60?upload_id=AEnB2Up8pnk4CCaofHXI7w_wchDz1oZozu8BFEK4B4ovH6zaNYoVYiMMUe3RidNrgXz63AHSJ4jWJhnbi9GbV0X_dmD25L79Iw&upload_protocol=resumable
+    uri: https://www.googleapis.com/upload/drive/v3/files/1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U?upload_id=AEnB2UpaFu-D0HOIuyS1FFKLTaZs-Zrbu-tvakozKrCeOJg1kefrFA_Rx93KQa7wXvuwtXaZ2sEaDKK2RoBUbYef3GvowzRtcSEmhsxGNntvwoyROdArUwo&upload_protocol=resumable
     body:
       encoding: UTF-8
       string: new file content
@@ -1130,7 +1482,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:28 GMT
+      - Thu, 18 Oct 2018 11:43:54 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       X-Goog-Upload-Command:
@@ -1145,7 +1497,7 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2Up8pnk4CCaofHXI7w_wchDz1oZozu8BFEK4B4ovH6zaNYoVYiMMUe3RidNrgXz63AHSJ4jWJhnbi9GbV0X_dmD25L79Iw
+      - AEnB2UpaFu-D0HOIuyS1FFKLTaZs-Zrbu-tvakozKrCeOJg1kefrFA_Rx93KQa7wXvuwtXaZ2sEaDKK2RoBUbYef3GvowzRtcSEmhsxGNntvwoyROdArUwo
       X-Goog-Upload-Status:
       - final
       Vary:
@@ -1160,7 +1512,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:44:28 GMT
+      - Thu, 18 Oct 2018 11:43:55 GMT
       Content-Length:
       - '154'
       Server:
@@ -1172,15 +1524,15 @@ http_interactions:
       string: |
         {
          "kind": "drive#file",
-         "id": "1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60",
+         "id": "1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U",
          "name": "Doc ABC",
          "mimeType": "application/vnd.google-apps.document"
         }
-    http_version:
-  recorded_at: Thu, 18 Oct 2018 09:44:28 GMT
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:43:55 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1192,7 +1544,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:29 GMT
+      - Thu, 18 Oct 2018 11:43:56 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1203,9 +1555,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:44:29 GMT
+      - Thu, 18 Oct 2018 11:43:56 GMT
       Date:
-      - Thu, 18 Oct 2018 09:44:29 GMT
+      - Thu, 18 Oct 2018 11:43:56 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1231,14 +1583,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60",
+         "id": "1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U",
          "name": "Doc ABC",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1XE_AzwZoCOOOvOnauIkIvaPex2Nnu8HH"
+          "1Rj5AwNfHfP0Op7_FkgWhRvfwZeOQYgR5"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60&v=2&s=AMedNnoAAAAAW8hyHWBo3osYCQqxBGIj_Lu2dmuwE4SR&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U&v=2&s=AMedNnoAAAAAW8iOHHZ5G_wAh_5PEOqI2q2BFC_OPQWt&sz=s220",
          "thumbnailVersion": "2",
          "permissions": [
           {
@@ -1261,11 +1613,11 @@ http_interactions:
           }
          ]
         }
-    http_version:
-  recorded_at: Thu, 18 Oct 2018 09:44:29 GMT
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:43:56 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1277,7 +1629,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:29 GMT
+      - Thu, 18 Oct 2018 11:43:56 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1288,9 +1640,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:44:29 GMT
+      - Thu, 18 Oct 2018 11:43:56 GMT
       Date:
-      - Thu, 18 Oct 2018 09:44:29 GMT
+      - Thu, 18 Oct 2018 11:43:56 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1319,13 +1671,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "3",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-18T09:44:28.395Z"
+         "modifiedTime": "2018-10-18T11:43:55.232Z"
         }
-    http_version:
-  recorded_at: Thu, 18 Oct 2018 09:44:29 GMT
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:43:56 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1fUkRaCbs0jN9_9ZF2PltSzvOwSz01QbphWX271PPX60&s=AMedNnoAAAAAW8hyHWBo3osYCQqxBGIj_Lu2dmuwE4SR&sz=s350&v=2
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1pW4KaxEgB6pE9tDx6qPhyrGf_3xZx0jAcGtc4xuPs_U&s=AMedNnoAAAAAW8iOHHZ5G_wAh_5PEOqI2q2BFC_OPQWt&sz=s350&v=2
     body:
       encoding: UTF-8
       string: ''
@@ -1337,7 +1689,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:29 GMT
+      - Thu, 18 Oct 2018 11:43:56 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1368,7 +1720,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 18 Oct 2018 09:44:29 GMT
+      - Thu, 18 Oct 2018 11:43:56 GMT
       Server:
       - fife
       Content-Length:
@@ -1381,11 +1733,11 @@ http_interactions:
       encoding: ASCII-8BIT
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
-    http_version:
-  recorded_at: Thu, 18 Oct 2018 09:44:29 GMT
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:43:56 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1cO1pbUgZAFXFOpOGgIvbXUvnJV2WS7bC
+    uri: https://www.googleapis.com/drive/v3/files/1Orp-Om_dlS4e3JsJHEZeHxEIYXKP999h
     body:
       encoding: UTF-8
       string: ''
@@ -1397,7 +1749,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:44:29 GMT
+      - Thu, 18 Oct 2018 11:43:56 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1414,7 +1766,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:44:30 GMT
+      - Thu, 18 Oct 2018 11:43:57 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1425,6 +1777,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Thu, 18 Oct 2018 09:44:30 GMT
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 11:43:57 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Project/User_can_create_project.yml
+++ b/spec/support/fixtures/vcr_cassettes/Project/User_can_create_project.yml
@@ -1,0 +1,470 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://www.googleapis.com/oauth2/v4/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR TRACKING ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.14.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Mon, 22 Oct 2018 19:46:55 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Mon, 22 Oct 2018 19:46:55 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-22
+        19:46:55 UTC","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 22 Oct 2018 19:46:55 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 22 Oct 2018 19:46:56 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1sf9_IihmRQzzNRAj67Uw1ilCmbDmz5mH",
+         "name": "Test @ 2018-10-22 19:46:55 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 22 Oct 2018 19:46:56 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"My Awesome
+        New Project! (Archive)","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 22 Oct 2018 19:46:57 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 22 Oct 2018 19:46:58 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1clp3Q_H9kmFzEPwIK8zyjwAVhvf-Y-vX",
+         "name": "My Awesome New Project! (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 22 Oct 2018 19:46:58 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1clp3Q_H9kmFzEPwIK8zyjwAVhvf-Y-vX/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 22 Oct 2018 19:46:58 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 22 Oct 2018 19:46:59 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "13193959451567607887",
+         "type": "user",
+         "role": "reader"
+        }
+    http_version: 
+  recorded_at: Mon, 22 Oct 2018 19:46:59 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1clp3Q_H9kmFzEPwIK8zyjwAVhvf-Y-vX?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 22 Oct 2018 19:46:59 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 22 Oct 2018 19:46:59 GMT
+      Date:
+      - Mon, 22 Oct 2018 19:46:59 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1clp3Q_H9kmFzEPwIK8zyjwAVhvf-Y-vX",
+         "name": "My Awesome New Project! (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 22 Oct 2018 19:46:59 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1clp3Q_H9kmFzEPwIK8zyjwAVhvf-Y-vX/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 22 Oct 2018 19:46:59 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 22 Oct 2018 19:47:00 GMT
+      Expires:
+      - Mon, 22 Oct 2018 19:47:00 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 22 Oct 2018 19:47:00 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1sf9_IihmRQzzNRAj67Uw1ilCmbDmz5mH
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 22 Oct 2018 19:47:00 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 22 Oct 2018 19:47:01 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 22 Oct 2018 19:47:01 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Project/User_can_delete_project.yml
+++ b/spec/support/fixtures/vcr_cassettes/Project/User_can_delete_project.yml
@@ -1,0 +1,294 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"3 Krikkit
+        One (Archive)","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 10:33:16 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 10:33:16 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1ttn6BPBTyx4mP_98LrofFmwtFoNo7v26",
+         "name": "3 Krikkit One (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 10:33:16 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1ttn6BPBTyx4mP_98LrofFmwtFoNo7v26/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 10:33:16 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 10:33:17 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "13193959451567607887",
+         "type": "user",
+         "role": "reader"
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 10:33:17 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1ttn6BPBTyx4mP_98LrofFmwtFoNo7v26?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 10:33:17 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 10:33:17 GMT
+      Date:
+      - Thu, 18 Oct 2018 10:33:17 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1ttn6BPBTyx4mP_98LrofFmwtFoNo7v26",
+         "name": "3 Krikkit One (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 10:33:17 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1ttn6BPBTyx4mP_98LrofFmwtFoNo7v26/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 10:33:17 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 10:33:17 GMT
+      Expires:
+      - Thu, 18 Oct 2018 10:33:17 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 10:33:17 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Project/User_can_edit_project.yml
+++ b/spec/support/fixtures/vcr_cassettes/Project/User_can_edit_project.yml
@@ -1,0 +1,294 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"1 Heart of
+        Gold (Archive)","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 10:33:10 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 10:33:11 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1TDc8wZmvBTsWpCaGXZUWvcHhN1Fn1Fhr",
+         "name": "1 Heart of Gold (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 10:33:11 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1TDc8wZmvBTsWpCaGXZUWvcHhN1Fn1Fhr/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 10:33:11 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 10:33:12 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "13193959451567607887",
+         "type": "user",
+         "role": "reader"
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 10:33:12 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1TDc8wZmvBTsWpCaGXZUWvcHhN1Fn1Fhr?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 10:33:12 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 10:33:12 GMT
+      Date:
+      - Thu, 18 Oct 2018 10:33:12 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1TDc8wZmvBTsWpCaGXZUWvcHhN1Fn1Fhr",
+         "name": "1 Heart of Gold (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 10:33:12 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1TDc8wZmvBTsWpCaGXZUWvcHhN1Fn1Fhr/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 10:33:12 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 10:33:12 GMT
+      Expires:
+      - Thu, 18 Oct 2018 10:33:12 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 10:33:12 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Project/User_can_view_project.yml
+++ b/spec/support/fixtures/vcr_cassettes/Project/User_can_view_project.yml
@@ -1,0 +1,293 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"2 RW6 (Archive)","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 10:33:14 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 10:33:14 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1ed50tQewaQi74aTRXkVYsG-O1SG1IS7y",
+         "name": "2 RW6 (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 10:33:14 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1ed50tQewaQi74aTRXkVYsG-O1SG1IS7y/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 10:33:14 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 18 Oct 2018 10:33:15 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "13193959451567607887",
+         "type": "user",
+         "role": "reader"
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 10:33:15 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1ed50tQewaQi74aTRXkVYsG-O1SG1IS7y?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 10:33:15 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 18 Oct 2018 10:33:15 GMT
+      Date:
+      - Thu, 18 Oct 2018 10:33:15 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1ed50tQewaQi74aTRXkVYsG-O1SG1IS7y",
+         "name": "2 RW6 (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 10:33:15 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1ed50tQewaQi74aTRXkVYsG-O1SG1IS7y/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 18 Oct 2018 10:33:15 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 18 Oct 2018 10:33:15 GMT
+      Expires:
+      - Thu, 18 Oct 2018 10:33:15 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 18 Oct 2018 10:33:15 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Project_Archive/_setup/creates_a_folder_in_Google_Drive.yml
+++ b/spec/support/fixtures/vcr_cassettes/Project_Archive/_setup/creates_a_folder_in_Google_Drive.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:30:12 GMT
+      - Mon, 22 Oct 2018 00:19:55 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,68 +53,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:30:12 GMT
-- request:
-    method: post
-    uri: https://www.googleapis.com/oauth2/v4/token
-    body:
-      encoding: ASCII-8BIT
-      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR USER ACCOUNT>&client_id=<CLIENT
-        ID>&client_secret=<CLIENT SECRET>
-    headers:
-      User-Agent:
-      - Faraday v0.14.0
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-      Vary:
-      - Origin
-      - Referer
-      - X-Origin
-      Date:
-      - Thu, 18 Oct 2018 09:30:13 GMT
-      Server:
-      - ESF
-      Cache-Control:
-      - private
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Content-Type-Options:
-      - nosniff
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
-          "expires_in": 3600,
-          "scope": "https://www.googleapis.com/auth/drive",
-          "token_type": "Bearer"
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:30:13 GMT
+  recorded_at: Mon, 22 Oct 2018 00:19:56 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        09:30:13 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-22
+        00:19:56 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,11 +69,11 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:30:13 GMT
+      - Mon, 22 Oct 2018 00:19:56 GMT
       Content-Type:
       - application/json
       Authorization:
-      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
   response:
     status:
       code: 200
@@ -140,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:30:13 GMT
+      - Mon, 22 Oct 2018 00:19:57 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,34 +110,34 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1AXJx4W0R_l8qTHO1H9Wb6gnMYvHVK7X1",
-         "name": "Test @ 2018-10-18 09:30:13 UTC",
+         "id": "1voHPxwkBMZIqqEMB1LYp03nDCm5r2UYm",
+         "name": "Test @ 2018-10-22 00:19:56 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "0AEIi2L68pCuiUk9PVA"
+          "0AIeK5UAEPQfeUk9PVA"
          ],
          "thumbnailVersion": "0",
          "permissions": [
           {
            "kind": "drive#permission",
-           "id": "13193959451567607887",
+           "id": "11673017242486491425",
            "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
            "role": "owner",
-           "displayName": "Testuser Upshift One",
+           "displayName": "Upshift One",
            "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:30:13 GMT
+  recorded_at: Mon, 22 Oct 2018 00:19:57 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1AXJx4W0R_l8qTHO1H9Wb6gnMYvHVK7X1/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"reader","type":"user"}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Demo (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -200,11 +146,11 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:30:13 GMT
+      - Mon, 22 Oct 2018 00:19:57 GMT
       Content-Type:
       - application/json
       Authorization:
-      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
   response:
     status:
       code: 200
@@ -217,7 +163,84 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:30:14 GMT
+      - Mon, 22 Oct 2018 00:19:57 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1ePm_k9ETa5hAvG6lBbDGOYKnA10xvU28",
+         "name": "Demo (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 22 Oct 2018 00:19:57 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1ePm_k9ETa5hAvG6lBbDGOYKnA10xvU28/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 22 Oct 2018 00:19:57 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 22 Oct 2018 00:19:58 GMT
       Vary:
       - Origin
       - X-Origin
@@ -242,101 +265,15 @@ http_interactions:
       string: |
         {
          "kind": "drive#permission",
-         "id": "11673017242486491425",
+         "id": "13193959451567607887",
          "type": "user",
          "role": "reader"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:30:14 GMT
-- request:
-    method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["1AXJx4W0R_l8qTHO1H9Wb6gnMYvHVK7X1"]}'
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 09:30:14 GMT
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Thu, 18 Oct 2018 09:30:14 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1Ag5TObMn8wjHjeYnonqteTlyW10MHJza",
-         "name": "Test File",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "1AXJx4W0R_l8qTHO1H9Wb6gnMYvHVK7X1"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "reader",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:30:14 GMT
+  recorded_at: Mon, 22 Oct 2018 00:19:58 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Ag5TObMn8wjHjeYnonqteTlyW10MHJza?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ePm_k9ETa5hAvG6lBbDGOYKnA10xvU28?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -348,7 +285,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:30:14 GMT
+      - Mon, 22 Oct 2018 00:19:58 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -359,9 +296,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:30:15 GMT
+      - Mon, 22 Oct 2018 00:19:59 GMT
       Date:
-      - Thu, 18 Oct 2018 09:30:15 GMT
+      - Mon, 22 Oct 2018 00:19:59 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -387,20 +324,40 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1Ag5TObMn8wjHjeYnonqteTlyW10MHJza",
-         "name": "Test File",
+         "id": "1ePm_k9ETa5hAvG6lBbDGOYKnA10xvU28",
+         "name": "Demo (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1AXJx4W0R_l8qTHO1H9Wb6gnMYvHVK7X1"
+          "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:30:15 GMT
+  recorded_at: Mon, 22 Oct 2018 00:19:59 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Ag5TObMn8wjHjeYnonqteTlyW10MHJza/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1ePm_k9ETa5hAvG6lBbDGOYKnA10xvU28/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -412,7 +369,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:30:15 GMT
+      - Mon, 22 Oct 2018 00:19:59 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -430,9 +387,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:30:15 GMT
+      - Mon, 22 Oct 2018 00:19:59 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:30:15 GMT
+      - Mon, 22 Oct 2018 00:19:59 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -464,10 +421,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:30:15 GMT
+  recorded_at: Mon, 22 Oct 2018 00:19:59 GMT
 - request:
-    method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1AXJx4W0R_l8qTHO1H9Wb6gnMYvHVK7X1
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1ePm_k9ETa5hAvG6lBbDGOYKnA10xvU28?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -479,9 +436,160 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:30:15 GMT
+      - Mon, 22 Oct 2018 00:19:59 GMT
       Authorization:
-      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 22 Oct 2018 00:19:59 GMT
+      Date:
+      - Mon, 22 Oct 2018 00:19:59 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1ePm_k9ETa5hAvG6lBbDGOYKnA10xvU28",
+         "name": "Demo (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 22 Oct 2018 00:19:59 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1ePm_k9ETa5hAvG6lBbDGOYKnA10xvU28/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 22 Oct 2018 00:19:59 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 22 Oct 2018 00:19:59 GMT
+      Expires:
+      - Mon, 22 Oct 2018 00:19:59 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 22 Oct 2018 00:19:59 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1ePm_k9ETa5hAvG6lBbDGOYKnA10xvU28
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 22 Oct 2018 00:19:59 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
       - application/x-www-form-urlencoded
   response:
@@ -496,7 +604,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:30:15 GMT
+      - Mon, 22 Oct 2018 00:20:00 GMT
       Vary:
       - Origin
       - X-Origin
@@ -508,5 +616,49 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:30:15 GMT
+  recorded_at: Mon, 22 Oct 2018 00:20:00 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1voHPxwkBMZIqqEMB1LYp03nDCm5r2UYm
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 22 Oct 2018 00:20:00 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 22 Oct 2018 00:20:01 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 22 Oct 2018 00:20:01 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Project_Archive/_setup/shares_view_access_to_the_archive_with_the_repository_owner.yml
+++ b/spec/support/fixtures/vcr_cassettes/Project_Archive/_setup/shares_view_access_to_the_archive_with_the_repository_owner.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:30:12 GMT
+      - Mon, 22 Oct 2018 00:19:47 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,68 +53,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:30:12 GMT
-- request:
-    method: post
-    uri: https://www.googleapis.com/oauth2/v4/token
-    body:
-      encoding: ASCII-8BIT
-      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR USER ACCOUNT>&client_id=<CLIENT
-        ID>&client_secret=<CLIENT SECRET>
-    headers:
-      User-Agent:
-      - Faraday v0.14.0
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=utf-8
-      Vary:
-      - Origin
-      - Referer
-      - X-Origin
-      Date:
-      - Thu, 18 Oct 2018 09:30:13 GMT
-      Server:
-      - ESF
-      Cache-Control:
-      - private
-      X-Xss-Protection:
-      - 1; mode=block
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Content-Type-Options:
-      - nosniff
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
-          "expires_in": 3600,
-          "scope": "https://www.googleapis.com/auth/drive",
-          "token_type": "Bearer"
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:30:13 GMT
+  recorded_at: Mon, 22 Oct 2018 00:19:47 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        09:30:13 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-22
+        00:19:47 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,11 +69,11 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:30:13 GMT
+      - Mon, 22 Oct 2018 00:19:47 GMT
       Content-Type:
       - application/json
       Authorization:
-      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
   response:
     status:
       code: 200
@@ -140,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:30:13 GMT
+      - Mon, 22 Oct 2018 00:19:49 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,34 +110,34 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1AXJx4W0R_l8qTHO1H9Wb6gnMYvHVK7X1",
-         "name": "Test @ 2018-10-18 09:30:13 UTC",
+         "id": "1ivT1SJUHYDIx5Z5oS1g65zmwobozYMWO",
+         "name": "Test @ 2018-10-22 00:19:47 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "0AEIi2L68pCuiUk9PVA"
+          "0AIeK5UAEPQfeUk9PVA"
          ],
          "thumbnailVersion": "0",
          "permissions": [
           {
            "kind": "drive#permission",
-           "id": "13193959451567607887",
+           "id": "11673017242486491425",
            "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
            "role": "owner",
-           "displayName": "Testuser Upshift One",
+           "displayName": "Upshift One",
            "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:30:13 GMT
+  recorded_at: Mon, 22 Oct 2018 00:19:49 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1AXJx4W0R_l8qTHO1H9Wb6gnMYvHVK7X1/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"reader","type":"user"}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Demo (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -200,11 +146,11 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:30:13 GMT
+      - Mon, 22 Oct 2018 00:19:49 GMT
       Content-Type:
       - application/json
       Authorization:
-      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
   response:
     status:
       code: 200
@@ -217,7 +163,84 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:30:14 GMT
+      - Mon, 22 Oct 2018 00:19:50 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1VHcmgz6Vtg06HTGS_KQ7uzXyRh3HHFGa",
+         "name": "Demo (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 22 Oct 2018 00:19:50 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1VHcmgz6Vtg06HTGS_KQ7uzXyRh3HHFGa/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 22 Oct 2018 00:19:50 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 22 Oct 2018 00:19:51 GMT
       Vary:
       - Origin
       - X-Origin
@@ -242,101 +265,15 @@ http_interactions:
       string: |
         {
          "kind": "drive#permission",
-         "id": "11673017242486491425",
+         "id": "13193959451567607887",
          "type": "user",
          "role": "reader"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:30:14 GMT
-- request:
-    method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["1AXJx4W0R_l8qTHO1H9Wb6gnMYvHVK7X1"]}'
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 09:30:14 GMT
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Thu, 18 Oct 2018 09:30:14 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1Ag5TObMn8wjHjeYnonqteTlyW10MHJza",
-         "name": "Test File",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "1AXJx4W0R_l8qTHO1H9Wb6gnMYvHVK7X1"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "reader",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:30:14 GMT
+  recorded_at: Mon, 22 Oct 2018 00:19:51 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Ag5TObMn8wjHjeYnonqteTlyW10MHJza?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1VHcmgz6Vtg06HTGS_KQ7uzXyRh3HHFGa?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -348,7 +285,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:30:14 GMT
+      - Mon, 22 Oct 2018 00:19:51 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -359,9 +296,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:30:15 GMT
+      - Mon, 22 Oct 2018 00:19:52 GMT
       Date:
-      - Thu, 18 Oct 2018 09:30:15 GMT
+      - Mon, 22 Oct 2018 00:19:52 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -387,20 +324,40 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1Ag5TObMn8wjHjeYnonqteTlyW10MHJza",
-         "name": "Test File",
+         "id": "1VHcmgz6Vtg06HTGS_KQ7uzXyRh3HHFGa",
+         "name": "Demo (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1AXJx4W0R_l8qTHO1H9Wb6gnMYvHVK7X1"
+          "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:30:15 GMT
+  recorded_at: Mon, 22 Oct 2018 00:19:52 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Ag5TObMn8wjHjeYnonqteTlyW10MHJza/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1VHcmgz6Vtg06HTGS_KQ7uzXyRh3HHFGa/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -412,7 +369,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:30:15 GMT
+      - Mon, 22 Oct 2018 00:19:52 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -430,9 +387,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 18 Oct 2018 09:30:15 GMT
+      - Mon, 22 Oct 2018 00:19:52 GMT
       Expires:
-      - Thu, 18 Oct 2018 09:30:15 GMT
+      - Mon, 22 Oct 2018 00:19:52 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -464,10 +421,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:30:15 GMT
+  recorded_at: Mon, 22 Oct 2018 00:19:52 GMT
 - request:
-    method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1AXJx4W0R_l8qTHO1H9Wb6gnMYvHVK7X1
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1VHcmgz6Vtg06HTGS_KQ7uzXyRh3HHFGa?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -479,9 +436,93 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:30:15 GMT
+      - Mon, 22 Oct 2018 00:19:52 GMT
       Authorization:
-      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 22 Oct 2018 00:19:52 GMT
+      Date:
+      - Mon, 22 Oct 2018 00:19:52 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1VHcmgz6Vtg06HTGS_KQ7uzXyRh3HHFGa",
+         "name": "Demo (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 22 Oct 2018 00:19:52 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1VHcmgz6Vtg06HTGS_KQ7uzXyRh3HHFGa
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 22 Oct 2018 00:19:52 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
       - application/x-www-form-urlencoded
   response:
@@ -496,7 +537,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:30:15 GMT
+      - Mon, 22 Oct 2018 00:19:53 GMT
       Vary:
       - Origin
       - X-Origin
@@ -508,5 +549,49 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:30:15 GMT
+  recorded_at: Mon, 22 Oct 2018 00:19:54 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1ivT1SJUHYDIx5Z5oS1g65zmwobozYMWO
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 22 Oct 2018 00:19:54 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 22 Oct 2018 00:19:54 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 22 Oct 2018 00:19:55 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Project_Setup/validations/when_link_is_a_google_drive_doc/adds_an_error.yml
+++ b/spec/support/fixtures/vcr_cassettes/Project_Setup/validations/when_link_is_a_google_drive_doc/adds_an_error.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,42 +21,39 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:41:06 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:30:08 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:06 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:08 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -66,7 +63,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -78,49 +75,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:41:06 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:30:09 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:06 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:09 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        21:41:06 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:30:09 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -129,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:41:06 GMT
+      - Thu, 18 Oct 2018 09:30:09 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -146,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:41:07 GMT
+      - Thu, 18 Oct 2018 09:30:09 GMT
       Vary:
       - Origin
       - X-Origin
@@ -163,28 +157,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "15bDco4BLFrQ5AzF9kPgqqXCjR3L9vVAO",
-         "name": "Test @ 2018-03-18 21:41:06 UTC",
+         "id": "1Wwcebk0msp2HsCZtJQ6pgleSAkCaLaTv",
+         "name": "Test @ 2018-10-18 09:30:09 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AEIi2L68pCuiUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:07 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:09 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/15bDco4BLFrQ5AzF9kPgqqXCjR3L9vVAO/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1Wwcebk0msp2HsCZtJQ6pgleSAkCaLaTv/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"reader","type":"user"}'
@@ -196,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:41:07 GMT
+      - Thu, 18 Oct 2018 09:30:09 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -213,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:41:08 GMT
+      - Thu, 18 Oct 2018 09:30:10 GMT
       Vary:
       - Origin
       - X-Origin
@@ -230,8 +234,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -244,13 +247,13 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:08 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:10 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["15bDco4BLFrQ5AzF9kPgqqXCjR3L9vVAO"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1Wwcebk0msp2HsCZtJQ6pgleSAkCaLaTv"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -259,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:41:08 GMT
+      - Thu, 18 Oct 2018 09:30:10 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -276,7 +279,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:41:09 GMT
+      - Thu, 18 Oct 2018 09:30:11 GMT
       Vary:
       - Origin
       - X-Origin
@@ -293,28 +296,47 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1Bc4vbBGfcp971MlY7u4GhFN0RmFE6kAmbKj3lsEGFZE",
+         "id": "1ynN_zX_ezbL1T1MTEpbERJaKJ3pT6wyG-ZjQWTkmFa4",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "15bDco4BLFrQ5AzF9kPgqqXCjR3L9vVAO"
+          "1Wwcebk0msp2HsCZtJQ6pgleSAkCaLaTv"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "reader",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:09 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:11 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Bc4vbBGfcp971MlY7u4GhFN0RmFE6kAmbKj3lsEGFZE?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ynN_zX_ezbL1T1MTEpbERJaKJ3pT6wyG-ZjQWTkmFa4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -326,7 +348,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:41:09 GMT
+      - Thu, 18 Oct 2018 09:30:11 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -337,9 +359,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:41:09 GMT
+      - Thu, 18 Oct 2018 09:30:11 GMT
       Date:
-      - Sun, 18 Mar 2018 21:41:09 GMT
+      - Thu, 18 Oct 2018 09:30:11 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -358,28 +380,27 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1Bc4vbBGfcp971MlY7u4GhFN0RmFE6kAmbKj3lsEGFZE",
+         "id": "1ynN_zX_ezbL1T1MTEpbERJaKJ3pT6wyG-ZjQWTkmFa4",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "15bDco4BLFrQ5AzF9kPgqqXCjR3L9vVAO"
+          "1Wwcebk0msp2HsCZtJQ6pgleSAkCaLaTv"
          ],
          "thumbnailVersion": "0"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:09 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:11 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Bc4vbBGfcp971MlY7u4GhFN0RmFE6kAmbKj3lsEGFZE/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1ynN_zX_ezbL1T1MTEpbERJaKJ3pT6wyG-ZjQWTkmFa4/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -391,7 +412,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:41:09 GMT
+      - Thu, 18 Oct 2018 09:30:11 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -409,9 +430,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:41:09 GMT
+      - Thu, 18 Oct 2018 09:30:12 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:41:09 GMT
+      - Thu, 18 Oct 2018 09:30:12 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -423,8 +444,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -436,20 +456,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "insufficientFilePermissions",
-            "message": "The user does not have sufficient permissions for file 1Bc4vbBGfcp971MlY7u4GhFN0RmFE6kAmbKj3lsEGFZE.",
+            "message": "The user does not have sufficient permissions for file 1ynN_zX_ezbL1T1MTEpbERJaKJ3pT6wyG-ZjQWTkmFa4.",
             "locationType": "header",
             "location": "Authorization"
            }
           ],
           "code": 403,
-          "message": "The user does not have sufficient permissions for file 1Bc4vbBGfcp971MlY7u4GhFN0RmFE6kAmbKj3lsEGFZE."
+          "message": "The user does not have sufficient permissions for file 1ynN_zX_ezbL1T1MTEpbERJaKJ3pT6wyG-ZjQWTkmFa4."
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:09 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:12 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/15bDco4BLFrQ5AzF9kPgqqXCjR3L9vVAO
+    uri: https://www.googleapis.com/drive/v3/files/1Wwcebk0msp2HsCZtJQ6pgleSAkCaLaTv
     body:
       encoding: UTF-8
       string: ''
@@ -461,7 +481,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:41:09 GMT
+      - Thu, 18 Oct 2018 09:30:12 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -478,18 +498,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:41:10 GMT
+      - Thu, 18 Oct 2018 09:30:12 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:10 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:12 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Project_Setup/validations/when_link_is_drive_google_com/open_id_/is_valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/Project_Setup/validations/when_link_is_drive_google_com/open_id_/is_valid.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,42 +21,39 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:40:56 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:26:39 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:56 GMT
+  recorded_at: Thu, 18 Oct 2018 09:26:39 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -66,7 +63,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -78,49 +75,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:40:56 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:26:39 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:56 GMT
+  recorded_at: Thu, 18 Oct 2018 09:26:39 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        21:40:56 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:26:39 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -129,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:40:56 GMT
+      - Thu, 18 Oct 2018 09:26:39 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -146,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:40:57 GMT
+      - Thu, 18 Oct 2018 09:26:40 GMT
       Vary:
       - Origin
       - X-Origin
@@ -163,28 +157,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1qACHGt3YFB_mAWI4ZnZshatS5WixIcpG",
-         "name": "Test @ 2018-03-18 21:40:56 UTC",
+         "id": "1_9gFIa1gnu5D-8Blc4d1ELYn68wOwW9r",
+         "name": "Test @ 2018-10-18 09:26:39 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AEIi2L68pCuiUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:57 GMT
+  recorded_at: Thu, 18 Oct 2018 09:26:40 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1qACHGt3YFB_mAWI4ZnZshatS5WixIcpG/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1_9gFIa1gnu5D-8Blc4d1ELYn68wOwW9r/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"reader","type":"user"}'
@@ -196,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:40:57 GMT
+      - Thu, 18 Oct 2018 09:26:40 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -213,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:40:57 GMT
+      - Thu, 18 Oct 2018 09:26:40 GMT
       Vary:
       - Origin
       - X-Origin
@@ -230,8 +234,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -244,13 +247,13 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:57 GMT
+  recorded_at: Thu, 18 Oct 2018 09:26:40 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["1qACHGt3YFB_mAWI4ZnZshatS5WixIcpG"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["1_9gFIa1gnu5D-8Blc4d1ELYn68wOwW9r"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -259,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:40:57 GMT
+      - Thu, 18 Oct 2018 09:26:40 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -276,7 +279,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:40:58 GMT
+      - Thu, 18 Oct 2018 09:26:41 GMT
       Vary:
       - Origin
       - X-Origin
@@ -293,28 +296,47 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1OuJgwFKGPaTHylrU_y3-jU-RooNuTaJs",
+         "id": "1VtgQpzOpSEy0eXZWqSd51pQsbO83fj1l",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1qACHGt3YFB_mAWI4ZnZshatS5WixIcpG"
+          "1_9gFIa1gnu5D-8Blc4d1ELYn68wOwW9r"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "reader",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:58 GMT
+  recorded_at: Thu, 18 Oct 2018 09:26:41 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1OuJgwFKGPaTHylrU_y3-jU-RooNuTaJs?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1VtgQpzOpSEy0eXZWqSd51pQsbO83fj1l?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -326,7 +348,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:40:58 GMT
+      - Thu, 18 Oct 2018 09:26:41 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -337,9 +359,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:40:58 GMT
+      - Thu, 18 Oct 2018 09:26:42 GMT
       Date:
-      - Sun, 18 Mar 2018 21:40:58 GMT
+      - Thu, 18 Oct 2018 09:26:42 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -358,28 +380,27 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1OuJgwFKGPaTHylrU_y3-jU-RooNuTaJs",
+         "id": "1VtgQpzOpSEy0eXZWqSd51pQsbO83fj1l",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1qACHGt3YFB_mAWI4ZnZshatS5WixIcpG"
+          "1_9gFIa1gnu5D-8Blc4d1ELYn68wOwW9r"
          ],
          "thumbnailVersion": "0"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:58 GMT
+  recorded_at: Thu, 18 Oct 2018 09:26:42 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1OuJgwFKGPaTHylrU_y3-jU-RooNuTaJs/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1VtgQpzOpSEy0eXZWqSd51pQsbO83fj1l/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -391,7 +412,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:40:58 GMT
+      - Thu, 18 Oct 2018 09:26:42 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -409,9 +430,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:40:58 GMT
+      - Thu, 18 Oct 2018 09:26:42 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:40:58 GMT
+      - Thu, 18 Oct 2018 09:26:42 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -423,8 +444,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -444,10 +464,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:58 GMT
+  recorded_at: Thu, 18 Oct 2018 09:26:42 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1qACHGt3YFB_mAWI4ZnZshatS5WixIcpG
+    uri: https://www.googleapis.com/drive/v3/files/1_9gFIa1gnu5D-8Blc4d1ELYn68wOwW9r
     body:
       encoding: UTF-8
       string: ''
@@ -459,7 +479,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:40:59 GMT
+      - Thu, 18 Oct 2018 09:26:42 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -476,18 +496,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:40:59 GMT
+      - Thu, 18 Oct 2018 09:26:42 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:40:59 GMT
+  recorded_at: Thu, 18 Oct 2018 09:26:42 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Project_Setup/validations/when_link_looks_like_google_drive_folder_but_has_ID_of_doc/adds_an_error.yml
+++ b/spec/support/fixtures/vcr_cassettes/Project_Setup/validations/when_link_looks_like_google_drive_folder_but_has_ID_of_doc/adds_an_error.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,42 +21,39 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:41:10 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:30:05 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:10 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:05 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -66,7 +63,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -78,49 +75,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:41:10 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:30:05 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:10 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:05 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        21:41:10 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:30:05 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -129,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:41:10 GMT
+      - Thu, 18 Oct 2018 09:30:05 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -146,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:41:11 GMT
+      - Thu, 18 Oct 2018 09:30:05 GMT
       Vary:
       - Origin
       - X-Origin
@@ -163,28 +157,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1YV-_HM2czXzJIFu4uzyW2EdhdpQQYYfU",
-         "name": "Test @ 2018-03-18 21:41:10 UTC",
+         "id": "1xgOu6eoK1sqE9_PBIm9XNOTlpvSawPyp",
+         "name": "Test @ 2018-10-18 09:30:05 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AEIi2L68pCuiUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:11 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:05 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1YV-_HM2czXzJIFu4uzyW2EdhdpQQYYfU/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1xgOu6eoK1sqE9_PBIm9XNOTlpvSawPyp/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"reader","type":"user"}'
@@ -196,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:41:11 GMT
+      - Thu, 18 Oct 2018 09:30:05 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -213,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:41:12 GMT
+      - Thu, 18 Oct 2018 09:30:06 GMT
       Vary:
       - Origin
       - X-Origin
@@ -230,8 +234,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -244,13 +247,13 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:12 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:06 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1YV-_HM2czXzJIFu4uzyW2EdhdpQQYYfU"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1xgOu6eoK1sqE9_PBIm9XNOTlpvSawPyp"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -259,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:41:12 GMT
+      - Thu, 18 Oct 2018 09:30:06 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -276,7 +279,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:41:13 GMT
+      - Thu, 18 Oct 2018 09:30:07 GMT
       Vary:
       - Origin
       - X-Origin
@@ -293,28 +296,47 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1SjpEQ8VhTUNe0_Bgbl6jz8M0rXe3yQ4FPXjnJAI6G5k",
+         "id": "1lg6dkNAfK4RyB9r0bIKBTSYol-35Bl03rM6cp4pOUJ4",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1YV-_HM2czXzJIFu4uzyW2EdhdpQQYYfU"
+          "1xgOu6eoK1sqE9_PBIm9XNOTlpvSawPyp"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "reader",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:13 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:07 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1SjpEQ8VhTUNe0_Bgbl6jz8M0rXe3yQ4FPXjnJAI6G5k?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1lg6dkNAfK4RyB9r0bIKBTSYol-35Bl03rM6cp4pOUJ4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -326,7 +348,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:41:13 GMT
+      - Thu, 18 Oct 2018 09:30:07 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -337,9 +359,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:41:13 GMT
+      - Thu, 18 Oct 2018 09:30:07 GMT
       Date:
-      - Sun, 18 Mar 2018 21:41:13 GMT
+      - Thu, 18 Oct 2018 09:30:07 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -358,28 +380,27 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1SjpEQ8VhTUNe0_Bgbl6jz8M0rXe3yQ4FPXjnJAI6G5k",
+         "id": "1lg6dkNAfK4RyB9r0bIKBTSYol-35Bl03rM6cp4pOUJ4",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1YV-_HM2czXzJIFu4uzyW2EdhdpQQYYfU"
+          "1xgOu6eoK1sqE9_PBIm9XNOTlpvSawPyp"
          ],
          "thumbnailVersion": "0"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:13 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:08 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1SjpEQ8VhTUNe0_Bgbl6jz8M0rXe3yQ4FPXjnJAI6G5k/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1lg6dkNAfK4RyB9r0bIKBTSYol-35Bl03rM6cp4pOUJ4/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -391,7 +412,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:41:13 GMT
+      - Thu, 18 Oct 2018 09:30:08 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -409,9 +430,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:41:13 GMT
+      - Thu, 18 Oct 2018 09:30:08 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:41:13 GMT
+      - Thu, 18 Oct 2018 09:30:08 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -423,8 +444,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -436,20 +456,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "insufficientFilePermissions",
-            "message": "The user does not have sufficient permissions for file 1SjpEQ8VhTUNe0_Bgbl6jz8M0rXe3yQ4FPXjnJAI6G5k.",
+            "message": "The user does not have sufficient permissions for file 1lg6dkNAfK4RyB9r0bIKBTSYol-35Bl03rM6cp4pOUJ4.",
             "locationType": "header",
             "location": "Authorization"
            }
           ],
           "code": 403,
-          "message": "The user does not have sufficient permissions for file 1SjpEQ8VhTUNe0_Bgbl6jz8M0rXe3yQ4FPXjnJAI6G5k."
+          "message": "The user does not have sufficient permissions for file 1lg6dkNAfK4RyB9r0bIKBTSYol-35Bl03rM6cp4pOUJ4."
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:13 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:08 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1YV-_HM2czXzJIFu4uzyW2EdhdpQQYYfU
+    uri: https://www.googleapis.com/drive/v3/files/1xgOu6eoK1sqE9_PBIm9XNOTlpvSawPyp
     body:
       encoding: UTF-8
       string: ''
@@ -461,7 +481,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:41:13 GMT
+      - Thu, 18 Oct 2018 09:30:08 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -478,18 +498,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:41:14 GMT
+      - Thu, 18 Oct 2018 09:30:08 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:14 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:08 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Project_Setup/validations/when_link_to_google_drive_folder_is_inaccessible/adds_an_error.yml
+++ b/spec/support/fixtures/vcr_cassettes/Project_Setup/validations/when_link_to_google_drive_folder_is_inaccessible/adds_an_error.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,42 +21,39 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:41:03 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:29:58 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:03 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:58 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -66,7 +63,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -78,49 +75,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:41:03 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:29:59 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:03 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:59 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        21:41:03 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:29:59 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -129,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:41:03 GMT
+      - Thu, 18 Oct 2018 09:29:59 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -146,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:41:04 GMT
+      - Thu, 18 Oct 2018 09:29:59 GMT
       Vary:
       - Origin
       - X-Origin
@@ -163,31 +157,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1prEmMyasna6KE7EBlMebR0jktzJQ-RB9",
-         "name": "Test @ 2018-03-18 21:41:03 UTC",
+         "id": "1J98gGl5HcBw756IMNxQH_veGyR1to_Xi",
+         "name": "Test @ 2018-10-18 09:29:59 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AEIi2L68pCuiUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:04 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:59 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["1prEmMyasna6KE7EBlMebR0jktzJQ-RB9"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["1J98gGl5HcBw756IMNxQH_veGyR1to_Xi"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -196,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:41:04 GMT
+      - Thu, 18 Oct 2018 09:29:59 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -213,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:41:05 GMT
+      - Thu, 18 Oct 2018 09:30:00 GMT
       Vary:
       - Origin
       - X-Origin
@@ -230,28 +234,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1klNI61UDc-Qvs8PqsmEhP2p7WRi_hcpE",
+         "id": "1l6QuU4ufLLziDi6my9Zg0pRTCd0DFWUc",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1prEmMyasna6KE7EBlMebR0jktzJQ-RB9"
+          "1J98gGl5HcBw756IMNxQH_veGyR1to_Xi"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:05 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:00 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1klNI61UDc-Qvs8PqsmEhP2p7WRi_hcpE?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1l6QuU4ufLLziDi6my9Zg0pRTCd0DFWUc?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -263,7 +277,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:41:05 GMT
+      - Thu, 18 Oct 2018 09:30:00 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -281,9 +295,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:41:05 GMT
+      - Thu, 18 Oct 2018 09:30:00 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:41:05 GMT
+      - Thu, 18 Oct 2018 09:30:00 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -295,8 +309,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -308,20 +321,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1klNI61UDc-Qvs8PqsmEhP2p7WRi_hcpE.",
+            "message": "File not found: 1l6QuU4ufLLziDi6my9Zg0pRTCd0DFWUc.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1klNI61UDc-Qvs8PqsmEhP2p7WRi_hcpE."
+          "message": "File not found: 1l6QuU4ufLLziDi6my9Zg0pRTCd0DFWUc."
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:05 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:00 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1prEmMyasna6KE7EBlMebR0jktzJQ-RB9
+    uri: https://www.googleapis.com/drive/v3/files/1J98gGl5HcBw756IMNxQH_veGyR1to_Xi
     body:
       encoding: UTF-8
       string: ''
@@ -333,7 +346,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:41:05 GMT
+      - Thu, 18 Oct 2018 09:30:00 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -350,18 +363,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:41:06 GMT
+      - Thu, 18 Oct 2018 09:30:01 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:06 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:01 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Project_Setup/validations/when_link_to_google_drive_folder_is_invalid/adds_an_error.yml
+++ b/spec/support/fixtures/vcr_cassettes/Project_Setup/validations/when_link_to_google_drive_folder_is_invalid/adds_an_error.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,42 +21,39 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:41:00 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:29:55 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:00 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:55 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -66,7 +63,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -78,49 +75,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:41:00 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:29:56 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:00 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:56 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        21:41:00 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:29:56 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -129,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:41:00 GMT
+      - Thu, 18 Oct 2018 09:29:56 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -146,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:41:01 GMT
+      - Thu, 18 Oct 2018 09:29:56 GMT
       Vary:
       - Origin
       - X-Origin
@@ -163,28 +157,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1Dm6NdmAt5Q-bInxuDSP-8HwBNbyspJIY",
-         "name": "Test @ 2018-03-18 21:41:00 UTC",
+         "id": "1Nqp5mXNs7eFlWHDYu5QPr5TCMz5VAwG6",
+         "name": "Test @ 2018-10-18 09:29:56 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AEIi2L68pCuiUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:01 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:56 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1Dm6NdmAt5Q-bInxuDSP-8HwBNbyspJIY/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1Nqp5mXNs7eFlWHDYu5QPr5TCMz5VAwG6/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"reader","type":"user"}'
@@ -196,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:41:01 GMT
+      - Thu, 18 Oct 2018 09:29:56 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -213,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:41:02 GMT
+      - Thu, 18 Oct 2018 09:29:57 GMT
       Vary:
       - Origin
       - X-Origin
@@ -230,8 +234,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -244,13 +247,13 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:02 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:57 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["1Dm6NdmAt5Q-bInxuDSP-8HwBNbyspJIY"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["1Nqp5mXNs7eFlWHDYu5QPr5TCMz5VAwG6"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -259,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:41:02 GMT
+      - Thu, 18 Oct 2018 09:29:57 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -276,7 +279,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:41:02 GMT
+      - Thu, 18 Oct 2018 09:29:58 GMT
       Vary:
       - Origin
       - X-Origin
@@ -293,28 +296,47 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1xKkCozpmz-fqU7QvFHXdjXqBoR0hfP6s",
+         "id": "1xAywDI9HudFpNqFkuUJoc6t633NqEAcs",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1Dm6NdmAt5Q-bInxuDSP-8HwBNbyspJIY"
+          "1Nqp5mXNs7eFlWHDYu5QPr5TCMz5VAwG6"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "reader",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:03 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:58 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1Dm6NdmAt5Q-bInxuDSP-8HwBNbyspJIY
+    uri: https://www.googleapis.com/drive/v3/files/1Nqp5mXNs7eFlWHDYu5QPr5TCMz5VAwG6
     body:
       encoding: UTF-8
       string: ''
@@ -326,7 +348,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:41:03 GMT
+      - Thu, 18 Oct 2018 09:29:58 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -343,18 +365,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:41:03 GMT
+      - Thu, 18 Oct 2018 09:29:58 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:03 GMT
+  recorded_at: Thu, 18 Oct 2018 09:29:58 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Project_Setup/validations/when_link_to_google_drive_folder_is_valid/is_valid.yml
+++ b/spec/support/fixtures/vcr_cassettes/Project_Setup/validations/when_link_to_google_drive_folder_is_valid/is_valid.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,42 +21,39 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:41:14 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:30:01 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:14 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:01 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/oauth2/v4/token
@@ -66,7 +63,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -78,49 +75,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 21:41:14 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:30:01 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:14 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:01 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        21:41:14 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:30:01 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -129,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:41:14 GMT
+      - Thu, 18 Oct 2018 09:30:01 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -146,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:41:15 GMT
+      - Thu, 18 Oct 2018 09:30:02 GMT
       Vary:
       - Origin
       - X-Origin
@@ -163,28 +157,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1sk94ebH_zmQ_o3dhwvRknw2gIXeFn1Lj",
-         "name": "Test @ 2018-03-18 21:41:14 UTC",
+         "id": "1i0vvZGUHbq6OS7YiQU80p83apJZ97kdZ",
+         "name": "Test @ 2018-10-18 09:30:01 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AEIi2L68pCuiUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:15 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:02 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1sk94ebH_zmQ_o3dhwvRknw2gIXeFn1Lj/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1i0vvZGUHbq6OS7YiQU80p83apJZ97kdZ/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"reader","type":"user"}'
@@ -196,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:41:15 GMT
+      - Thu, 18 Oct 2018 09:30:02 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -213,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:41:16 GMT
+      - Thu, 18 Oct 2018 09:30:03 GMT
       Vary:
       - Origin
       - X-Origin
@@ -230,8 +234,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -244,13 +247,13 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:16 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:03 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["1sk94ebH_zmQ_o3dhwvRknw2gIXeFn1Lj"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["1i0vvZGUHbq6OS7YiQU80p83apJZ97kdZ"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -259,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:41:16 GMT
+      - Thu, 18 Oct 2018 09:30:03 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -276,7 +279,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:41:16 GMT
+      - Thu, 18 Oct 2018 09:30:03 GMT
       Vary:
       - Origin
       - X-Origin
@@ -293,28 +296,47 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "16V2p9m-hXjRKbdnK40GCvDXWoYuIiRzX",
+         "id": "1SJ8cc_Ye5XVO8oQw1j53lihGO9HIkrnI",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1sk94ebH_zmQ_o3dhwvRknw2gIXeFn1Lj"
+          "1i0vvZGUHbq6OS7YiQU80p83apJZ97kdZ"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "reader",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:16 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:03 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/16V2p9m-hXjRKbdnK40GCvDXWoYuIiRzX?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1SJ8cc_Ye5XVO8oQw1j53lihGO9HIkrnI?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -326,7 +348,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:41:16 GMT
+      - Thu, 18 Oct 2018 09:30:03 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -337,9 +359,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 21:41:17 GMT
+      - Thu, 18 Oct 2018 09:30:03 GMT
       Date:
-      - Sun, 18 Mar 2018 21:41:17 GMT
+      - Thu, 18 Oct 2018 09:30:03 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -358,28 +380,27 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "16V2p9m-hXjRKbdnK40GCvDXWoYuIiRzX",
+         "id": "1SJ8cc_Ye5XVO8oQw1j53lihGO9HIkrnI",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1sk94ebH_zmQ_o3dhwvRknw2gIXeFn1Lj"
+          "1i0vvZGUHbq6OS7YiQU80p83apJZ97kdZ"
          ],
          "thumbnailVersion": "0"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:17 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:04 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/16V2p9m-hXjRKbdnK40GCvDXWoYuIiRzX/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1SJ8cc_Ye5XVO8oQw1j53lihGO9HIkrnI/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -391,7 +412,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:41:17 GMT
+      - Thu, 18 Oct 2018 09:30:04 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -409,9 +430,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 21:41:17 GMT
+      - Thu, 18 Oct 2018 09:30:04 GMT
       Expires:
-      - Sun, 18 Mar 2018 21:41:17 GMT
+      - Thu, 18 Oct 2018 09:30:04 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -423,8 +444,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -444,10 +464,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:17 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:04 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1sk94ebH_zmQ_o3dhwvRknw2gIXeFn1Lj
+    uri: https://www.googleapis.com/drive/v3/files/1i0vvZGUHbq6OS7YiQU80p83apJZ97kdZ
     body:
       encoding: UTF-8
       string: ''
@@ -459,7 +479,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 21:41:17 GMT
+      - Thu, 18 Oct 2018 09:30:04 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -476,18 +496,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 21:41:17 GMT
+      - Thu, 18 Oct 2018 09:30:04 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 21:41:17 GMT
+  recorded_at: Thu, 18 Oct 2018 09:30:04 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_content/retrieves_the_content.yml
+++ b/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_content/retrieves_the_content.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:27:17 GMT
+      - Fri, 19 Oct 2018 07:23:41 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,14 +53,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:27:18 GMT
+  recorded_at: Fri, 19 Oct 2018 07:23:41 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        09:27:18 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-19
+        07:23:41 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -69,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:27:18 GMT
+      - Fri, 19 Oct 2018 07:23:41 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -86,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:27:18 GMT
+      - Fri, 19 Oct 2018 07:23:41 GMT
       Vary:
       - Origin
       - X-Origin
@@ -110,8 +110,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1-ZzcnZAvbLZqr5aq7errllhTvhSr3pOt",
-         "name": "Test @ 2018-10-18 09:27:18 UTC",
+         "id": "17f0cDVQIZYE0yaH7BnP2JuAX4YzsoMyR",
+         "name": "Test @ 2018-10-19 07:23:41 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -131,13 +131,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:27:18 GMT
+  recorded_at: Fri, 19 Oct 2018 07:23:42 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1-ZzcnZAvbLZqr5aq7errllhTvhSr3pOt"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"A File with
+        Content","parents":["17f0cDVQIZYE0yaH7BnP2JuAX4YzsoMyR"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -146,7 +147,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:27:18 GMT
+      - Fri, 19 Oct 2018 07:23:42 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -163,7 +164,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:27:19 GMT
+      - Fri, 19 Oct 2018 07:23:43 GMT
       Vary:
       - Origin
       - X-Origin
@@ -187,12 +188,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1wgFGbBtzaz66cmxbJZfjQo_G9pp-1w7RHaSNM5MrPbc",
-         "name": "Test File",
+         "id": "1IVUPi9gq_kRxSgnYz6-jj8opsU9WmykmnvZfg6G9CJI",
+         "name": "A File with Content",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1-ZzcnZAvbLZqr5aq7errllhTvhSr3pOt"
+          "17f0cDVQIZYE0yaH7BnP2JuAX4YzsoMyR"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -208,10 +209,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:27:19 GMT
+  recorded_at: Fri, 19 Oct 2018 07:23:43 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/upload/drive/v3/files/1wgFGbBtzaz66cmxbJZfjQo_G9pp-1w7RHaSNM5MrPbc
+    uri: https://www.googleapis.com/upload/drive/v3/files/1IVUPi9gq_kRxSgnYz6-jj8opsU9WmykmnvZfg6G9CJI
     body:
       encoding: UTF-8
       string: ''
@@ -223,7 +224,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:27:19 GMT
+      - Fri, 19 Oct 2018 07:23:43 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       X-Goog-Upload-Protocol:
@@ -231,7 +232,7 @@ http_interactions:
       X-Goog-Upload-Command:
       - start
       X-Goog-Upload-Header-Content-Length:
-      - '16'
+      - '42'
       X-Goog-Upload-Header-Content-Type:
       - application/octet-stream
       Content-Type:
@@ -242,22 +243,22 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2UoPgCl5L5iC8TJkax_SkqFVeaJjQ7o8RWm6cGQO6AZzTGCpxeySMmtHT6fY8arbkvAkBqKKBUXMPVXOtTwJy7Ap20Kl5HWOKg7uUZX67dNcSp451ss
+      - AEnB2UrydyWducEXw_I8B0v7BLeUNQNT6p98KcnWYCtqjJd6ul2U3d1T9oFhhTCFTIVFkq1oc04BKhgWkuuDZwBSDRsEmr0a2g
       X-Goog-Upload-Status:
       - active
       X-Goog-Upload-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1wgFGbBtzaz66cmxbJZfjQo_G9pp-1w7RHaSNM5MrPbc?upload_id=AEnB2UoPgCl5L5iC8TJkax_SkqFVeaJjQ7o8RWm6cGQO6AZzTGCpxeySMmtHT6fY8arbkvAkBqKKBUXMPVXOtTwJy7Ap20Kl5HWOKg7uUZX67dNcSp451ss&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1IVUPi9gq_kRxSgnYz6-jj8opsU9WmykmnvZfg6G9CJI?upload_id=AEnB2UrydyWducEXw_I8B0v7BLeUNQNT6p98KcnWYCtqjJd6ul2U3d1T9oFhhTCFTIVFkq1oc04BKhgWkuuDZwBSDRsEmr0a2g&upload_protocol=resumable
       X-Goog-Upload-Control-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1wgFGbBtzaz66cmxbJZfjQo_G9pp-1w7RHaSNM5MrPbc?upload_id=AEnB2UoPgCl5L5iC8TJkax_SkqFVeaJjQ7o8RWm6cGQO6AZzTGCpxeySMmtHT6fY8arbkvAkBqKKBUXMPVXOtTwJy7Ap20Kl5HWOKg7uUZX67dNcSp451ss&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1IVUPi9gq_kRxSgnYz6-jj8opsU9WmykmnvZfg6G9CJI?upload_id=AEnB2UrydyWducEXw_I8B0v7BLeUNQNT6p98KcnWYCtqjJd6ul2U3d1T9oFhhTCFTIVFkq1oc04BKhgWkuuDZwBSDRsEmr0a2g&upload_protocol=resumable
       X-Goog-Upload-Chunk-Granularity:
       - '262144'
       X-Goog-Upload-Header-Vary:
       - Origin
       - X-Origin
       X-Goog-Upload-Header-X-Google-Backends:
-      - iobx6:4201
+      - iofg63:4245
       X-Goog-Upload-Header-X-Google-Session-Info:
-      - CLrLzJuGFRoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqVARKBAXlhMjkuR2xzNkJrMU0xT3lDRWRZYk5TQTNJUHZpb19UczBYWUdvcmJxOWtXWUdxVGo1b2ctWG13QWRmTF9xS1owQ2FDYzRtdXJkX2FrWTc4QUpsRVJwM3JZNXNteVJza1ZSSmdLbUZKNFhGRWZETlpoZ0d4S3hMXzFZSENpdGlPRDAEOg0xLzJNM1JHd3dWbFp-
+      - CLrLzJuGFRoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x3N0JpSU5RWTBkN1V1N0M1d091YTl3UlhPOHhnM2dsR1VnUHo4VG43M1E2NmpXeDAzaTVmdnhWOXJaLUgxTElIb05SLXVHTThJVGotT3pCUHpLNmRmYnRyLW9nTzFWSkJJVU9QTW5QdC1Bc05laFVheno5TU9JQmdiRFNRMAQ6DTEvMk0zUkd3d1ZsWn4
       X-Goog-Upload-Header-Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       X-Goog-Upload-Header-Pragma:
@@ -265,11 +266,11 @@ http_interactions:
       X-Goog-Upload-Header-Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       X-Goog-Upload-Header-Date:
-      - Thu, 18 Oct 2018 09:27:19 GMT
+      - Fri, 19 Oct 2018 07:23:43 GMT
       Content-Length:
       - '0'
       Date:
-      - Thu, 18 Oct 2018 09:27:19 GMT
+      - Fri, 19 Oct 2018 07:23:44 GMT
       Server:
       - UploadServer
       Content-Type:
@@ -280,13 +281,13 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:27:19 GMT
+  recorded_at: Fri, 19 Oct 2018 07:23:44 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/upload/drive/v3/files/1wgFGbBtzaz66cmxbJZfjQo_G9pp-1w7RHaSNM5MrPbc?upload_id=AEnB2UoPgCl5L5iC8TJkax_SkqFVeaJjQ7o8RWm6cGQO6AZzTGCpxeySMmtHT6fY8arbkvAkBqKKBUXMPVXOtTwJy7Ap20Kl5HWOKg7uUZX67dNcSp451ss&upload_protocol=resumable
+    uri: https://www.googleapis.com/upload/drive/v3/files/1IVUPi9gq_kRxSgnYz6-jj8opsU9WmykmnvZfg6G9CJI?upload_id=AEnB2UrydyWducEXw_I8B0v7BLeUNQNT6p98KcnWYCtqjJd6ul2U3d1T9oFhhTCFTIVFkq1oc04BKhgWkuuDZwBSDRsEmr0a2g&upload_protocol=resumable
     body:
       encoding: UTF-8
-      string: new file content
+      string: "Super super amazing content!\r\nHello world!"
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -295,7 +296,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:27:19 GMT
+      - Fri, 19 Oct 2018 07:23:44 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       X-Goog-Upload-Command:
@@ -310,7 +311,7 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2UoPgCl5L5iC8TJkax_SkqFVeaJjQ7o8RWm6cGQO6AZzTGCpxeySMmtHT6fY8arbkvAkBqKKBUXMPVXOtTwJy7Ap20Kl5HWOKg7uUZX67dNcSp451ss
+      - AEnB2UrydyWducEXw_I8B0v7BLeUNQNT6p98KcnWYCtqjJd6ul2U3d1T9oFhhTCFTIVFkq1oc04BKhgWkuuDZwBSDRsEmr0a2g
       X-Goog-Upload-Status:
       - final
       Vary:
@@ -325,9 +326,9 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:27:20 GMT
+      - Fri, 19 Oct 2018 07:23:45 GMT
       Content-Length:
-      - '156'
+      - '166'
       Server:
       - UploadServer
       Alt-Svc:
@@ -337,15 +338,15 @@ http_interactions:
       string: |
         {
          "kind": "drive#file",
-         "id": "1wgFGbBtzaz66cmxbJZfjQo_G9pp-1w7RHaSNM5MrPbc",
-         "name": "Test File",
+         "id": "1IVUPi9gq_kRxSgnYz6-jj8opsU9WmykmnvZfg6G9CJI",
+         "name": "A File with Content",
          "mimeType": "application/vnd.google-apps.document"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:27:20 GMT
+  recorded_at: Fri, 19 Oct 2018 07:23:45 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1wgFGbBtzaz66cmxbJZfjQo_G9pp-1w7RHaSNM5MrPbc?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1IVUPi9gq_kRxSgnYz6-jj8opsU9WmykmnvZfg6G9CJI/export?alt=media&mimeType=text/plain
     body:
       encoding: UTF-8
       string: ''
@@ -357,27 +358,27 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:27:25 GMT
+      - Fri, 19 Oct 2018 07:23:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
   response:
     status:
       code: 200
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:27:26 GMT
+      - Fri, 19 Oct 2018 07:23:45 GMT
       Date:
-      - Thu, 18 Oct 2018 09:27:26 GMT
+      - Fri, 19 Oct 2018 07:23:45 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
+      Content-Disposition:
+      - attachment
       Vary:
       - Origin
       - X-Origin
       Content-Type:
-      - application/json; charset=UTF-8
+      - text/plain
       Content-Encoding:
       - gzip
       X-Content-Type-Options:
@@ -393,95 +394,14 @@ http_interactions:
       Transfer-Encoding:
       - chunked
     body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1wgFGbBtzaz66cmxbJZfjQo_G9pp-1w7RHaSNM5MrPbc",
-         "name": "Test File",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1-ZzcnZAvbLZqr5aq7errllhTvhSr3pOt"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1wgFGbBtzaz66cmxbJZfjQo_G9pp-1w7RHaSNM5MrPbc&v=1&s=AMedNnoAAAAAW8huHQvKOMVhrtF0Gum0cjDeEer0rYge&sz=s220",
-         "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:27:26 GMT
-- request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1wgFGbBtzaz66cmxbJZfjQo_G9pp-1w7RHaSNM5MrPbc&s=AMedNnoAAAAAW8huHQvKOMVhrtF0Gum0cjDeEer0rYge&sz=s350&v=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 18 Oct 2018 09:27:26 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Expose-Headers:
-      - Content-Length
-      Etag:
-      - '"v1"'
-      Expires:
-      - Fri, 01 Jan 1990 00:00:00 GMT
-      Cache-Control:
-      - private, max-age=86400, no-transform
-      Content-Disposition:
-      - inline;filename="unnamed.png"
-      Content-Type:
-      - image/png
-      Vary:
-      - Origin
-      Access-Control-Allow-Origin:
-      - "*"
-      Timing-Allow-Origin:
-      - "*"
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Thu, 18 Oct 2018 09:27:26 GMT
-      Server:
-      - fife
-      Content-Length:
-      - '1022'
-      X-Xss-Protection:
-      - 1; mode=block
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
       encoding: ASCII-8BIT
       string: !binary |-
-        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+        77u/U3VwZXIgc3VwZXIgYW1hemluZyBjb250ZW50IQ0KSGVsbG8gd29ybGQh
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:27:26 GMT
+  recorded_at: Fri, 19 Oct 2018 07:23:45 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1-ZzcnZAvbLZqr5aq7errllhTvhSr3pOt
+    uri: https://www.googleapis.com/drive/v3/files/17f0cDVQIZYE0yaH7BnP2JuAX4YzsoMyR
     body:
       encoding: UTF-8
       string: ''
@@ -493,7 +413,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:27:26 GMT
+      - Fri, 19 Oct 2018 07:23:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -510,7 +430,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:27:26 GMT
+      - Fri, 19 Oct 2018 07:23:45 GMT
       Vary:
       - Origin
       - X-Origin
@@ -522,5 +442,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:27:26 GMT
+  recorded_at: Fri, 19 Oct 2018 07:23:45 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_content_version/1_2_1.yml
+++ b/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_content_version/1_2_1.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,49 +21,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 19:41:42 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:27:59 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:42 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:59 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        19:41:42 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:27:59 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -72,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:42 GMT
+      - Thu, 18 Oct 2018 09:27:59 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -89,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:42 GMT
+      - Thu, 18 Oct 2018 09:28:00 GMT
       Vary:
       - Origin
       - X-Origin
@@ -106,31 +103,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1EXMUVheeLMHRJw3ZpAmQbukJWbrjqqL9",
-         "name": "Test @ 2018-03-18 19:41:42 UTC",
+         "id": "1pL30V9aAey8mSF6vu5mfmuHgahnCvCJh",
+         "name": "Test @ 2018-10-18 09:27:59 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:42 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:00 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1EXMUVheeLMHRJw3ZpAmQbukJWbrjqqL9"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1pL30V9aAey8mSF6vu5mfmuHgahnCvCJh"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -139,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:42 GMT
+      - Thu, 18 Oct 2018 09:28:00 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -156,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:43 GMT
+      - Thu, 18 Oct 2018 09:28:01 GMT
       Vary:
       - Origin
       - X-Origin
@@ -173,28 +180,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "18ieiGLsZ-R4rV0XlpKZauIzyQcrWF0eiV9Sleaqr8c4",
+         "id": "1iL_4Ct_5c0dPs3OXrGcnTKxVJNgnulpWJNAr9XdW3bk",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1EXMUVheeLMHRJw3ZpAmQbukJWbrjqqL9"
+          "1pL30V9aAey8mSF6vu5mfmuHgahnCvCJh"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:43 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:01 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/18ieiGLsZ-R4rV0XlpKZauIzyQcrWF0eiV9Sleaqr8c4?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1iL_4Ct_5c0dPs3OXrGcnTKxVJNgnulpWJNAr9XdW3bk?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -206,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:43 GMT
+      - Thu, 18 Oct 2018 09:28:01 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -217,9 +234,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 19:41:43 GMT
+      - Thu, 18 Oct 2018 09:28:01 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:43 GMT
+      - Thu, 18 Oct 2018 09:28:01 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -238,28 +255,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "18ieiGLsZ-R4rV0XlpKZauIzyQcrWF0eiV9Sleaqr8c4",
+         "id": "1iL_4Ct_5c0dPs3OXrGcnTKxVJNgnulpWJNAr9XdW3bk",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1EXMUVheeLMHRJw3ZpAmQbukJWbrjqqL9"
+          "1pL30V9aAey8mSF6vu5mfmuHgahnCvCJh"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:44 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:01 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/18ieiGLsZ-R4rV0XlpKZauIzyQcrWF0eiV9Sleaqr8c4/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1iL_4Ct_5c0dPs3OXrGcnTKxVJNgnulpWJNAr9XdW3bk/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -271,7 +298,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:44 GMT
+      - Thu, 18 Oct 2018 09:28:01 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -282,9 +309,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 19:41:44 GMT
+      - Thu, 18 Oct 2018 09:28:01 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:44 GMT
+      - Thu, 18 Oct 2018 09:28:01 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -303,8 +330,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -314,13 +340,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-03-18T19:41:43.001Z"
+         "modifiedTime": "2018-10-18T09:28:00.729Z"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:44 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:01 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1EXMUVheeLMHRJw3ZpAmQbukJWbrjqqL9
+    uri: https://www.googleapis.com/drive/v3/files/1pL30V9aAey8mSF6vu5mfmuHgahnCvCJh
     body:
       encoding: UTF-8
       string: ''
@@ -332,7 +358,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:44 GMT
+      - Thu, 18 Oct 2018 09:28:01 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -349,18 +375,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:44 GMT
+      - Thu, 18 Oct 2018 09:28:02 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:44 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:02 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_content_version/1_3_1.yml
+++ b/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_content_version/1_3_1.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:27:27 GMT
+      - Fri, 19 Oct 2018 06:53:52 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,14 +53,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:27:27 GMT
+  recorded_at: Fri, 19 Oct 2018 06:53:52 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        09:27:27 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-19
+        06:53:52 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -69,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:27:27 GMT
+      - Fri, 19 Oct 2018 06:53:52 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -86,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:27:27 GMT
+      - Fri, 19 Oct 2018 06:53:53 GMT
       Vary:
       - Origin
       - X-Origin
@@ -110,8 +110,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1ACmoMmGbTEugzCRW5BvoB2EeLD4n2zlG",
-         "name": "Test @ 2018-10-18 09:27:27 UTC",
+         "id": "16xNnywLLLTdGV6lg-mfo1EwCVONsM49S",
+         "name": "Test @ 2018-10-19 06:53:52 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -131,13 +131,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:27:27 GMT
+  recorded_at: Fri, 19 Oct 2018 06:53:53 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["1ACmoMmGbTEugzCRW5BvoB2EeLD4n2zlG"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["16xNnywLLLTdGV6lg-mfo1EwCVONsM49S"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -146,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:27:27 GMT
+      - Fri, 19 Oct 2018 06:53:53 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -163,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:27:28 GMT
+      - Fri, 19 Oct 2018 06:53:55 GMT
       Vary:
       - Origin
       - X-Origin
@@ -187,12 +187,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1QkXf7sb6dgGi3jGxpdiZEJ-XND2S2RX3",
+         "id": "1EkvB0-V0L6sE_eJqhBEMMiovfiO8Tr7J0wW1nvqE3qE",
          "name": "Test File",
-         "mimeType": "application/vnd.google-apps.folder",
+         "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1ACmoMmGbTEugzCRW5BvoB2EeLD4n2zlG"
+          "16xNnywLLLTdGV6lg-mfo1EwCVONsM49S"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -208,10 +208,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:27:28 GMT
+  recorded_at: Fri, 19 Oct 2018 06:53:55 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1QkXf7sb6dgGi3jGxpdiZEJ-XND2S2RX3?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1EkvB0-V0L6sE_eJqhBEMMiovfiO8Tr7J0wW1nvqE3qE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -223,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:27:33 GMT
+      - Fri, 19 Oct 2018 06:53:55 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -234,9 +234,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:27:33 GMT
+      - Fri, 19 Oct 2018 06:53:55 GMT
       Date:
-      - Thu, 18 Oct 2018 09:27:33 GMT
+      - Fri, 19 Oct 2018 06:53:55 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -262,12 +262,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1QkXf7sb6dgGi3jGxpdiZEJ-XND2S2RX3",
+         "id": "1EkvB0-V0L6sE_eJqhBEMMiovfiO8Tr7J0wW1nvqE3qE",
          "name": "Test File",
-         "mimeType": "application/vnd.google-apps.folder",
+         "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1ACmoMmGbTEugzCRW5BvoB2EeLD4n2zlG"
+          "16xNnywLLLTdGV6lg-mfo1EwCVONsM49S"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -283,10 +283,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:27:33 GMT
+  recorded_at: Fri, 19 Oct 2018 06:53:55 GMT
 - request:
-    method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1ACmoMmGbTEugzCRW5BvoB2EeLD4n2zlG
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1EkvB0-V0L6sE_eJqhBEMMiovfiO8Tr7J0wW1nvqE3qE/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -298,7 +298,67 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:27:33 GMT
+      - Fri, 19 Oct 2018 06:53:55 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 19 Oct 2018 06:53:55 GMT
+      Date:
+      - Fri, 19 Oct 2018 06:53:55 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-19T06:53:53.649Z"
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 06:53:56 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/16xNnywLLLTdGV6lg-mfo1EwCVONsM49S
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 06:53:56 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -315,7 +375,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:27:33 GMT
+      - Fri, 19 Oct 2018 06:53:56 GMT
       Vary:
       - Origin
       - X-Origin
@@ -327,5 +387,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:27:33 GMT
+  recorded_at: Fri, 19 Oct 2018 06:53:56 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_content_version/when_file_content_is_updated/1_2_2_1.yml
+++ b/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_content_version/when_file_content_is_updated/1_2_2_1.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,49 +21,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 19:41:44 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:28:02 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:44 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:02 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        19:41:44 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:28:02 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -72,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:44 GMT
+      - Thu, 18 Oct 2018 09:28:02 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -89,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:45 GMT
+      - Thu, 18 Oct 2018 09:28:02 GMT
       Vary:
       - Origin
       - X-Origin
@@ -106,31 +103,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "13UV2ZxitmOTqad6gHGB9hYZU1LopenYd",
-         "name": "Test @ 2018-03-18 19:41:44 UTC",
+         "id": "16VlnlXwYPTPO231sKT9HjRRi0gndqHTA",
+         "name": "Test @ 2018-10-18 09:28:02 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:45 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:03 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["13UV2ZxitmOTqad6gHGB9hYZU1LopenYd"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["16VlnlXwYPTPO231sKT9HjRRi0gndqHTA"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -139,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:45 GMT
+      - Thu, 18 Oct 2018 09:28:03 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -156,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:45 GMT
+      - Thu, 18 Oct 2018 09:28:04 GMT
       Vary:
       - Origin
       - X-Origin
@@ -173,28 +180,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "16IqS_Sx9uAei-YHyqOb7IJtkE63lJxFsz-liLXyPYlU",
+         "id": "1CEuIfIEQXG_k5mjYhab-XZQ4eheHiNfRuSmjxJ5-qy4",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "13UV2ZxitmOTqad6gHGB9hYZU1LopenYd"
+          "16VlnlXwYPTPO231sKT9HjRRi0gndqHTA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:46 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:04 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/upload/drive/v3/files/16IqS_Sx9uAei-YHyqOb7IJtkE63lJxFsz-liLXyPYlU
+    uri: https://www.googleapis.com/upload/drive/v3/files/1CEuIfIEQXG_k5mjYhab-XZQ4eheHiNfRuSmjxJ5-qy4
     body:
       encoding: UTF-8
       string: ''
@@ -206,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:46 GMT
+      - Thu, 18 Oct 2018 09:28:04 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       X-Goog-Upload-Protocol:
@@ -225,22 +242,22 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2UpLuYoi2A9DMp6KMqOeqXgBzV-foGR6wuAl8rZo-dc-DljPuepEAtTCzYVGjBF3hJHUbd1LPdyktM9voWK_10mtT5vKFg
+      - AEnB2UrKNz8hr_8sYK0aZ78-YWO-z_RveEIBbKROn2jVFcsOGryM4Uy4hrqNczH1GVuy410QVMDmQZOqJ6h1ubffAqWjb-jqikPB-SNw0ujQeAyo9s6kD2s
       X-Goog-Upload-Status:
       - active
       X-Goog-Upload-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/16IqS_Sx9uAei-YHyqOb7IJtkE63lJxFsz-liLXyPYlU?upload_id=AEnB2UpLuYoi2A9DMp6KMqOeqXgBzV-foGR6wuAl8rZo-dc-DljPuepEAtTCzYVGjBF3hJHUbd1LPdyktM9voWK_10mtT5vKFg&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1CEuIfIEQXG_k5mjYhab-XZQ4eheHiNfRuSmjxJ5-qy4?upload_id=AEnB2UrKNz8hr_8sYK0aZ78-YWO-z_RveEIBbKROn2jVFcsOGryM4Uy4hrqNczH1GVuy410QVMDmQZOqJ6h1ubffAqWjb-jqikPB-SNw0ujQeAyo9s6kD2s&upload_protocol=resumable
       X-Goog-Upload-Control-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/16IqS_Sx9uAei-YHyqOb7IJtkE63lJxFsz-liLXyPYlU?upload_id=AEnB2UpLuYoi2A9DMp6KMqOeqXgBzV-foGR6wuAl8rZo-dc-DljPuepEAtTCzYVGjBF3hJHUbd1LPdyktM9voWK_10mtT5vKFg&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1CEuIfIEQXG_k5mjYhab-XZQ4eheHiNfRuSmjxJ5-qy4?upload_id=AEnB2UrKNz8hr_8sYK0aZ78-YWO-z_RveEIBbKROn2jVFcsOGryM4Uy4hrqNczH1GVuy410QVMDmQZOqJ6h1ubffAqWjb-jqikPB-SNw0ujQeAyo9s6kD2s&upload_protocol=resumable
       X-Goog-Upload-Chunk-Granularity:
       - '262144'
       X-Goog-Upload-Header-Vary:
       - Origin
       - X-Origin
       X-Goog-Upload-Header-X-Google-Backends:
-      - ioca1:4582
+      - iokl26:4461
       X-Goog-Upload-Header-X-Google-Session-Info:
-      - CLrLzJuGFRoCGAY6bwoPZHJpdmUtcm9zeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqYARKEAXlhMjkuR2wyQ0JjWmNIWXRma0Q0SlY5bU5jNWludHRiQUJ0Rnc1dmI1RFhUYjMzWXlZRDlfbExMbWQxWTdmT1NtZDlwZG9rYksxdEpIN3dNM0VmZVZlRnp0M2JycVBiQ250N0QzSlhzVTRBNFZRME9EakhHTkE5Vjh3UmJBZ0hYU0c5dzAEOg0xLzdZYTRzRm02VnZ-
+      - CLrLzJuGFRoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqVARKBAXlhMjkuR2xzNkJtNnM2RWxvNDdMWWdVeWxkcFVTaUx1MnQtWFhxZEgzN0M4c1FnakFEWk5BVXRfNTlOeEpJUVpocjZuLWhWVm5kcU9vdHVMaTRxd2pNdjZYR0E2S0tuM1FldjJ4SmV1R1JMWDJqMFJoaG5fQVBIcHlOQ3dzRE0wUjAEOg0xLzJNM1JHd3dWbFp-
       X-Goog-Upload-Header-Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       X-Goog-Upload-Header-Pragma:
@@ -248,26 +265,25 @@ http_interactions:
       X-Goog-Upload-Header-Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       X-Goog-Upload-Header-Date:
-      - Sun, 18 Mar 2018 19:41:46 GMT
+      - Thu, 18 Oct 2018 09:28:04 GMT
       Content-Length:
       - '0'
       Date:
-      - Sun, 18 Mar 2018 19:41:46 GMT
+      - Thu, 18 Oct 2018 09:28:04 GMT
       Server:
       - UploadServer
       Content-Type:
       - text/html; charset=UTF-8
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:46 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:04 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/upload/drive/v3/files/16IqS_Sx9uAei-YHyqOb7IJtkE63lJxFsz-liLXyPYlU?upload_id=AEnB2UpLuYoi2A9DMp6KMqOeqXgBzV-foGR6wuAl8rZo-dc-DljPuepEAtTCzYVGjBF3hJHUbd1LPdyktM9voWK_10mtT5vKFg&upload_protocol=resumable
+    uri: https://www.googleapis.com/upload/drive/v3/files/1CEuIfIEQXG_k5mjYhab-XZQ4eheHiNfRuSmjxJ5-qy4?upload_id=AEnB2UrKNz8hr_8sYK0aZ78-YWO-z_RveEIBbKROn2jVFcsOGryM4Uy4hrqNczH1GVuy410QVMDmQZOqJ6h1ubffAqWjb-jqikPB-SNw0ujQeAyo9s6kD2s&upload_protocol=resumable
     body:
       encoding: UTF-8
       string: new file content
@@ -279,7 +295,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:46 GMT
+      - Thu, 18 Oct 2018 09:28:04 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       X-Goog-Upload-Command:
@@ -294,7 +310,7 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2UpLuYoi2A9DMp6KMqOeqXgBzV-foGR6wuAl8rZo-dc-DljPuepEAtTCzYVGjBF3hJHUbd1LPdyktM9voWK_10mtT5vKFg
+      - AEnB2UrKNz8hr_8sYK0aZ78-YWO-z_RveEIBbKROn2jVFcsOGryM4Uy4hrqNczH1GVuy410QVMDmQZOqJ6h1ubffAqWjb-jqikPB-SNw0ujQeAyo9s6kD2s
       X-Goog-Upload-Status:
       - final
       Vary:
@@ -309,28 +325,27 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:47 GMT
+      - Thu, 18 Oct 2018 09:28:05 GMT
       Content-Length:
       - '156'
       Server:
       - UploadServer
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: |
         {
          "kind": "drive#file",
-         "id": "16IqS_Sx9uAei-YHyqOb7IJtkE63lJxFsz-liLXyPYlU",
+         "id": "1CEuIfIEQXG_k5mjYhab-XZQ4eheHiNfRuSmjxJ5-qy4",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:47 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:05 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/16IqS_Sx9uAei-YHyqOb7IJtkE63lJxFsz-liLXyPYlU?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1CEuIfIEQXG_k5mjYhab-XZQ4eheHiNfRuSmjxJ5-qy4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -342,7 +357,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:47 GMT
+      - Thu, 18 Oct 2018 09:28:05 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -353,9 +368,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 19:41:47 GMT
+      - Thu, 18 Oct 2018 09:28:05 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:47 GMT
+      - Thu, 18 Oct 2018 09:28:05 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -374,28 +389,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "16IqS_Sx9uAei-YHyqOb7IJtkE63lJxFsz-liLXyPYlU",
+         "id": "1CEuIfIEQXG_k5mjYhab-XZQ4eheHiNfRuSmjxJ5-qy4",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "13UV2ZxitmOTqad6gHGB9hYZU1LopenYd"
+          "16VlnlXwYPTPO231sKT9HjRRi0gndqHTA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:47 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:05 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/16IqS_Sx9uAei-YHyqOb7IJtkE63lJxFsz-liLXyPYlU/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1CEuIfIEQXG_k5mjYhab-XZQ4eheHiNfRuSmjxJ5-qy4/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -407,7 +432,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:47 GMT
+      - Thu, 18 Oct 2018 09:28:05 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -418,9 +443,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 19:41:47 GMT
+      - Thu, 18 Oct 2018 09:28:05 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:47 GMT
+      - Thu, 18 Oct 2018 09:28:05 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -439,8 +464,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -450,13 +474,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "3",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-03-18T19:41:46.998Z"
+         "modifiedTime": "2018-10-18T09:28:04.840Z"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:47 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:05 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/13UV2ZxitmOTqad6gHGB9hYZU1LopenYd
+    uri: https://www.googleapis.com/drive/v3/files/16VlnlXwYPTPO231sKT9HjRRi0gndqHTA
     body:
       encoding: UTF-8
       string: ''
@@ -468,7 +492,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:47 GMT
+      - Thu, 18 Oct 2018 09:28:05 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -485,18 +509,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:48 GMT
+      - Thu, 18 Oct 2018 09:28:05 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:48 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:05 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_content_version/when_file_content_is_updated/1_3_2_1.yml
+++ b/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_content_version/when_file_content_is_updated/1_3_2_1.yml
@@ -1,0 +1,526 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://www.googleapis.com/oauth2/v4/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR TRACKING ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.14.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Fri, 19 Oct 2018 06:53:56 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 06:53:56 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-19
+        06:53:56 UTC","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 06:53:56 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 06:53:57 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "10v2O--5pECSwXO7HZBJdWd5oy8U4Da04",
+         "name": "Test @ 2018-10-19 06:53:56 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 06:53:57 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["10v2O--5pECSwXO7HZBJdWd5oy8U4Da04"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 06:53:57 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 06:53:59 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1GY0zKhzYohYhp2wc3e9saVrkqoG9ghnriwJ4SEHI8E8",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "10v2O--5pECSwXO7HZBJdWd5oy8U4Da04"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 06:53:59 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/upload/drive/v3/files/1GY0zKhzYohYhp2wc3e9saVrkqoG9ghnriwJ4SEHI8E8
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 06:53:59 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      X-Goog-Upload-Protocol:
+      - resumable
+      X-Goog-Upload-Command:
+      - start
+      X-Goog-Upload-Header-Content-Length:
+      - '16'
+      X-Goog-Upload-Header-Content-Type:
+      - application/octet-stream
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Guploader-Uploadid:
+      - AEnB2UqKc6PUn-3iV2GUmi4jhop-jOKOmgapeVR6df5TnPkvTOC8qYM8HZXXfAmlNwTeU8vS6DRRUcn7o_WTsEVvbCAVlSuxDQ
+      X-Goog-Upload-Status:
+      - active
+      X-Goog-Upload-Url:
+      - https://www.googleapis.com/upload/drive/v3/files/1GY0zKhzYohYhp2wc3e9saVrkqoG9ghnriwJ4SEHI8E8?upload_id=AEnB2UqKc6PUn-3iV2GUmi4jhop-jOKOmgapeVR6df5TnPkvTOC8qYM8HZXXfAmlNwTeU8vS6DRRUcn7o_WTsEVvbCAVlSuxDQ&upload_protocol=resumable
+      X-Goog-Upload-Control-Url:
+      - https://www.googleapis.com/upload/drive/v3/files/1GY0zKhzYohYhp2wc3e9saVrkqoG9ghnriwJ4SEHI8E8?upload_id=AEnB2UqKc6PUn-3iV2GUmi4jhop-jOKOmgapeVR6df5TnPkvTOC8qYM8HZXXfAmlNwTeU8vS6DRRUcn7o_WTsEVvbCAVlSuxDQ&upload_protocol=resumable
+      X-Goog-Upload-Chunk-Granularity:
+      - '262144'
+      X-Goog-Upload-Header-Vary:
+      - Origin
+      - X-Origin
+      X-Goog-Upload-Header-X-Google-Backends:
+      - iofo123:4357
+      X-Goog-Upload-Header-X-Google-Session-Info:
+      - CLrLzJuGFRoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x3N0JpY2l1Z1VKRTBzQzRvbjRYVzlHNnFjVUdVTnNISmJHN2NzQmhxTW9wbU0yTTQtdE55Skd2VUNoSDZSVExHckdjbExqVS1JT0EwOTVJeWJOemdSNTl3Zk90MWpJYXQ4bHpCTkpVcG42bl9OaXY1bHpRakxEaTV1X1J3MAQ6DTEvMk0zUkd3d1ZsWn4
+      X-Goog-Upload-Header-Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      X-Goog-Upload-Header-Pragma:
+      - no-cache
+      X-Goog-Upload-Header-Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      X-Goog-Upload-Header-Date:
+      - Fri, 19 Oct 2018 06:53:59 GMT
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 19 Oct 2018 06:53:59 GMT
+      Server:
+      - UploadServer
+      Content-Type:
+      - text/html; charset=UTF-8
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 06:54:00 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/upload/drive/v3/files/1GY0zKhzYohYhp2wc3e9saVrkqoG9ghnriwJ4SEHI8E8?upload_id=AEnB2UqKc6PUn-3iV2GUmi4jhop-jOKOmgapeVR6df5TnPkvTOC8qYM8HZXXfAmlNwTeU8vS6DRRUcn7o_WTsEVvbCAVlSuxDQ&upload_protocol=resumable
+    body:
+      encoding: UTF-8
+      string: new file content
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 06:54:00 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      X-Goog-Upload-Command:
+      - upload, finalize
+      X-Goog-Upload-Offset:
+      - '0'
+      Content-Type:
+      - application/octet-stream
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Guploader-Uploadid:
+      - AEnB2UqKc6PUn-3iV2GUmi4jhop-jOKOmgapeVR6df5TnPkvTOC8qYM8HZXXfAmlNwTeU8vS6DRRUcn7o_WTsEVvbCAVlSuxDQ
+      X-Goog-Upload-Status:
+      - final
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 06:54:01 GMT
+      Content-Length:
+      - '156'
+      Server:
+      - UploadServer
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#file",
+         "id": "1GY0zKhzYohYhp2wc3e9saVrkqoG9ghnriwJ4SEHI8E8",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document"
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 06:54:01 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1GY0zKhzYohYhp2wc3e9saVrkqoG9ghnriwJ4SEHI8E8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 06:54:01 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 19 Oct 2018 06:54:01 GMT
+      Date:
+      - Fri, 19 Oct 2018 06:54:01 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1GY0zKhzYohYhp2wc3e9saVrkqoG9ghnriwJ4SEHI8E8",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "10v2O--5pECSwXO7HZBJdWd5oy8U4Da04"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1GY0zKhzYohYhp2wc3e9saVrkqoG9ghnriwJ4SEHI8E8&v=1&s=AMedNnoAAAAAW8mbqc1N3qqzN-GHAfGPydr0pJoTw83u&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 06:54:01 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1GY0zKhzYohYhp2wc3e9saVrkqoG9ghnriwJ4SEHI8E8/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 06:54:01 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 19 Oct 2018 06:54:01 GMT
+      Date:
+      - Fri, 19 Oct 2018 06:54:01 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "3",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-19T06:54:00.357Z"
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 06:54:01 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/10v2O--5pECSwXO7HZBJdWd5oy8U4Da04
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 06:54:01 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 06:54:02 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 06:54:02 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_content_version/when_file_is_folder/1_2_3_1.yml
+++ b/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_content_version/when_file_is_folder/1_2_3_1.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,49 +21,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 19:41:48 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:28:06 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:48 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:06 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        19:41:48 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:28:06 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -72,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:48 GMT
+      - Thu, 18 Oct 2018 09:28:06 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -89,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:48 GMT
+      - Thu, 18 Oct 2018 09:28:06 GMT
       Vary:
       - Origin
       - X-Origin
@@ -106,31 +103,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1rnNxZNnRn36fDNTBNwnSlb_igrHdmEhp",
-         "name": "Test @ 2018-03-18 19:41:48 UTC",
+         "id": "19v4JJRT9r1kLIUe-QRU8Cu64yT0RFReH",
+         "name": "Test @ 2018-10-18 09:28:06 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:48 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:06 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["1rnNxZNnRn36fDNTBNwnSlb_igrHdmEhp"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["19v4JJRT9r1kLIUe-QRU8Cu64yT0RFReH"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -139,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:48 GMT
+      - Thu, 18 Oct 2018 09:28:06 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -156,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:49 GMT
+      - Thu, 18 Oct 2018 09:28:07 GMT
       Vary:
       - Origin
       - X-Origin
@@ -173,28 +180,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1Uu7lvR-ME6Y55v31h6vhND9BnTtx3MwS",
+         "id": "1rqsGhmS56KuxH11f1mVfcILKNopU2S1U",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1rnNxZNnRn36fDNTBNwnSlb_igrHdmEhp"
+          "19v4JJRT9r1kLIUe-QRU8Cu64yT0RFReH"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:49 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:07 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Uu7lvR-ME6Y55v31h6vhND9BnTtx3MwS?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1rqsGhmS56KuxH11f1mVfcILKNopU2S1U?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -206,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:49 GMT
+      - Thu, 18 Oct 2018 09:28:07 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -217,9 +234,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 19:41:49 GMT
+      - Thu, 18 Oct 2018 09:28:07 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:49 GMT
+      - Thu, 18 Oct 2018 09:28:07 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -238,28 +255,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1Uu7lvR-ME6Y55v31h6vhND9BnTtx3MwS",
+         "id": "1rqsGhmS56KuxH11f1mVfcILKNopU2S1U",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1rnNxZNnRn36fDNTBNwnSlb_igrHdmEhp"
+          "19v4JJRT9r1kLIUe-QRU8Cu64yT0RFReH"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:49 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:07 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Uu7lvR-ME6Y55v31h6vhND9BnTtx3MwS/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1rqsGhmS56KuxH11f1mVfcILKNopU2S1U/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -271,7 +298,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:49 GMT
+      - Thu, 18 Oct 2018 09:28:07 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -289,9 +316,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 19:41:49 GMT
+      - Thu, 18 Oct 2018 09:28:07 GMT
       Expires:
-      - Sun, 18 Mar 2018 19:41:49 GMT
+      - Thu, 18 Oct 2018 09:28:07 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -303,8 +330,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -324,10 +350,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:49 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:07 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1rnNxZNnRn36fDNTBNwnSlb_igrHdmEhp
+    uri: https://www.googleapis.com/drive/v3/files/19v4JJRT9r1kLIUe-QRU8Cu64yT0RFReH
     body:
       encoding: UTF-8
       string: ''
@@ -339,7 +365,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:49 GMT
+      - Thu, 18 Oct 2018 09:28:07 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -356,18 +382,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:49 GMT
+      - Thu, 18 Oct 2018 09:28:08 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:49 GMT
+  recorded_at: Thu, 18 Oct 2018 09:28:08 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_content_version/when_file_is_folder/1_3_3_1.yml
+++ b/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_content_version/when_file_is_folder/1_3_3_1.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:27:33 GMT
+      - Fri, 19 Oct 2018 06:54:02 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,14 +53,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:27:33 GMT
+  recorded_at: Fri, 19 Oct 2018 06:54:02 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        09:27:33 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-19
+        06:54:02 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -69,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:27:33 GMT
+      - Fri, 19 Oct 2018 06:54:02 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -86,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:27:34 GMT
+      - Fri, 19 Oct 2018 06:54:03 GMT
       Vary:
       - Origin
       - X-Origin
@@ -110,8 +110,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1rUz00Po8obzzMndAWke-N1yO3sTPMVQP",
-         "name": "Test @ 2018-10-18 09:27:33 UTC",
+         "id": "1-eP3aSu1NmBIwBsTfMN58DokH5ZR9h-A",
+         "name": "Test @ 2018-10-19 06:54:02 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -131,13 +131,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:27:34 GMT
+  recorded_at: Fri, 19 Oct 2018 06:54:03 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["1rUz00Po8obzzMndAWke-N1yO3sTPMVQP"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["1-eP3aSu1NmBIwBsTfMN58DokH5ZR9h-A"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -146,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:27:34 GMT
+      - Fri, 19 Oct 2018 06:54:03 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -163,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:27:34 GMT
+      - Fri, 19 Oct 2018 06:54:04 GMT
       Vary:
       - Origin
       - X-Origin
@@ -187,12 +187,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1zD7K4SNUBdq8EzfmBie3lRAyq0dwRQLG",
+         "id": "1EnKCcc6yqhpIk215wv3Juz9p6EZp6W5r",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1rUz00Po8obzzMndAWke-N1yO3sTPMVQP"
+          "1-eP3aSu1NmBIwBsTfMN58DokH5ZR9h-A"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -208,10 +208,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:27:34 GMT
+  recorded_at: Fri, 19 Oct 2018 06:54:04 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1zD7K4SNUBdq8EzfmBie3lRAyq0dwRQLG?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1EnKCcc6yqhpIk215wv3Juz9p6EZp6W5r?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -223,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:27:39 GMT
+      - Fri, 19 Oct 2018 06:54:04 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -234,9 +234,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:27:39 GMT
+      - Fri, 19 Oct 2018 06:54:04 GMT
       Date:
-      - Thu, 18 Oct 2018 09:27:39 GMT
+      - Fri, 19 Oct 2018 06:54:04 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -262,12 +262,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1zD7K4SNUBdq8EzfmBie3lRAyq0dwRQLG",
+         "id": "1EnKCcc6yqhpIk215wv3Juz9p6EZp6W5r",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1rUz00Po8obzzMndAWke-N1yO3sTPMVQP"
+          "1-eP3aSu1NmBIwBsTfMN58DokH5ZR9h-A"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -283,10 +283,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:27:39 GMT
+  recorded_at: Fri, 19 Oct 2018 06:54:04 GMT
 - request:
-    method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1rUz00Po8obzzMndAWke-N1yO3sTPMVQP
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1EnKCcc6yqhpIk215wv3Juz9p6EZp6W5r/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -298,7 +298,74 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:27:39 GMT
+      - Fri, 19 Oct 2018 06:54:04 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Fri, 19 Oct 2018 06:54:04 GMT
+      Expires:
+      - Fri, 19 Oct 2018 06:54:04 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 06:54:04 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1-eP3aSu1NmBIwBsTfMN58DokH5ZR9h-A
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 06:54:04 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -315,7 +382,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:27:40 GMT
+      - Fri, 19 Oct 2018 06:54:05 GMT
       Vary:
       - Origin
       - X-Origin
@@ -327,5 +394,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:27:40 GMT
+  recorded_at: Fri, 19 Oct 2018 06:54:05 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_create_name_parent_id_mime_type_api_connection_nil_/creates_a_file_named_Test_File_.yml
+++ b/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_create_name_parent_id_mime_type_api_connection_nil_/creates_a_file_named_Test_File_.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,49 +21,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 19:41:33 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:27:51 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:33 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:51 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        19:41:33 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:27:51 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -72,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:33 GMT
+      - Thu, 18 Oct 2018 09:27:51 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -89,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:33 GMT
+      - Thu, 18 Oct 2018 09:27:51 GMT
       Vary:
       - Origin
       - X-Origin
@@ -106,31 +103,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1hPgpeL14SB_Lq6goiQoo-VhPUwvf-RUW",
-         "name": "Test @ 2018-03-18 19:41:33 UTC",
+         "id": "1MmfEB-pxOIWO4j_EheqEvQcWVEYz04VB",
+         "name": "Test @ 2018-10-18 09:27:51 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:33 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:51 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1hPgpeL14SB_Lq6goiQoo-VhPUwvf-RUW"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1MmfEB-pxOIWO4j_EheqEvQcWVEYz04VB"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -139,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:33 GMT
+      - Thu, 18 Oct 2018 09:27:51 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -156,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:34 GMT
+      - Thu, 18 Oct 2018 09:27:52 GMT
       Vary:
       - Origin
       - X-Origin
@@ -173,28 +180,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1GQHD_PqsJ07VRlfOEBrsoa61aJizzkVwIh6CEOFUi0A",
+         "id": "1-eBpx-4XRhoDma-pRKjj-9rgWgGDUuNe57mDm9LcIFE",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1hPgpeL14SB_Lq6goiQoo-VhPUwvf-RUW"
+          "1MmfEB-pxOIWO4j_EheqEvQcWVEYz04VB"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:34 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:52 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1GQHD_PqsJ07VRlfOEBrsoa61aJizzkVwIh6CEOFUi0A?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1-eBpx-4XRhoDma-pRKjj-9rgWgGDUuNe57mDm9LcIFE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -206,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:34 GMT
+      - Thu, 18 Oct 2018 09:27:52 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -217,9 +234,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 19:41:34 GMT
+      - Thu, 18 Oct 2018 09:27:53 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:34 GMT
+      - Thu, 18 Oct 2018 09:27:53 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -238,28 +255,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1GQHD_PqsJ07VRlfOEBrsoa61aJizzkVwIh6CEOFUi0A",
+         "id": "1-eBpx-4XRhoDma-pRKjj-9rgWgGDUuNe57mDm9LcIFE",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1hPgpeL14SB_Lq6goiQoo-VhPUwvf-RUW"
+          "1MmfEB-pxOIWO4j_EheqEvQcWVEYz04VB"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:34 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:53 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1hPgpeL14SB_Lq6goiQoo-VhPUwvf-RUW
+    uri: https://www.googleapis.com/drive/v3/files/1MmfEB-pxOIWO4j_EheqEvQcWVEYz04VB
     body:
       encoding: UTF-8
       string: ''
@@ -271,7 +298,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:34 GMT
+      - Thu, 18 Oct 2018 09:27:53 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -288,18 +315,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:34 GMT
+      - Thu, 18 Oct 2018 09:27:53 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:34 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:53 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_create_name_parent_id_mime_type_api_connection_nil_/restricts_access_to_creator.yml
+++ b/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_create_name_parent_id_mime_type_api_connection_nil_/restricts_access_to_creator.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 18 Oct 2018 09:27:49 GMT
+      - Thu, 18 Oct 2018 09:31:43 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,14 +53,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:27:49 GMT
+  recorded_at: Thu, 18 Oct 2018 09:31:43 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
-        09:27:49 UTC","parents":["root"]}'
+        09:31:43 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -69,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:27:49 GMT
+      - Thu, 18 Oct 2018 09:31:43 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -86,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:27:49 GMT
+      - Thu, 18 Oct 2018 09:31:44 GMT
       Vary:
       - Origin
       - X-Origin
@@ -110,8 +110,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1o4KkDZvWdel_yPllXnltdUdJSNJHay-9",
-         "name": "Test @ 2018-10-18 09:27:49 UTC",
+         "id": "1GpWlEoYMn-2OpUS5O2u9MU3AAZ2F0x4s",
+         "name": "Test @ 2018-10-18 09:31:43 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -131,13 +131,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:27:49 GMT
+  recorded_at: Thu, 18 Oct 2018 09:31:44 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1o4KkDZvWdel_yPllXnltdUdJSNJHay-9"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1GpWlEoYMn-2OpUS5O2u9MU3AAZ2F0x4s"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -146,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:27:49 GMT
+      - Thu, 18 Oct 2018 09:31:44 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -163,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:27:50 GMT
+      - Thu, 18 Oct 2018 09:31:45 GMT
       Vary:
       - Origin
       - X-Origin
@@ -187,12 +187,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1Q4yMNq1J-iTO6TfoU53Psduqr5vLKtN8vIam006HhXI",
+         "id": "15hhoR3oar032u8sJ-7oQmD-i9YFna0Q2fKNc_Wqcz_A",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1o4KkDZvWdel_yPllXnltdUdJSNJHay-9"
+          "1GpWlEoYMn-2OpUS5O2u9MU3AAZ2F0x4s"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -208,10 +208,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:27:50 GMT
+  recorded_at: Thu, 18 Oct 2018 09:31:45 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Q4yMNq1J-iTO6TfoU53Psduqr5vLKtN8vIam006HhXI?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/15hhoR3oar032u8sJ-7oQmD-i9YFna0Q2fKNc_Wqcz_A?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -223,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:27:50 GMT
+      - Thu, 18 Oct 2018 09:31:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -234,9 +234,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 18 Oct 2018 09:27:50 GMT
+      - Thu, 18 Oct 2018 09:31:45 GMT
       Date:
-      - Thu, 18 Oct 2018 09:27:50 GMT
+      - Thu, 18 Oct 2018 09:31:45 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -262,12 +262,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1Q4yMNq1J-iTO6TfoU53Psduqr5vLKtN8vIam006HhXI",
+         "id": "15hhoR3oar032u8sJ-7oQmD-i9YFna0Q2fKNc_Wqcz_A",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1o4KkDZvWdel_yPllXnltdUdJSNJHay-9"
+          "1GpWlEoYMn-2OpUS5O2u9MU3AAZ2F0x4s"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -283,10 +283,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:27:50 GMT
+  recorded_at: Thu, 18 Oct 2018 09:31:45 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1o4KkDZvWdel_yPllXnltdUdJSNJHay-9
+    uri: https://www.googleapis.com/drive/v3/files/1GpWlEoYMn-2OpUS5O2u9MU3AAZ2F0x4s
     body:
       encoding: UTF-8
       string: ''
@@ -298,7 +298,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 18 Oct 2018 09:27:50 GMT
+      - Thu, 18 Oct 2018 09:31:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -315,7 +315,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 18 Oct 2018 09:27:50 GMT
+      - Thu, 18 Oct 2018 09:31:45 GMT
       Vary:
       - Origin
       - X-Origin
@@ -327,5 +327,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 18 Oct 2018 09:27:51 GMT
+  recorded_at: Thu, 18 Oct 2018 09:31:45 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_create_name_parent_id_mime_type_api_connection_nil_/sets_mime_type_to_document.yml
+++ b/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_create_name_parent_id_mime_type_api_connection_nil_/sets_mime_type_to_document.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,49 +21,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 19:41:35 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:27:46 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:35 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:46 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        19:41:35 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:27:46 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -72,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:35 GMT
+      - Thu, 18 Oct 2018 09:27:46 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -89,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:35 GMT
+      - Thu, 18 Oct 2018 09:27:47 GMT
       Vary:
       - Origin
       - X-Origin
@@ -106,31 +103,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1PGtIvE4FgdAJDHL6J0XTW2h6_Xezw6mC",
-         "name": "Test @ 2018-03-18 19:41:35 UTC",
+         "id": "1EuuUs-knCZR-ZToxecTDzgRPpWCByUh6",
+         "name": "Test @ 2018-10-18 09:27:46 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:35 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:47 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1PGtIvE4FgdAJDHL6J0XTW2h6_Xezw6mC"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1EuuUs-knCZR-ZToxecTDzgRPpWCByUh6"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -139,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:35 GMT
+      - Thu, 18 Oct 2018 09:27:47 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -156,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:36 GMT
+      - Thu, 18 Oct 2018 09:27:48 GMT
       Vary:
       - Origin
       - X-Origin
@@ -173,28 +180,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1kJqDe_T2JLFTq35_ltupkMrjfa5klFHuJXAbu75whY4",
+         "id": "1GFZlfsVjDx28cOsoiKng6j4FooiSg2ek28e7KVhZtOA",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1PGtIvE4FgdAJDHL6J0XTW2h6_Xezw6mC"
+          "1EuuUs-knCZR-ZToxecTDzgRPpWCByUh6"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:36 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:48 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1kJqDe_T2JLFTq35_ltupkMrjfa5klFHuJXAbu75whY4?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1GFZlfsVjDx28cOsoiKng6j4FooiSg2ek28e7KVhZtOA?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -206,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:36 GMT
+      - Thu, 18 Oct 2018 09:27:48 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -217,9 +234,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 19:41:37 GMT
+      - Thu, 18 Oct 2018 09:27:48 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:37 GMT
+      - Thu, 18 Oct 2018 09:27:48 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -238,28 +255,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1kJqDe_T2JLFTq35_ltupkMrjfa5klFHuJXAbu75whY4",
+         "id": "1GFZlfsVjDx28cOsoiKng6j4FooiSg2ek28e7KVhZtOA",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1PGtIvE4FgdAJDHL6J0XTW2h6_Xezw6mC"
+          "1EuuUs-knCZR-ZToxecTDzgRPpWCByUh6"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:37 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:48 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1PGtIvE4FgdAJDHL6J0XTW2h6_Xezw6mC
+    uri: https://www.googleapis.com/drive/v3/files/1EuuUs-knCZR-ZToxecTDzgRPpWCByUh6
     body:
       encoding: UTF-8
       string: ''
@@ -271,7 +298,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:37 GMT
+      - Thu, 18 Oct 2018 09:27:48 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -288,18 +315,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:37 GMT
+      - Thu, 18 Oct 2018 09:27:48 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:37 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:48 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_duplicate_name_parent_id_/duplicates_the_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_duplicate_name_parent_id_/duplicates_the_file.yml
@@ -1,0 +1,654 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://www.googleapis.com/oauth2/v4/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR TRACKING ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.14.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Fri, 19 Oct 2018 07:07:18 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 07:07:18 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-19
+        07:07:18 UTC","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 07:07:18 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 07:07:19 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1JOzjfW4su1NLO4rcbJ_oXtYgjyW7Wkhe",
+         "name": "Test @ 2018-10-19 07:07:18 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 07:07:19 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1JOzjfW4su1NLO4rcbJ_oXtYgjyW7Wkhe"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 07:07:19 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 07:07:21 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1jDK7n5-v-lK5Ig5BOuRm8tRbhiTBq-OEWbVPYl884kw",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1JOzjfW4su1NLO4rcbJ_oXtYgjyW7Wkhe"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 07:07:21 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/upload/drive/v3/files/1jDK7n5-v-lK5Ig5BOuRm8tRbhiTBq-OEWbVPYl884kw
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 07:07:21 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      X-Goog-Upload-Protocol:
+      - resumable
+      X-Goog-Upload-Command:
+      - start
+      X-Goog-Upload-Header-Content-Length:
+      - '22'
+      X-Goog-Upload-Header-Content-Type:
+      - application/octet-stream
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Guploader-Uploadid:
+      - AEnB2UqwveKBUcwt9-A8u1GmXCb7j8shfb9nLYHnJn71P92ME6GN-Aww9jA_xzWjw2EWHNV4fWsmYYnQZKxIM7gVbKkxXSgj5A
+      X-Goog-Upload-Status:
+      - active
+      X-Goog-Upload-Url:
+      - https://www.googleapis.com/upload/drive/v3/files/1jDK7n5-v-lK5Ig5BOuRm8tRbhiTBq-OEWbVPYl884kw?upload_id=AEnB2UqwveKBUcwt9-A8u1GmXCb7j8shfb9nLYHnJn71P92ME6GN-Aww9jA_xzWjw2EWHNV4fWsmYYnQZKxIM7gVbKkxXSgj5A&upload_protocol=resumable
+      X-Goog-Upload-Control-Url:
+      - https://www.googleapis.com/upload/drive/v3/files/1jDK7n5-v-lK5Ig5BOuRm8tRbhiTBq-OEWbVPYl884kw?upload_id=AEnB2UqwveKBUcwt9-A8u1GmXCb7j8shfb9nLYHnJn71P92ME6GN-Aww9jA_xzWjw2EWHNV4fWsmYYnQZKxIM7gVbKkxXSgj5A&upload_protocol=resumable
+      X-Goog-Upload-Chunk-Granularity:
+      - '262144'
+      X-Goog-Upload-Header-Vary:
+      - Origin
+      - X-Origin
+      X-Goog-Upload-Header-X-Google-Backends:
+      - oibh23:4039
+      X-Goog-Upload-Header-X-Google-Session-Info:
+      - CLrLzJuGFRoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x3N0JqZ2NSME9QRmxJdFJDUHNlTWQyMWlWVE5nZThJb1Jza3luQUo5UWtwSnduX3RVTnkyQy1RQnZVNHdrWU9EWklLRjBjcVlLRTZkakY5d05tMzhBcmt6ZWMwQU0zZm1nNG5kYmRnYS1NT20tQ3ZRa0VTcFUzZkRUOGRBMAQ6DTEvMk0zUkd3d1ZsWn4
+      X-Goog-Upload-Header-Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      X-Goog-Upload-Header-Pragma:
+      - no-cache
+      X-Goog-Upload-Header-Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      X-Goog-Upload-Header-Date:
+      - Fri, 19 Oct 2018 07:07:22 GMT
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 19 Oct 2018 07:07:22 GMT
+      Server:
+      - UploadServer
+      Content-Type:
+      - text/html; charset=UTF-8
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 07:07:22 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/upload/drive/v3/files/1jDK7n5-v-lK5Ig5BOuRm8tRbhiTBq-OEWbVPYl884kw?upload_id=AEnB2UqwveKBUcwt9-A8u1GmXCb7j8shfb9nLYHnJn71P92ME6GN-Aww9jA_xzWjw2EWHNV4fWsmYYnQZKxIM7gVbKkxXSgj5A&upload_protocol=resumable
+    body:
+      encoding: UTF-8
+      string: "Amazing content!\r\nYes!"
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 07:07:22 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      X-Goog-Upload-Command:
+      - upload, finalize
+      X-Goog-Upload-Offset:
+      - '0'
+      Content-Type:
+      - application/octet-stream
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Guploader-Uploadid:
+      - AEnB2UqwveKBUcwt9-A8u1GmXCb7j8shfb9nLYHnJn71P92ME6GN-Aww9jA_xzWjw2EWHNV4fWsmYYnQZKxIM7gVbKkxXSgj5A
+      X-Goog-Upload-Status:
+      - final
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 07:07:23 GMT
+      Content-Length:
+      - '156'
+      Server:
+      - UploadServer
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#file",
+         "id": "1jDK7n5-v-lK5Ig5BOuRm8tRbhiTBq-OEWbVPYl884kw",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document"
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 07:07:23 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Subfolder","parents":["1JOzjfW4su1NLO4rcbJ_oXtYgjyW7Wkhe"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 07:07:23 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 07:07:24 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1O1rJaRhxbUhBnxrwW1F8vCSIcwyPU5DF",
+         "name": "Subfolder",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "1JOzjfW4su1NLO4rcbJ_oXtYgjyW7Wkhe"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 07:07:24 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1jDK7n5-v-lK5Ig5BOuRm8tRbhiTBq-OEWbVPYl884kw/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"Duplicate","parents":["1O1rJaRhxbUhBnxrwW1F8vCSIcwyPU5DF"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 07:07:24 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 07:07:26 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "121jsoQGW3HpvEmyi_e8FOtwbeyCfsClhdJ3kY9U7V4w",
+         "name": "Duplicate",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1O1rJaRhxbUhBnxrwW1F8vCSIcwyPU5DF"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 07:07:26 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/121jsoQGW3HpvEmyi_e8FOtwbeyCfsClhdJ3kY9U7V4w/export?alt=media&mimeType=text/plain
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 07:07:26 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 19 Oct 2018 07:07:27 GMT
+      Date:
+      - Fri, 19 Oct 2018 07:07:27 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Disposition:
+      - attachment
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - text/plain
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/QW1hemluZyBjb250ZW50IQ0KWWVzIQ==
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 07:07:27 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1jDK7n5-v-lK5Ig5BOuRm8tRbhiTBq-OEWbVPYl884kw/export?alt=media&mimeType=text/plain
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 07:07:27 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 19 Oct 2018 07:07:27 GMT
+      Date:
+      - Fri, 19 Oct 2018 07:07:27 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Disposition:
+      - attachment
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - text/plain
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        77u/QW1hemluZyBjb250ZW50IQ0KWWVzIQ==
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 07:07:27 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1JOzjfW4su1NLO4rcbJ_oXtYgjyW7Wkhe
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 07:07:27 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 07:07:28 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 07:07:28 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_relocate_to_from_/relocates_file_to_subfolder.yml
+++ b/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_relocate_to_from_/relocates_file_to_subfolder.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,49 +21,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 19:43:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:27:56 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:43:15 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:56 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        19:43:15 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:27:56 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -72,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:43:15 GMT
+      - Thu, 18 Oct 2018 09:27:56 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -89,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:43:16 GMT
+      - Thu, 18 Oct 2018 09:27:56 GMT
       Vary:
       - Origin
       - X-Origin
@@ -106,31 +103,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1PdQMkoeFKxnGZKMK-qWKJ3eiQQEMj46y",
-         "name": "Test @ 2018-03-18 19:43:15 UTC",
+         "id": "1IeX6RHW99Se3GSJxQF1BnAZZIWlMMyGh",
+         "name": "Test @ 2018-10-18 09:27:56 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:43:16 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:56 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1PdQMkoeFKxnGZKMK-qWKJ3eiQQEMj46y"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1IeX6RHW99Se3GSJxQF1BnAZZIWlMMyGh"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -139,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:43:16 GMT
+      - Thu, 18 Oct 2018 09:27:56 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -156,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:43:17 GMT
+      - Thu, 18 Oct 2018 09:27:57 GMT
       Vary:
       - Origin
       - X-Origin
@@ -173,31 +180,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "14nLzMPN_DlBXCqoN9E4NUReV4XLZ-NiFX8itk_0A0BM",
+         "id": "1lA9XATHrOAEj3xxpBZWj7SRclEr88yTZVHIVqyqWc-A",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1PdQMkoeFKxnGZKMK-qWKJ3eiQQEMj46y"
+          "1IeX6RHW99Se3GSJxQF1BnAZZIWlMMyGh"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:43:17 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:57 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Subfolder","parents":["1PdQMkoeFKxnGZKMK-qWKJ3eiQQEMj46y"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Subfolder","parents":["1IeX6RHW99Se3GSJxQF1BnAZZIWlMMyGh"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -206,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:43:17 GMT
+      - Thu, 18 Oct 2018 09:27:57 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -223,7 +240,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:43:17 GMT
+      - Thu, 18 Oct 2018 09:27:58 GMT
       Vary:
       - Origin
       - X-Origin
@@ -240,28 +257,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1ZqKPWPlFWu0ZQ9Gd2WwgpnLQ0zZTWPw5",
+         "id": "1wyC6gwqV6Z67GJoHjYHc7tP5I7kW0-aE",
          "name": "Subfolder",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1PdQMkoeFKxnGZKMK-qWKJ3eiQQEMj46y"
+          "1IeX6RHW99Se3GSJxQF1BnAZZIWlMMyGh"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:43:17 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:58 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/14nLzMPN_DlBXCqoN9E4NUReV4XLZ-NiFX8itk_0A0BM?addParents=1ZqKPWPlFWu0ZQ9Gd2WwgpnLQ0zZTWPw5&fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion&removeParents=1PdQMkoeFKxnGZKMK-qWKJ3eiQQEMj46y
+    uri: https://www.googleapis.com/drive/v3/files/1lA9XATHrOAEj3xxpBZWj7SRclEr88yTZVHIVqyqWc-A?addParents=1wyC6gwqV6Z67GJoHjYHc7tP5I7kW0-aE&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1IeX6RHW99Se3GSJxQF1BnAZZIWlMMyGh
     body:
       encoding: UTF-8
       string: ''
@@ -273,7 +300,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:43:17 GMT
+      - Thu, 18 Oct 2018 09:27:58 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -290,7 +317,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:43:18 GMT
+      - Thu, 18 Oct 2018 09:27:58 GMT
       Vary:
       - Origin
       - X-Origin
@@ -307,28 +334,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "14nLzMPN_DlBXCqoN9E4NUReV4XLZ-NiFX8itk_0A0BM",
+         "id": "1lA9XATHrOAEj3xxpBZWj7SRclEr88yTZVHIVqyqWc-A",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1ZqKPWPlFWu0ZQ9Gd2WwgpnLQ0zZTWPw5"
+          "1wyC6gwqV6Z67GJoHjYHc7tP5I7kW0-aE"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:43:18 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:59 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/14nLzMPN_DlBXCqoN9E4NUReV4XLZ-NiFX8itk_0A0BM?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1lA9XATHrOAEj3xxpBZWj7SRclEr88yTZVHIVqyqWc-A?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -340,7 +377,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:43:18 GMT
+      - Thu, 18 Oct 2018 09:27:59 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -351,9 +388,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 19:43:18 GMT
+      - Thu, 18 Oct 2018 09:27:59 GMT
       Date:
-      - Sun, 18 Mar 2018 19:43:18 GMT
+      - Thu, 18 Oct 2018 09:27:59 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -372,28 +409,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "14nLzMPN_DlBXCqoN9E4NUReV4XLZ-NiFX8itk_0A0BM",
+         "id": "1lA9XATHrOAEj3xxpBZWj7SRclEr88yTZVHIVqyqWc-A",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1ZqKPWPlFWu0ZQ9Gd2WwgpnLQ0zZTWPw5"
+          "1wyC6gwqV6Z67GJoHjYHc7tP5I7kW0-aE"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:43:18 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:59 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1PdQMkoeFKxnGZKMK-qWKJ3eiQQEMj46y
+    uri: https://www.googleapis.com/drive/v3/files/1IeX6RHW99Se3GSJxQF1BnAZZIWlMMyGh
     body:
       encoding: UTF-8
       string: ''
@@ -405,7 +452,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:43:18 GMT
+      - Thu, 18 Oct 2018 09:27:59 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -422,18 +469,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:43:18 GMT
+      - Thu, 18 Oct 2018 09:27:59 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:43:18 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:59 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_rename_name_/renames_file_to_Renamed_Test_File_.yml
+++ b/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_rename_name_/renames_file_to_Renamed_Test_File_.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,49 +21,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 19:43:18 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:27:14 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:43:18 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:14 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        19:43:18 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:27:14 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -72,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:43:18 GMT
+      - Thu, 18 Oct 2018 09:27:14 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -89,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:43:19 GMT
+      - Thu, 18 Oct 2018 09:27:15 GMT
       Vary:
       - Origin
       - X-Origin
@@ -106,31 +103,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "11Q9FfA5tKwX0i3tonTTqUlkqVDtj7DdM",
-         "name": "Test @ 2018-03-18 19:43:18 UTC",
+         "id": "1a1irXyBGvLC36J2WxAZBj_g2s7LVKOun",
+         "name": "Test @ 2018-10-18 09:27:14 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:43:19 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:15 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["11Q9FfA5tKwX0i3tonTTqUlkqVDtj7DdM"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1a1irXyBGvLC36J2WxAZBj_g2s7LVKOun"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -139,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:43:19 GMT
+      - Thu, 18 Oct 2018 09:27:15 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -156,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:43:20 GMT
+      - Thu, 18 Oct 2018 09:27:16 GMT
       Vary:
       - Origin
       - X-Origin
@@ -173,28 +180,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1itaGwe73NZFV5IxOTUZHbdW-ED6fUat9dsEg4BZyjcM",
+         "id": "1WWxBZH0rJyjbYHEpGcNamUgRe2lhuWNnbkhq319E7K8",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "11Q9FfA5tKwX0i3tonTTqUlkqVDtj7DdM"
+          "1a1irXyBGvLC36J2WxAZBj_g2s7LVKOun"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:43:20 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:16 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1itaGwe73NZFV5IxOTUZHbdW-ED6fUat9dsEg4BZyjcM?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1WWxBZH0rJyjbYHEpGcNamUgRe2lhuWNnbkhq319E7K8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"name":"Renamed Test File"}'
@@ -206,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:43:20 GMT
+      - Thu, 18 Oct 2018 09:27:16 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -223,7 +240,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:43:20 GMT
+      - Thu, 18 Oct 2018 09:27:17 GMT
       Vary:
       - Origin
       - X-Origin
@@ -240,28 +257,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1itaGwe73NZFV5IxOTUZHbdW-ED6fUat9dsEg4BZyjcM",
+         "id": "1WWxBZH0rJyjbYHEpGcNamUgRe2lhuWNnbkhq319E7K8",
          "name": "Renamed Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "11Q9FfA5tKwX0i3tonTTqUlkqVDtj7DdM"
+          "1a1irXyBGvLC36J2WxAZBj_g2s7LVKOun"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:43:20 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:17 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1itaGwe73NZFV5IxOTUZHbdW-ED6fUat9dsEg4BZyjcM?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1WWxBZH0rJyjbYHEpGcNamUgRe2lhuWNnbkhq319E7K8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -273,7 +300,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:43:20 GMT
+      - Thu, 18 Oct 2018 09:27:17 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -284,9 +311,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 19:43:20 GMT
+      - Thu, 18 Oct 2018 09:27:17 GMT
       Date:
-      - Sun, 18 Mar 2018 19:43:20 GMT
+      - Thu, 18 Oct 2018 09:27:17 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -305,28 +332,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1itaGwe73NZFV5IxOTUZHbdW-ED6fUat9dsEg4BZyjcM",
+         "id": "1WWxBZH0rJyjbYHEpGcNamUgRe2lhuWNnbkhq319E7K8",
          "name": "Renamed Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "11Q9FfA5tKwX0i3tonTTqUlkqVDtj7DdM"
+          "1a1irXyBGvLC36J2WxAZBj_g2s7LVKOun"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:43:20 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:17 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/11Q9FfA5tKwX0i3tonTTqUlkqVDtj7DdM
+    uri: https://www.googleapis.com/drive/v3/files/1a1irXyBGvLC36J2WxAZBj_g2s7LVKOun
     body:
       encoding: UTF-8
       string: ''
@@ -338,7 +375,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:43:20 GMT
+      - Thu, 18 Oct 2018 09:27:17 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -355,18 +392,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:43:21 GMT
+      - Thu, 18 Oct 2018 09:27:17 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:43:21 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:17 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_thumbnail/when_file_has_content/1_5_2_1.yml
+++ b/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_thumbnail/when_file_has_content/1_5_2_1.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,49 +21,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 19:56:20 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:27:17 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:56:20 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:18 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        19:56:20 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:27:18 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -72,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:56:20 GMT
+      - Thu, 18 Oct 2018 09:27:18 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -89,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:56:20 GMT
+      - Thu, 18 Oct 2018 09:27:18 GMT
       Vary:
       - Origin
       - X-Origin
@@ -106,31 +103,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1am4aaW2q8RzF8yvNmFmKN_NYL_m5zVsn",
-         "name": "Test @ 2018-03-18 19:56:20 UTC",
+         "id": "1-ZzcnZAvbLZqr5aq7errllhTvhSr3pOt",
+         "name": "Test @ 2018-10-18 09:27:18 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:56:20 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:18 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1am4aaW2q8RzF8yvNmFmKN_NYL_m5zVsn"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1-ZzcnZAvbLZqr5aq7errllhTvhSr3pOt"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -139,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:56:20 GMT
+      - Thu, 18 Oct 2018 09:27:18 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -156,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:56:21 GMT
+      - Thu, 18 Oct 2018 09:27:19 GMT
       Vary:
       - Origin
       - X-Origin
@@ -173,28 +180,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1YSuZhvGbVE0ZetZ8-IOOO64bhFpuHYfgtto-Scnkl2k",
+         "id": "1wgFGbBtzaz66cmxbJZfjQo_G9pp-1w7RHaSNM5MrPbc",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1am4aaW2q8RzF8yvNmFmKN_NYL_m5zVsn"
+          "1-ZzcnZAvbLZqr5aq7errllhTvhSr3pOt"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:56:21 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:19 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/upload/drive/v3/files/1YSuZhvGbVE0ZetZ8-IOOO64bhFpuHYfgtto-Scnkl2k
+    uri: https://www.googleapis.com/upload/drive/v3/files/1wgFGbBtzaz66cmxbJZfjQo_G9pp-1w7RHaSNM5MrPbc
     body:
       encoding: UTF-8
       string: ''
@@ -206,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:56:21 GMT
+      - Thu, 18 Oct 2018 09:27:19 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       X-Goog-Upload-Protocol:
@@ -225,22 +242,22 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2Ura7rrRZHSoFYkzyW-8xFo7IHX1jgRp7Gend1qTEA-VnVWPmngqwXbJy8aZDmmbifeOZ8HyUZo5RGfCpL0_5DmAjZIfMg
+      - AEnB2UoPgCl5L5iC8TJkax_SkqFVeaJjQ7o8RWm6cGQO6AZzTGCpxeySMmtHT6fY8arbkvAkBqKKBUXMPVXOtTwJy7Ap20Kl5HWOKg7uUZX67dNcSp451ss
       X-Goog-Upload-Status:
       - active
       X-Goog-Upload-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1YSuZhvGbVE0ZetZ8-IOOO64bhFpuHYfgtto-Scnkl2k?upload_id=AEnB2Ura7rrRZHSoFYkzyW-8xFo7IHX1jgRp7Gend1qTEA-VnVWPmngqwXbJy8aZDmmbifeOZ8HyUZo5RGfCpL0_5DmAjZIfMg&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1wgFGbBtzaz66cmxbJZfjQo_G9pp-1w7RHaSNM5MrPbc?upload_id=AEnB2UoPgCl5L5iC8TJkax_SkqFVeaJjQ7o8RWm6cGQO6AZzTGCpxeySMmtHT6fY8arbkvAkBqKKBUXMPVXOtTwJy7Ap20Kl5HWOKg7uUZX67dNcSp451ss&upload_protocol=resumable
       X-Goog-Upload-Control-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1YSuZhvGbVE0ZetZ8-IOOO64bhFpuHYfgtto-Scnkl2k?upload_id=AEnB2Ura7rrRZHSoFYkzyW-8xFo7IHX1jgRp7Gend1qTEA-VnVWPmngqwXbJy8aZDmmbifeOZ8HyUZo5RGfCpL0_5DmAjZIfMg&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1wgFGbBtzaz66cmxbJZfjQo_G9pp-1w7RHaSNM5MrPbc?upload_id=AEnB2UoPgCl5L5iC8TJkax_SkqFVeaJjQ7o8RWm6cGQO6AZzTGCpxeySMmtHT6fY8arbkvAkBqKKBUXMPVXOtTwJy7Ap20Kl5HWOKg7uUZX67dNcSp451ss&upload_protocol=resumable
       X-Goog-Upload-Chunk-Granularity:
       - '262144'
       X-Goog-Upload-Header-Vary:
       - Origin
       - X-Origin
       X-Goog-Upload-Header-X-Google-Backends:
-      - ioom35:4566
+      - iobx6:4201
       X-Goog-Upload-Header-X-Google-Session-Info:
-      - CLrLzJuGFRoCGAY6bwoPZHJpdmUtcm9zeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqYARKEAXlhMjkuR2wyQ0JWSWdlVVpPdEZXMllEdXdmM3Zwb2F1YVVITVJ0MzBDWDRpNTJzVWRUWmk4ZGViTWJkSmltbUdpVTNsNkVhYml2UEloYzBEQmpWd0ZmWWRrdFRFbDNIVUYtWXlYeFFEZFZwTDVJMEpvZUl5LVlLMF9XcDFqcmpfQ0J2azAEOg0xLzdZYTRzRm02VnZ-
+      - CLrLzJuGFRoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqVARKBAXlhMjkuR2xzNkJrMU0xT3lDRWRZYk5TQTNJUHZpb19UczBYWUdvcmJxOWtXWUdxVGo1b2ctWG13QWRmTF9xS1owQ2FDYzRtdXJkX2FrWTc4QUpsRVJwM3JZNXNteVJza1ZSSmdLbUZKNFhGRWZETlpoZ0d4S3hMXzFZSENpdGlPRDAEOg0xLzJNM1JHd3dWbFp-
       X-Goog-Upload-Header-Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       X-Goog-Upload-Header-Pragma:
@@ -248,26 +265,25 @@ http_interactions:
       X-Goog-Upload-Header-Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       X-Goog-Upload-Header-Date:
-      - Sun, 18 Mar 2018 19:56:21 GMT
+      - Thu, 18 Oct 2018 09:27:19 GMT
       Content-Length:
       - '0'
       Date:
-      - Sun, 18 Mar 2018 19:56:22 GMT
+      - Thu, 18 Oct 2018 09:27:19 GMT
       Server:
       - UploadServer
       Content-Type:
       - text/html; charset=UTF-8
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:56:22 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:19 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/upload/drive/v3/files/1YSuZhvGbVE0ZetZ8-IOOO64bhFpuHYfgtto-Scnkl2k?upload_id=AEnB2Ura7rrRZHSoFYkzyW-8xFo7IHX1jgRp7Gend1qTEA-VnVWPmngqwXbJy8aZDmmbifeOZ8HyUZo5RGfCpL0_5DmAjZIfMg&upload_protocol=resumable
+    uri: https://www.googleapis.com/upload/drive/v3/files/1wgFGbBtzaz66cmxbJZfjQo_G9pp-1w7RHaSNM5MrPbc?upload_id=AEnB2UoPgCl5L5iC8TJkax_SkqFVeaJjQ7o8RWm6cGQO6AZzTGCpxeySMmtHT6fY8arbkvAkBqKKBUXMPVXOtTwJy7Ap20Kl5HWOKg7uUZX67dNcSp451ss&upload_protocol=resumable
     body:
       encoding: UTF-8
       string: new file content
@@ -279,7 +295,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:56:22 GMT
+      - Thu, 18 Oct 2018 09:27:19 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       X-Goog-Upload-Command:
@@ -294,7 +310,7 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2Ura7rrRZHSoFYkzyW-8xFo7IHX1jgRp7Gend1qTEA-VnVWPmngqwXbJy8aZDmmbifeOZ8HyUZo5RGfCpL0_5DmAjZIfMg
+      - AEnB2UoPgCl5L5iC8TJkax_SkqFVeaJjQ7o8RWm6cGQO6AZzTGCpxeySMmtHT6fY8arbkvAkBqKKBUXMPVXOtTwJy7Ap20Kl5HWOKg7uUZX67dNcSp451ss
       X-Goog-Upload-Status:
       - final
       Vary:
@@ -309,28 +325,27 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:56:23 GMT
+      - Thu, 18 Oct 2018 09:27:20 GMT
       Content-Length:
       - '156'
       Server:
       - UploadServer
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: |
         {
          "kind": "drive#file",
-         "id": "1YSuZhvGbVE0ZetZ8-IOOO64bhFpuHYfgtto-Scnkl2k",
+         "id": "1wgFGbBtzaz66cmxbJZfjQo_G9pp-1w7RHaSNM5MrPbc",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:56:23 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:20 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1YSuZhvGbVE0ZetZ8-IOOO64bhFpuHYfgtto-Scnkl2k?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1wgFGbBtzaz66cmxbJZfjQo_G9pp-1w7RHaSNM5MrPbc?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -342,7 +357,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:56:28 GMT
+      - Thu, 18 Oct 2018 09:27:25 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -353,9 +368,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 19:56:28 GMT
+      - Thu, 18 Oct 2018 09:27:26 GMT
       Date:
-      - Sun, 18 Mar 2018 19:56:28 GMT
+      - Thu, 18 Oct 2018 09:27:26 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -374,29 +389,39 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1YSuZhvGbVE0ZetZ8-IOOO64bhFpuHYfgtto-Scnkl2k",
+         "id": "1wgFGbBtzaz66cmxbJZfjQo_G9pp-1w7RHaSNM5MrPbc",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1am4aaW2q8RzF8yvNmFmKN_NYL_m5zVsn"
+          "1-ZzcnZAvbLZqr5aq7errllhTvhSr3pOt"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1YSuZhvGbVE0ZetZ8-IOOO64bhFpuHYfgtto-Scnkl2k&v=1&s=AMedNnoAAAAAWq7gjChV8aicW1FDy0aGk0ag7RDoOSkY&sz=s220",
-         "thumbnailVersion": "1"
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1wgFGbBtzaz66cmxbJZfjQo_G9pp-1w7RHaSNM5MrPbc&v=1&s=AMedNnoAAAAAW8huHQvKOMVhrtF0Gum0cjDeEer0rYge&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:56:28 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:26 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1YSuZhvGbVE0ZetZ8-IOOO64bhFpuHYfgtto-Scnkl2k&s=AMedNnoAAAAAWq7gjChV8aicW1FDy0aGk0ag7RDoOSkY&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1wgFGbBtzaz66cmxbJZfjQo_G9pp-1w7RHaSNM5MrPbc&s=AMedNnoAAAAAW8huHQvKOMVhrtF0Gum0cjDeEer0rYge&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -408,7 +433,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:56:28 GMT
+      - Thu, 18 Oct 2018 09:27:26 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -439,7 +464,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Sun, 18 Mar 2018 19:56:29 GMT
+      - Thu, 18 Oct 2018 09:27:26 GMT
       Server:
       - fife
       Content-Length:
@@ -447,17 +472,16 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:56:29 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:26 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1am4aaW2q8RzF8yvNmFmKN_NYL_m5zVsn
+    uri: https://www.googleapis.com/drive/v3/files/1-ZzcnZAvbLZqr5aq7errllhTvhSr3pOt
     body:
       encoding: UTF-8
       string: ''
@@ -469,7 +493,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:56:29 GMT
+      - Thu, 18 Oct 2018 09:27:26 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -486,18 +510,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:56:29 GMT
+      - Thu, 18 Oct 2018 09:27:26 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:56:29 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:26 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_thumbnail/when_file_has_content/1_7_2_1.yml
+++ b/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_thumbnail/when_file_has_content/1_7_2_1.yml
@@ -1,0 +1,526 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://www.googleapis.com/oauth2/v4/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR TRACKING ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.14.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Fri, 19 Oct 2018 08:05:45 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:05:45 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-19
+        08:05:45 UTC","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:05:45 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:05:45 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1D9-lYq_O7L5w-yZdLMxS5p5eAvmuxKHw",
+         "name": "Test @ 2018-10-19 08:05:45 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:05:46 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1D9-lYq_O7L5w-yZdLMxS5p5eAvmuxKHw"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:05:46 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:05:48 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1CiTKr7Cusvm7WxeIjeX7nsCdBsD0-NyAauBvrBOuZbA",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1D9-lYq_O7L5w-yZdLMxS5p5eAvmuxKHw"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:05:48 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/upload/drive/v3/files/1CiTKr7Cusvm7WxeIjeX7nsCdBsD0-NyAauBvrBOuZbA
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:05:48 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      X-Goog-Upload-Protocol:
+      - resumable
+      X-Goog-Upload-Command:
+      - start
+      X-Goog-Upload-Header-Content-Length:
+      - '16'
+      X-Goog-Upload-Header-Content-Type:
+      - application/octet-stream
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Guploader-Uploadid:
+      - AEnB2UomgB-N_L3Ojjl3xz8MnJ5O9ekuXw6BWMw0QU1Efe0_76LClgsTa6C3y7I88ROSvdk29F4BOqCeuYTXjgwHMF0U7JiRvQ
+      X-Goog-Upload-Status:
+      - active
+      X-Goog-Upload-Url:
+      - https://www.googleapis.com/upload/drive/v3/files/1CiTKr7Cusvm7WxeIjeX7nsCdBsD0-NyAauBvrBOuZbA?upload_id=AEnB2UomgB-N_L3Ojjl3xz8MnJ5O9ekuXw6BWMw0QU1Efe0_76LClgsTa6C3y7I88ROSvdk29F4BOqCeuYTXjgwHMF0U7JiRvQ&upload_protocol=resumable
+      X-Goog-Upload-Control-Url:
+      - https://www.googleapis.com/upload/drive/v3/files/1CiTKr7Cusvm7WxeIjeX7nsCdBsD0-NyAauBvrBOuZbA?upload_id=AEnB2UomgB-N_L3Ojjl3xz8MnJ5O9ekuXw6BWMw0QU1Efe0_76LClgsTa6C3y7I88ROSvdk29F4BOqCeuYTXjgwHMF0U7JiRvQ&upload_protocol=resumable
+      X-Goog-Upload-Chunk-Granularity:
+      - '262144'
+      X-Goog-Upload-Header-Vary:
+      - Origin
+      - X-Origin
+      X-Goog-Upload-Header-X-Google-Backends:
+      - oifv202:4236
+      X-Goog-Upload-Header-X-Google-Session-Info:
+      - CLrLzJuGFRoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x3N0JyQWtGWkF6UTVmMld0Nml1VzZwMm0xQXBadDZaNGxXdXBHSjJ6ZW9LWUdWNVFiNTB0UkxyVDJCdUNNN0VIWDZqeFQ2c0hrUWkxdXJoeUpweWI0T3JPYzdacnA1U3VBbDByZGxLLTRJeXZkZXNiYlYtd2d5Z0xVLWFnMAQ6DTEvMk0zUkd3d1ZsWn4
+      X-Goog-Upload-Header-Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      X-Goog-Upload-Header-Pragma:
+      - no-cache
+      X-Goog-Upload-Header-Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      X-Goog-Upload-Header-Date:
+      - Fri, 19 Oct 2018 08:05:48 GMT
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 19 Oct 2018 08:05:48 GMT
+      Server:
+      - UploadServer
+      Content-Type:
+      - text/html; charset=UTF-8
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:05:48 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/upload/drive/v3/files/1CiTKr7Cusvm7WxeIjeX7nsCdBsD0-NyAauBvrBOuZbA?upload_id=AEnB2UomgB-N_L3Ojjl3xz8MnJ5O9ekuXw6BWMw0QU1Efe0_76LClgsTa6C3y7I88ROSvdk29F4BOqCeuYTXjgwHMF0U7JiRvQ&upload_protocol=resumable
+    body:
+      encoding: UTF-8
+      string: new file content
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:05:48 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      X-Goog-Upload-Command:
+      - upload, finalize
+      X-Goog-Upload-Offset:
+      - '0'
+      Content-Type:
+      - application/octet-stream
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Guploader-Uploadid:
+      - AEnB2UomgB-N_L3Ojjl3xz8MnJ5O9ekuXw6BWMw0QU1Efe0_76LClgsTa6C3y7I88ROSvdk29F4BOqCeuYTXjgwHMF0U7JiRvQ
+      X-Goog-Upload-Status:
+      - final
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:05:50 GMT
+      Content-Length:
+      - '156'
+      Server:
+      - UploadServer
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#file",
+         "id": "1CiTKr7Cusvm7WxeIjeX7nsCdBsD0-NyAauBvrBOuZbA",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document"
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:05:50 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1CiTKr7Cusvm7WxeIjeX7nsCdBsD0-NyAauBvrBOuZbA?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:05:55 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 19 Oct 2018 08:05:55 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:05:55 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1CiTKr7Cusvm7WxeIjeX7nsCdBsD0-NyAauBvrBOuZbA",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1D9-lYq_O7L5w-yZdLMxS5p5eAvmuxKHw"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1CiTKr7Cusvm7WxeIjeX7nsCdBsD0-NyAauBvrBOuZbA&v=1&s=AMedNnoAAAAAW8msg5EHpw0L8mI-tMBcMcOHGrpcQl9r&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:05:55 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1CiTKr7Cusvm7WxeIjeX7nsCdBsD0-NyAauBvrBOuZbA&s=AMedNnoAAAAAW8msg5EHpw0L8mI-tMBcMcOHGrpcQl9r&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:05:55 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Fri, 19 Oct 2018 08:05:56 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:05:56 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1D9-lYq_O7L5w-yZdLMxS5p5eAvmuxKHw
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:05:56 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:05:57 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:05:57 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_thumbnail/when_file_has_no_content/1_5_1_1.yml
+++ b/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_thumbnail/when_file_has_no_content/1_5_1_1.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,49 +21,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 19:56:13 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:27:27 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:56:13 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:27 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        19:56:13 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:27:27 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -72,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:56:13 GMT
+      - Thu, 18 Oct 2018 09:27:27 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -89,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:56:14 GMT
+      - Thu, 18 Oct 2018 09:27:27 GMT
       Vary:
       - Origin
       - X-Origin
@@ -106,31 +103,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1KhPq37mLDFyt9qusbDWD9TDQ9jle3g5-",
-         "name": "Test @ 2018-03-18 19:56:13 UTC",
+         "id": "1ACmoMmGbTEugzCRW5BvoB2EeLD4n2zlG",
+         "name": "Test @ 2018-10-18 09:27:27 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:56:14 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:27 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["1KhPq37mLDFyt9qusbDWD9TDQ9jle3g5-"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["1ACmoMmGbTEugzCRW5BvoB2EeLD4n2zlG"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -139,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:56:14 GMT
+      - Thu, 18 Oct 2018 09:27:27 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -156,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:56:14 GMT
+      - Thu, 18 Oct 2018 09:27:28 GMT
       Vary:
       - Origin
       - X-Origin
@@ -173,28 +180,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1GHJxy-c9yqa8eOq5HnBzECHOYhcMl1TJ",
+         "id": "1QkXf7sb6dgGi3jGxpdiZEJ-XND2S2RX3",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1KhPq37mLDFyt9qusbDWD9TDQ9jle3g5-"
+          "1ACmoMmGbTEugzCRW5BvoB2EeLD4n2zlG"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:56:14 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:28 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1GHJxy-c9yqa8eOq5HnBzECHOYhcMl1TJ?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1QkXf7sb6dgGi3jGxpdiZEJ-XND2S2RX3?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -206,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:56:19 GMT
+      - Thu, 18 Oct 2018 09:27:33 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -217,9 +234,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 19:56:19 GMT
+      - Thu, 18 Oct 2018 09:27:33 GMT
       Date:
-      - Sun, 18 Mar 2018 19:56:19 GMT
+      - Thu, 18 Oct 2018 09:27:33 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -238,28 +255,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1GHJxy-c9yqa8eOq5HnBzECHOYhcMl1TJ",
+         "id": "1QkXf7sb6dgGi3jGxpdiZEJ-XND2S2RX3",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1KhPq37mLDFyt9qusbDWD9TDQ9jle3g5-"
+          "1ACmoMmGbTEugzCRW5BvoB2EeLD4n2zlG"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:56:19 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:33 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1KhPq37mLDFyt9qusbDWD9TDQ9jle3g5-
+    uri: https://www.googleapis.com/drive/v3/files/1ACmoMmGbTEugzCRW5BvoB2EeLD4n2zlG
     body:
       encoding: UTF-8
       string: ''
@@ -271,7 +298,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:56:19 GMT
+      - Thu, 18 Oct 2018 09:27:33 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -288,18 +315,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:56:20 GMT
+      - Thu, 18 Oct 2018 09:27:33 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:56:20 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:33 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_thumbnail/when_file_has_no_content/1_7_1_1.yml
+++ b/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_thumbnail/when_file_has_no_content/1_7_1_1.yml
@@ -1,0 +1,331 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://www.googleapis.com/oauth2/v4/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR TRACKING ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.14.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Fri, 19 Oct 2018 08:05:57 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:05:57 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-19
+        08:05:57 UTC","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:05:57 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:05:58 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1TKdom2c2cjnZyr2S8W5ewm22pj43kd--",
+         "name": "Test @ 2018-10-19 08:05:57 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:05:58 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["1TKdom2c2cjnZyr2S8W5ewm22pj43kd--"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:05:58 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:05:59 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1qGhujrnVm-Whi-RLOM22NUHslv1DJeKA",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "1TKdom2c2cjnZyr2S8W5ewm22pj43kd--"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:05:59 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1qGhujrnVm-Whi-RLOM22NUHslv1DJeKA?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:06:04 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 19 Oct 2018 08:06:04 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:06:04 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1qGhujrnVm-Whi-RLOM22NUHslv1DJeKA",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "1TKdom2c2cjnZyr2S8W5ewm22pj43kd--"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:06:04 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1TKdom2c2cjnZyr2S8W5ewm22pj43kd--
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:06:04 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:06:05 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:06:05 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_thumbnail/when_file_is_folder/1_5_3_1.yml
+++ b/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_thumbnail/when_file_is_folder/1_5_3_1.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,49 +21,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 19:56:30 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:27:33 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:56:30 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:33 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        19:56:30 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:27:33 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -72,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:56:30 GMT
+      - Thu, 18 Oct 2018 09:27:33 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -89,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:56:30 GMT
+      - Thu, 18 Oct 2018 09:27:34 GMT
       Vary:
       - Origin
       - X-Origin
@@ -106,31 +103,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1Cl2YBkPHgCjjN1BNer1IsUO_dt_hZpVd",
-         "name": "Test @ 2018-03-18 19:56:30 UTC",
+         "id": "1rUz00Po8obzzMndAWke-N1yO3sTPMVQP",
+         "name": "Test @ 2018-10-18 09:27:33 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:56:30 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:34 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["1Cl2YBkPHgCjjN1BNer1IsUO_dt_hZpVd"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["1rUz00Po8obzzMndAWke-N1yO3sTPMVQP"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -139,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:56:30 GMT
+      - Thu, 18 Oct 2018 09:27:34 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -156,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:56:31 GMT
+      - Thu, 18 Oct 2018 09:27:34 GMT
       Vary:
       - Origin
       - X-Origin
@@ -173,28 +180,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1aQGzEB1LJsZRirKaSae6R_bOOHhm7W5d",
+         "id": "1zD7K4SNUBdq8EzfmBie3lRAyq0dwRQLG",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1Cl2YBkPHgCjjN1BNer1IsUO_dt_hZpVd"
+          "1rUz00Po8obzzMndAWke-N1yO3sTPMVQP"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:56:31 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:34 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1aQGzEB1LJsZRirKaSae6R_bOOHhm7W5d?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1zD7K4SNUBdq8EzfmBie3lRAyq0dwRQLG?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -206,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:56:36 GMT
+      - Thu, 18 Oct 2018 09:27:39 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -217,9 +234,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 19:56:36 GMT
+      - Thu, 18 Oct 2018 09:27:39 GMT
       Date:
-      - Sun, 18 Mar 2018 19:56:36 GMT
+      - Thu, 18 Oct 2018 09:27:39 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -238,28 +255,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1aQGzEB1LJsZRirKaSae6R_bOOHhm7W5d",
+         "id": "1zD7K4SNUBdq8EzfmBie3lRAyq0dwRQLG",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1Cl2YBkPHgCjjN1BNer1IsUO_dt_hZpVd"
+          "1rUz00Po8obzzMndAWke-N1yO3sTPMVQP"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:56:36 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:39 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1Cl2YBkPHgCjjN1BNer1IsUO_dt_hZpVd
+    uri: https://www.googleapis.com/drive/v3/files/1rUz00Po8obzzMndAWke-N1yO3sTPMVQP
     body:
       encoding: UTF-8
       string: ''
@@ -271,7 +298,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:56:36 GMT
+      - Thu, 18 Oct 2018 09:27:39 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -288,18 +315,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:56:36 GMT
+      - Thu, 18 Oct 2018 09:27:40 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:56:36 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:40 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_thumbnail/when_file_is_folder/1_7_3_1.yml
+++ b/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/_thumbnail/when_file_is_folder/1_7_3_1.yml
@@ -1,0 +1,331 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://www.googleapis.com/oauth2/v4/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR TRACKING ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.14.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Fri, 19 Oct 2018 08:06:05 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:06:05 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-19
+        08:06:05 UTC","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:06:05 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:06:05 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1-DQdLy6YOTs-VgMj33EY9RhyjKvl3vfW",
+         "name": "Test @ 2018-10-19 08:06:05 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:06:06 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["1-DQdLy6YOTs-VgMj33EY9RhyjKvl3vfW"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:06:06 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:06:06 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1xeD_PQ2vRn3TZHdo5IAO2fAu4ejd8aMZ",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "1-DQdLy6YOTs-VgMj33EY9RhyjKvl3vfW"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:06:07 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1xeD_PQ2vRn3TZHdo5IAO2fAu4ejd8aMZ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:06:12 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 19 Oct 2018 08:06:12 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:06:12 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1xeD_PQ2vRn3TZHdo5IAO2fAu4ejd8aMZ",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "1-DQdLy6YOTs-VgMj33EY9RhyjKvl3vfW"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:06:12 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1-DQdLy6YOTs-VgMj33EY9RhyjKvl3vfW
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 19 Oct 2018 08:06:12 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 19 Oct 2018 08:06:12 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 19 Oct 2018 08:06:13 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/deleted_file/is_marked_as_deleted_and_returns_nil_values.yml
+++ b/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/deleted_file/is_marked_as_deleted_and_returns_nil_values.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,49 +21,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 19:41:58 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:27:40 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:58 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:40 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        19:41:58 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:27:40 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -72,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:58 GMT
+      - Thu, 18 Oct 2018 09:27:40 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -89,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:58 GMT
+      - Thu, 18 Oct 2018 09:27:40 GMT
       Vary:
       - Origin
       - X-Origin
@@ -106,31 +103,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1YtKnWMiJJnc2bGTtp9v0ehSg8QN8XdxJ",
-         "name": "Test @ 2018-03-18 19:41:58 UTC",
+         "id": "1K2bIJVWJfLG9PjO6eo36Cu_Jc_neyYcz",
+         "name": "Test @ 2018-10-18 09:27:40 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:58 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:40 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1YtKnWMiJJnc2bGTtp9v0ehSg8QN8XdxJ"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1K2bIJVWJfLG9PjO6eo36Cu_Jc_neyYcz"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -139,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:58 GMT
+      - Thu, 18 Oct 2018 09:27:40 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -156,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:59 GMT
+      - Thu, 18 Oct 2018 09:27:41 GMT
       Vary:
       - Origin
       - X-Origin
@@ -173,28 +180,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1D23x9ILqdppIHrmbkYpeXu64fxjRFlG7yIEgR1wCfFk",
+         "id": "1dOKcu4GSzasgViKJsGTiucNJ8EXfLu3WzVIo0tiTC68",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1YtKnWMiJJnc2bGTtp9v0ehSg8QN8XdxJ"
+          "1K2bIJVWJfLG9PjO6eo36Cu_Jc_neyYcz"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:42:00 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:42 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1D23x9ILqdppIHrmbkYpeXu64fxjRFlG7yIEgR1wCfFk
+    uri: https://www.googleapis.com/drive/v3/files/1dOKcu4GSzasgViKJsGTiucNJ8EXfLu3WzVIo0tiTC68
     body:
       encoding: UTF-8
       string: ''
@@ -206,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:42:00 GMT
+      - Thu, 18 Oct 2018 09:27:42 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -223,23 +240,22 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:42:00 GMT
+      - Thu, 18 Oct 2018 09:27:42 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:42:00 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:43 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1D23x9ILqdppIHrmbkYpeXu64fxjRFlG7yIEgR1wCfFk?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1dOKcu4GSzasgViKJsGTiucNJ8EXfLu3WzVIo0tiTC68?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -251,7 +267,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:42:00 GMT
+      - Thu, 18 Oct 2018 09:27:43 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -269,9 +285,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sun, 18 Mar 2018 19:42:00 GMT
+      - Thu, 18 Oct 2018 09:27:43 GMT
       Expires:
-      - Sun, 18 Mar 2018 19:42:00 GMT
+      - Thu, 18 Oct 2018 09:27:43 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -283,8 +299,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
@@ -296,20 +311,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1D23x9ILqdppIHrmbkYpeXu64fxjRFlG7yIEgR1wCfFk.",
+            "message": "File not found: 1dOKcu4GSzasgViKJsGTiucNJ8EXfLu3WzVIo0tiTC68.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1D23x9ILqdppIHrmbkYpeXu64fxjRFlG7yIEgR1wCfFk."
+          "message": "File not found: 1dOKcu4GSzasgViKJsGTiucNJ8EXfLu3WzVIo0tiTC68."
          }
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:42:00 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:43 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1YtKnWMiJJnc2bGTtp9v0ehSg8QN8XdxJ
+    uri: https://www.googleapis.com/drive/v3/files/1K2bIJVWJfLG9PjO6eo36Cu_Jc_neyYcz
     body:
       encoding: UTF-8
       string: ''
@@ -321,7 +336,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:42:00 GMT
+      - Thu, 18 Oct 2018 09:27:43 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -338,18 +353,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:42:00 GMT
+      - Thu, 18 Oct 2018 09:27:43 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:42:00 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:43 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/trashed_file/is_marked_as_deleted_and_returns_nil_values.yml
+++ b/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_FileSync/trashed_file/is_marked_as_deleted_and_returns_nil_values.yml
@@ -9,7 +9,7 @@ http_interactions:
         ID>&client_secret=<CLIENT SECRET>
     headers:
       User-Agent:
-      - Faraday v0.13.1
+      - Faraday v0.14.0
       Content-Type:
       - application/x-www-form-urlencoded
       Accept-Encoding:
@@ -21,49 +21,46 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sun, 18 Mar 2018 19:41:56 GMT
+      Content-Type:
+      - application/json; charset=utf-8
       Vary:
       - Origin
+      - Referer
       - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
+      Date:
+      - Thu, 18 Oct 2018 09:27:43 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
       X-Xss-Protection:
       - 1; mode=block
-      Server:
-      - GSE
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
-      string: |
+      string: |-
         {
-         "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-         "token_type": "Bearer",
-         "expires_in": 3600
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:56 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:43 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-03-18
-        19:41:56 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-18
+        09:27:43 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -72,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:56 GMT
+      - Thu, 18 Oct 2018 09:27:43 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -89,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:56 GMT
+      - Thu, 18 Oct 2018 09:27:44 GMT
       Vary:
       - Origin
       - X-Origin
@@ -106,31 +103,41 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "15sjoH6BAwGcSQHDzmZOtu-FHOW-SO7Hd",
-         "name": "Test @ 2018-03-18 19:41:56 UTC",
+         "id": "11xGLgkxtI-1UBM4TWkjlPOfuhXQzKLfe",
+         "name": "Test @ 2018-10-18 09:27:43 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
           "0AIeK5UAEPQfeUk9PVA"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:56 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:44 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["15sjoH6BAwGcSQHDzmZOtu-FHOW-SO7Hd"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["11xGLgkxtI-1UBM4TWkjlPOfuhXQzKLfe"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -139,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:56 GMT
+      - Thu, 18 Oct 2018 09:27:44 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -156,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:57 GMT
+      - Thu, 18 Oct 2018 09:27:45 GMT
       Vary:
       - Origin
       - X-Origin
@@ -173,28 +180,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1Gli-16Z2IsZfVlMPuLoHJSpnIbAVavxS90KOwc2k1bk",
+         "id": "1ipMZfOTRG7CPZPq1UwQi8Y7AIUMXBEWy8_ec67WYKw8",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "15sjoH6BAwGcSQHDzmZOtu-FHOW-SO7Hd"
+          "11xGLgkxtI-1UBM4TWkjlPOfuhXQzKLfe"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:57 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:45 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1Gli-16Z2IsZfVlMPuLoHJSpnIbAVavxS90KOwc2k1bk?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ipMZfOTRG7CPZPq1UwQi8Y7AIUMXBEWy8_ec67WYKw8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"trashed":"true"}'
@@ -206,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:57 GMT
+      - Thu, 18 Oct 2018 09:27:45 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -223,7 +240,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:57 GMT
+      - Thu, 18 Oct 2018 09:27:45 GMT
       Vary:
       - Origin
       - X-Origin
@@ -240,28 +257,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1Gli-16Z2IsZfVlMPuLoHJSpnIbAVavxS90KOwc2k1bk",
+         "id": "1ipMZfOTRG7CPZPq1UwQi8Y7AIUMXBEWy8_ec67WYKw8",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": true,
          "parents": [
-          "15sjoH6BAwGcSQHDzmZOtu-FHOW-SO7Hd"
+          "11xGLgkxtI-1UBM4TWkjlPOfuhXQzKLfe"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:57 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:45 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Gli-16Z2IsZfVlMPuLoHJSpnIbAVavxS90KOwc2k1bk?fields=id,name,mimeType,parents,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ipMZfOTRG7CPZPq1UwQi8Y7AIUMXBEWy8_ec67WYKw8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -273,7 +300,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:57 GMT
+      - Thu, 18 Oct 2018 09:27:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -284,9 +311,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sun, 18 Mar 2018 19:41:57 GMT
+      - Thu, 18 Oct 2018 09:27:45 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:57 GMT
+      - Thu, 18 Oct 2018 09:27:45 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -305,28 +332,38 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1Gli-16Z2IsZfVlMPuLoHJSpnIbAVavxS90KOwc2k1bk",
+         "id": "1ipMZfOTRG7CPZPq1UwQi8Y7AIUMXBEWy8_ec67WYKw8",
          "name": "Test File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": true,
          "parents": [
-          "15sjoH6BAwGcSQHDzmZOtu-FHOW-SO7Hd"
+          "11xGLgkxtI-1UBM4TWkjlPOfuhXQzKLfe"
          ],
-         "thumbnailVersion": "0"
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:57 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:46 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/15sjoH6BAwGcSQHDzmZOtu-FHOW-SO7Hd
+    uri: https://www.googleapis.com/drive/v3/files/11xGLgkxtI-1UBM4TWkjlPOfuhXQzKLfe
     body:
       encoding: UTF-8
       string: ''
@@ -338,7 +375,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sun, 18 Mar 2018 19:41:57 GMT
+      - Thu, 18 Oct 2018 09:27:46 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -355,18 +392,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sun, 18 Mar 2018 19:41:58 GMT
+      - Thu, 18 Oct 2018 09:27:46 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="41,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39,35"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sun, 18 Mar 2018 19:41:58 GMT
+  recorded_at: Thu, 18 Oct 2018 09:27:46 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/vcr_configuration.rb
+++ b/spec/support/vcr_configuration.rb
@@ -67,7 +67,7 @@ VCR.configure do |c|
     # check response
     oauth_response_params = JSON.parse(interaction.response.body)
     oauth_response_params
-      .except('token_type', 'expires_in').each do |param, value|
+      .except('token_type', 'expires_in', 'scope').each do |param, value|
       # everything is good if the value starts with < and ends with >
       next if value.match?(/^<.*>$/)
 

--- a/spec/views/file_infos/index_spec.rb
+++ b/spec/views/file_infos/index_spec.rb
@@ -149,9 +149,15 @@ RSpec.describe 'file_infos/index', type: :view do
     let(:r1)  { build_stubbed :revision }
     let(:r2)  { build_stubbed :revision }
     let(:r3)  { build_stubbed :revision }
-    let(:s1)  { build_stubbed :file_resource_snapshot, name: 'f1' }
-    let(:s2)  { build_stubbed :file_resource_snapshot, name: 'f2' }
-    let(:s3)  { build_stubbed :file_resource_snapshot, name: 'f3' }
+    let(:s1) do
+      build_stubbed :file_resource_snapshot, :with_backup, name: 'f1'
+    end
+    let(:s2) do
+      build_stubbed :file_resource_snapshot, :with_backup, name: 'f2'
+    end
+    let(:s3) do
+      build_stubbed :file_resource_snapshot, :with_backup, name: 'f3'
+    end
 
     it 'renders the title of each revision' do
       render
@@ -175,6 +181,14 @@ RSpec.describe 'file_infos/index', type: :view do
           href: profile_project_revisions_path(project.owner, project,
                                                anchor: revision.id)
         )
+      end
+    end
+
+    it 'renders a link to file backup for each revision' do
+      render
+      committed_file_diffs.each do |diff|
+        link = diff.current_snapshot.backup.file_resource.external_link
+        expect(rendered).to have_link(text: diff.name, href: link)
       end
     end
 

--- a/spec/views/revisions/index_spec.rb
+++ b/spec/views/revisions/index_spec.rb
@@ -62,11 +62,14 @@ RSpec.describe 'revisions/index', type: :view do
 
   context 'when file diffs exist' do
     let(:diffs) do
-      build_stubbed_list(:file_resource_snapshot, 3).map do |snapshot|
+      snapshots.map do |snapshot|
         FileDiff.new(file_resource_id: 12,
                      current_snapshot: snapshot,
                      first_three_ancestors: ancestors)
       end
+    end
+    let(:snapshots) do
+      build_stubbed_list(:file_resource_snapshot, 3, :with_backup)
     end
 
     let(:ancestors) { [] }
@@ -76,6 +79,14 @@ RSpec.describe 'revisions/index', type: :view do
       allow(project).to receive(:root_folder).and_return root
       allow(root).to receive(:provider).and_return Providers::GoogleDrive
       allow(revisions.first).to receive(:file_diffs).and_return diffs
+    end
+
+    it 'renders a link to each file backup' do
+      render
+      diffs.each do |diff|
+        link = diff.current_snapshot.backup.file_resource.external_link
+        expect(rendered).to have_link(text: diff.name, href: link)
+      end
     end
 
     it 'renders a link to infos for each file' do

--- a/spec/views/revisions/new_spec.rb
+++ b/spec/views/revisions/new_spec.rb
@@ -60,11 +60,14 @@ RSpec.describe 'revisions/new', type: :view do
 
   context 'when file diffs exist' do
     let(:file_diffs) do
-      build_stubbed_list(:file_resource_snapshot, 3).map do |snapshot|
+      snapshots.map do |snapshot|
         FileDiff.new(file_resource_id: 12,
                      current_snapshot: snapshot,
                      first_three_ancestors: [])
       end
+    end
+    let(:snapshots) do
+      build_stubbed_list(:file_resource_snapshot, 3, :with_backup)
     end
 
     before do
@@ -87,6 +90,14 @@ RSpec.describe 'revisions/new', type: :view do
       file_diffs.each do |diff|
         expect(rendered)
           .to have_css('.file.addition', text: "#{diff.name} added")
+      end
+    end
+
+    it 'renders a link to each file backup' do
+      render
+      file_diffs.each do |diff|
+        link = diff.current_snapshot.backup.file_resource.external_link
+        expect(rendered).to have_link(text: diff.name, href: link)
       end
     end
 


### PR DESCRIPTION
Whenever we fetch file updates for a repository, Openly creates a copy (backup)
of changed files in a dedicated archive for the repository. These backups are
accessible to the repository owner only and can be accessed via the revisions
page. This allows the user to check out previous versions of files.

Highlights:
- Create dedicated project archive in Google Drive on repository creation
- Backup (copy) files on syncing changes with Google Drive
- Link to backups on revisions#index, revisions#new, and file_infos#index page