### PR TITLE
App color scheme: Set to 'blue darken-2'

### DIFF
--- a/app/views/layouts/application.slim
+++ b/app/views/layouts/application.slim
@@ -11,7 +11,9 @@ html
 
     = render 'application/favicon'
 
-  body class=[controller_action_identifier, color_scheme(@color_scheme)]
+  / body class=[controller_action_identifier, color_scheme(@color_scheme)]
+  / TODO: Set correct color once identified by design team
+  body class=[controller_action_identifier, color_scheme('blue darken-2')]
     main
       = render 'navbar'
       = yield


### PR DESCRIPTION
Use 'blue darken-2' as the app-wide color scheme. This overrides the
previous random rainbow color scheme. We are choosing a consistent
color scheme because it looks more professional.