### PR TITLE
Rewire Architecture

### DIFF
--- a/app/controllers/concerns/can_set_project_context.rb
+++ b/app/controllers/concerns/can_set_project_context.rb
@@ -33,6 +33,8 @@ module CanSetProjectContext
   # rubocop:disable Naming/AccessorMethodName
   def set_project_by_handle_and_slug!(scope: Project)
     @project = scope.find_by_handle_and_slug!(profile_handle, profile_slug)
+    # TODO: Consider extraction
+    @master_branch = @project.master_branch
   end
   # rubocop:enable Naming/AccessorMethodName
 

--- a/app/controllers/file_infos_controller.rb
+++ b/app/controllers/file_infos_controller.rb
@@ -18,15 +18,20 @@ class FileInfosController < ApplicationController
   # Attempt to find the file diff of stage (base) and last revision
   # (differentiator)
   def set_staged_file_diff
-    @staged_file_diff = Stage::FileDiff.find_by!(external_id: params[:id],
-                                                 project: @project)
+    staged_file =
+      @master_branch.staged_files
+                    .joins_staged_snapshot
+                    .find_by!(file_record_id: file_record_id)
+
+    @staged_file_diff = staged_file.diff(with_ancestry: true)
   rescue ActiveRecord::RecordNotFound
     @staged_file_diff = nil
   end
 
-  def file_resource_id
-    @file_resource_id ||=
-      FileResource.find_by!(external_id: params[:id]).id
+  def file_record_id
+    @file_record_id ||=
+      @master_branch.staged_files
+                    .find_by(external_id: params[:id]).file_record_id
   end
 
   # Find file in stage or version history
@@ -44,15 +49,15 @@ class FileInfosController < ApplicationController
 
   # Load file history
   def set_committed_file_diffs
-    # Note: Must use preload for current and previous snapshot to correctly set
-    #       provider ID.
     @committed_file_diffs =
-      FileDiff
-      .includes(revision: [:author])
-      .preload(:current_snapshot, :previous_snapshot)
-      .where(revisions: { project: @project, is_published: true },
-             file_resource_id: file_resource_id)
-      .merge(Revision.order(id: :desc))
+      VCS::FileDiff
+      .includes(commit: [:author])
+      .joins_current_or_previous_snapshot
+      .preload(:new_snapshot, :old_snapshot)
+      .where(
+        vcs_commits: { branch_id: @master_branch.id, is_published: true },
+        current_or_previous_snapshot: { file_record_id: file_record_id }
+      ).merge(VCS::Commit.order(id: :desc))
   end
 
   def set_user_can_force_sync_files

--- a/app/controllers/folders_controller.rb
+++ b/app/controllers/folders_controller.rb
@@ -22,29 +22,27 @@ class FoldersController < ApplicationController
   private
 
   def preload_thumbnails_for_children
-    FileResource::Thumbnail.preload_for(@children)
+    # FileResource::Thumbnail.preload_for(@children)
   end
 
   def set_ancestors
-    @ancestors = @folder&.ancestors_in_project.to_a
+    @ancestors = @folder.ancestors.to_a
   end
 
   def set_children
-    @children = @folder.children_as_diffs
+    @children = @folder.children.order_by_name_with_folders_first
   end
 
   def set_folder_from_param
-    @folder = Stage::FileDiff.find_by!(external_id: params[:id],
-                                       project: @project)
+    @folder = @master_branch.staged_folders.find_by_external_id(params[:id])
 
-    raise ActiveRecord::RecordNotFound unless @folder.folder?
+    raise ActiveRecord::RecordNotFound unless @folder.staged_snapshot.folder?
   end
 
   def set_folder_from_root
-    raise ActiveRecord::RecordNotFound unless @project.root_folder.present?
+    raise ActiveRecord::RecordNotFound unless @master_branch.root.present?
 
-    @folder = Stage::FileDiff.new(file_resource_id: @project.root_folder.id,
-                                  project: @project)
+    @folder = @master_branch.root
   end
 
   def set_user_can_commit_changes

--- a/app/controllers/force_syncs_controller.rb
+++ b/app/controllers/force_syncs_controller.rb
@@ -8,7 +8,6 @@ class ForceSyncsController < ApplicationController
   before_action :set_project_where_setup_is_complete
   before_action :authorize_project_access
   before_action :authorize_action
-  before_action :set_staged_file_diff
   before_action :set_file_resource
 
   def create
@@ -42,13 +41,7 @@ class ForceSyncsController < ApplicationController
 
   # Set the file resource
   def set_file_resource
-    @file = FileResources::GoogleDrive.find_by!(external_id: file_id)
-  end
-
-  # Attempt to find the file diff of stage (base) and last revision
-  # (differentiator)
-  def set_staged_file_diff
-    @staged_file_diff = Stage::FileDiff.find_by!(external_id: file_id,
-                                                 project: @project)
+    @file =
+      @project.master_branch.staged_files.find_by!(external_id: file_id)
   end
 end

--- a/app/controllers/revisions_controller.rb
+++ b/app/controllers/revisions_controller.rb
@@ -13,6 +13,7 @@ class RevisionsController < ApplicationController
 
   def index
     # TODO: Raise 404 if no revisions exist or redirect
+    # TODO: Change variable name from revision to commit
     @revisions =
       @project
       .master_branch
@@ -50,7 +51,7 @@ class RevisionsController < ApplicationController
   end
 
   def build_revision
-    revision = @project.revisions.create_draft_and_commit_files!(current_user)
+    revision = @project.master_branch.commits.create_draft_and_commit_files!(current_user)
     find_revision_by_id(revision.id)
   end
 
@@ -64,8 +65,9 @@ class RevisionsController < ApplicationController
 
   def find_revision_by_id(id)
     @revision =
-      Revision.preload_file_diffs_with_snapshots
-              .find_by!(id: id, project: @project, author: current_user)
+      VCS::Commit
+      .preload_file_diffs_with_snapshots
+      .find_by!(id: id, branch: @project.master_branch, author: current_user)
   end
 
   def preload_backups_for_file_diffs_in_revisions(revisions)

--- a/app/controllers/revisions_controller.rb
+++ b/app/controllers/revisions_controller.rb
@@ -15,7 +15,8 @@ class RevisionsController < ApplicationController
     # TODO: Raise 404 if no revisions exist or redirect
     @revisions =
       @project
-      .revisions
+      .master_branch
+      .commits
       .order(id: :desc)
       .includes(:author)
       .preload_file_diffs_with_snapshots
@@ -71,7 +72,7 @@ class RevisionsController < ApplicationController
     ActiveRecord::Associations::Preloader.new.preload(
       Array(revisions).flat_map(&:file_diffs)
                       .flat_map(&:current_or_previous_snapshot),
-      backup: [:file_resource]
+      :backup
     )
   end
 

--- a/app/helpers/file_helper.rb
+++ b/app/helpers/file_helper.rb
@@ -45,7 +45,7 @@ module FileHelper
       profile_project_revision_folder_path(project.owner, project,
                                            revision.id, file.external_id)
     else
-      file.backup&.file_resource&.external_link
+      file.backup&.external_link
     end
   end
 end

--- a/app/jobs/folder_import_job.rb
+++ b/app/jobs/folder_import_job.rb
@@ -9,12 +9,7 @@ class FolderImportJob < ApplicationJob
   def perform(*args)
     variables_from_arguments(*args)
 
-    file = FileResources::GoogleDrive.find(file_resource_id)
-
-    # Stage existing children of the folder
-    file.children.each do |child|
-      project.staged_files.create(file_resource: child)
-    end
+    file = VCS::StagedFile.find(staged_file_id)
 
     file.pull_children
 
@@ -26,13 +21,13 @@ class FolderImportJob < ApplicationJob
 
   private
 
-  attr_accessor :file_resource_id, :project, :setup
+  attr_accessor :staged_file_id, :project, :setup
 
   # Create a new FolderImportJob for the given file resource
-  def schedule_folder_import_job_for(file_resource)
+  def schedule_folder_import_job_for(staged_file)
     FolderImportJob.perform_later(
-      reference:        setup,
-      file_resource_id: file_resource.id
+      reference:      setup,
+      staged_file_id: staged_file.id
     )
   end
 
@@ -40,7 +35,6 @@ class FolderImportJob < ApplicationJob
   def variables_from_arguments(*args)
     reference_id          = args[0][:reference_id]
     self.setup            = Project::Setup.find(reference_id)
-    self.project          = setup.project
-    self.file_resource_id = args[0][:file_resource_id]
+    self.staged_file_id   = args[0][:staged_file_id]
   end
 end

--- a/app/models/concerns/vcs/backupable.rb
+++ b/app/models/concerns/vcs/backupable.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# A backupable FileResource
+module VCS::Backupable
+  extend ActiveSupport::Concern
+
+  included do
+    # Callbacks
+    after_save :perform_backup, if: :backup_on_save?
+  end
+
+  # Has this file resource already been backed up?
+  def backed_up?
+    current_snapshot&.backup&.persisted?
+  end
+
+  # Should this file resource be backed up on save?
+  # No, if folder.
+  # No, if deleted.
+  # No, if already backed up.
+  def backup_on_save?
+    !folder? && !deleted? && !backed_up?
+  end
+
+  private
+
+  # The action for performing the backup
+  def perform_backup
+    VCS::FileBackup.backup(self)
+    true
+  end
+end

--- a/app/models/concerns/vcs/diffing.rb
+++ b/app/models/concerns/vcs/diffing.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+# Add support for diffing file resources
+module VCS::Diffing
+  extend ActiveSupport::Concern
+
+  # Delegations
+  delegate :id, to: :current_or_previous_snapshot, prefix: true
+  delegate :external_id, :external_link, :folder?, :icon, :mime_type, :name,
+           :parent_id, :provider, :symbolic_mime_type, :thumbnail_id,
+           :thumbnail_image, :thumbnail_image_or_fallback,
+           to: :current_or_previous_snapshot
+
+  delegate_methods = %i[content_version name parent_id]
+  delegate(*delegate_methods, to: :current_snapshot, prefix: :current)
+  delegate(*delegate_methods, to: :previous_snapshot, prefix: :previous)
+
+  delegate :color, :text_color, to: :primary_change, allow_nil: true
+
+  def addition?
+    previous_snapshot_id.nil?
+  end
+
+  # Format first_three_ancestors into a path, joined by >
+  # 0 ancestors: Home
+  # 1-2 ancestors: Ancestor2 > Ancestor1
+  # 3(+) ancestors: .. > Ancestor2 > Ancestor1
+  def ancestor_path
+    case first_three_ancestors.length
+    when 0
+      'Home'
+    when 1, 2
+      first_three_ancestors.reverse.join(' > ')
+    when 3
+      first_three_ancestors.reverse.drop(1).unshift('..').join(' > ')
+    end
+  end
+
+  def association(association_name)
+    return super unless association_name == :thumbnail
+
+    current_or_previous_snapshot.association(association_name)
+  end
+
+  def change?
+    addition? || deletion? || update?
+  end
+
+  # Return changes made to this diff as an array of symbols. When file has been
+  # updated (moved, renamed, or modified), moved must come first in the list of
+  # changes, renamed second, and modified last.
+  def change_types
+    %i[addition deletion movement rename modification].select do |change|
+      send("#{change}?")
+    end
+  end
+
+  # Return the changes that have been made from previous_snapshot to
+  # current_snapshot as an array of FileDiff::Change instances.
+  def changes
+    @changes ||=
+      change_types.map do |type|
+        "FileDiff::Changes::#{type.to_s.humanize}".constantize.new(diff: self)
+      end
+  end
+
+  def deletion?
+    current_snapshot_id.nil?
+  end
+
+  def modification?
+    return false unless update?
+
+    current_content_version != previous_content_version
+  end
+
+  def movement?
+    return false unless update?
+
+    current_parent_id != previous_parent_id
+  end
+
+  # The first change is the primary change
+  def primary_change
+    changes.first
+  end
+
+  def rename?
+    return false unless update?
+
+    current_name != previous_name
+  end
+
+  def update?
+    return false if addition? || deletion?
+
+    current_snapshot_id != previous_snapshot_id
+  end
+
+  def current_or_previous_snapshot
+    current_snapshot || previous_snapshot
+  end
+end

--- a/app/models/concerns/vcs/diffing.rb
+++ b/app/models/concerns/vcs/diffing.rb
@@ -31,7 +31,7 @@ module VCS::Diffing
       'Home'
     when 1, 2
       first_three_ancestors.reverse.join(' > ')
-    when 3
+    else
       first_three_ancestors.reverse.drop(1).unshift('..').join(' > ')
     end
   end

--- a/app/models/concerns/vcs/resourceable.rb
+++ b/app/models/concerns/vcs/resourceable.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Add support for resourceable methods, such as #folder?, linable, ...
+module VCS::Resourceable
+  extend ActiveSupport::Concern
+
+  included do
+    belongs_to :thumbnail, class_name: 'VCS::FileThumbnail', optional: true,
+                           dependent: :destroy
+  end
+
+  def folder?
+    provider_mime_type_class.folder?(mime_type)
+  end
+
+  def external_link
+    provider_link_class.for(external_id: external_id, mime_type: mime_type)
+  end
+
+  def icon
+    provider_icon_class.for(mime_type: mime_type)
+  end
+
+  def provider
+    # @provider ||= Provider.find(provider_id)
+    @provider ||= Provider.find(0)
+  end
+
+  def symbolic_mime_type
+    provider_mime_type_class.to_symbol(mime_type)
+  end
+
+  def thumbnail_image
+    thumbnail&.image
+  end
+
+  def thumbnail_image_or_fallback
+    thumbnail_image || VCS::FileThumbnail.new.image
+  end
+
+  private
+
+  def provider_icon_class
+    Object.const_get("#{provider}::Icon")
+  end
+
+  def provider_link_class
+    Object.const_get("#{provider}::Link")
+  end
+
+  def provider_mime_type_class
+    Object.const_get("#{provider}::MimeType")
+  end
+end

--- a/app/models/concerns/vcs/snapshotable.rb
+++ b/app/models/concerns/vcs/snapshotable.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# A snapshotable FileResource
+module VCS::Snapshotable
+  extend ActiveSupport::Concern
+
+  included do
+    # Associations
+    has_many :snapshots, class_name: 'VCS::FileSnapshot'
+    belongs_to :current_snapshot, class_name: 'VCS::FileSnapshot',
+                                  autosave: false,
+                                  optional: true
+
+    # Callbacks
+    before_save :clear_snapshot, if:      :deleted?
+    after_save  :snapshot!,      unless:  :deleted?
+
+    # Validations
+    validate :current_snapshot_must_belong_to_snapshotable,
+             if: :current_snapshot
+  end
+
+  private
+
+  # Clear the current snapshot association
+  def clear_snapshot
+    self.current_snapshot = nil
+  end
+
+  # Validate that current snapshot is associated with this snapshotable
+  def current_snapshot_must_belong_to_snapshotable
+    return if current_snapshot.snapshotable_id == file_record_id
+
+    errors.add(:current_snapshot, "must belong to this #{model_name}")
+  end
+
+  # Capture a snapshot of this snapshotable instance
+  def snapshot!
+    self.current_snapshot =
+      VCS::FileSnapshot.for(attributes.merge(file_record_id: file_record_id))
+    # find_or_create_current_snapshot_by!(core_snapshot_attributes,
+    #                                     supplemental_snapshot_attributes)
+    update_column('current_snapshot_id', current_snapshot.id)
+  end
+end

--- a/app/models/concerns/vcs/syncable.rb
+++ b/app/models/concerns/vcs/syncable.rb
@@ -22,7 +22,7 @@ module VCS::Syncable
   # Fetch and save the most recent information about this syncable resource
   def pull
     fetch
-    save!
+    save
   end
 
   # Fetch and save the children of this syncable resource from its provider
@@ -59,7 +59,7 @@ module VCS::Syncable
         self
         .class
         .create_with(
-          sync_adapter: sync_adapter,
+          sync_adapter: child_sync_adapter,
           file_record: VCS::FileRecord.new(repository_id: branch.repository_id)
         ).find_or_initialize_by(
           branch_id: branch_id,
@@ -67,7 +67,7 @@ module VCS::Syncable
         )
 
       # Pull (fetch+save) child if it is a new record
-      staged_child.tap { |child| child.pull if staged_child.new_record? }
+      staged_child.tap { |child| child.pull if child.new_record? }
     end
   end
 

--- a/app/models/concerns/vcs/syncable.rb
+++ b/app/models/concerns/vcs/syncable.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+# A syncable FileResource
+module VCS::Syncable
+  extend ActiveSupport::Concern
+
+  included do
+    attr_writer :sync_adapter
+  end
+
+  # Fetch the most recent information about this syncable resource from its
+  # provider
+  def fetch
+    self.is_deleted = sync_adapter.deleted?
+    self.name = sync_adapter.name
+    self.mime_type = sync_adapter.mime_type
+    self.content_version = sync_adapter.content_version
+    self.external_parent_id = sync_adapter.parent_id
+    thumbnail_from_sync_adapter
+  end
+
+  # Fetch and save the most recent information about this syncable resource
+  def pull
+    fetch
+    save!
+  end
+
+  # Fetch and save the children of this syncable resource from its provider
+  def pull_children
+    self.staged_children = children_from_sync_adapter
+    # children_from_sync_adapter.each do |child|
+    #   child.update!(file_record_parent_id: file_record_id)
+    # end
+    # # TODO: Clear current snapshot of other children
+    # children.where.not(id: children_from_sync_adapter.map(&:id)).each(&:pull)
+  end
+
+  # Reset sync state when calling #reload
+  def reload
+    reset_sync_adapter
+    super
+  end
+
+  def sync_adapter
+    @sync_adapter ||= sync_adapter_class.new(external_id)
+  end
+
+  # Get version ID of thumbnail
+  def thumbnail_version_id
+    sync_adapter&.thumbnail_version
+  end
+
+  private
+
+  # Fetch children from sync adapter and convert to file resources
+  def children_from_sync_adapter
+    sync_adapter.children.map do |child_sync_adapter|
+      staged_child =
+        self
+        .class
+        .create_with(
+          sync_adapter: sync_adapter,
+          file_record: VCS::FileRecord.new(repository_id: branch.repository_id)
+        ).find_or_initialize_by(
+          branch_id: branch_id,
+          external_id: child_sync_adapter.id
+        )
+
+      # Pull (fetch+save) child if it is a new record
+      staged_child.tap { |child| child.pull if staged_child.new_record? }
+    end
+  end
+
+  # Find an instance of syncable's class from the external parent ID
+  # and set instance to parent of current syncable resource
+  def external_parent_id=(external_parent_id)
+    self.parent = branch.staged_files.find_by_external_id(external_parent_id)
+  end
+
+  # Reset the file's synchronization adapter
+  def reset_sync_adapter
+    @sync_adapter = nil
+    @destroy_on_save = nil
+  end
+
+  def sync_adapter_class
+    'Providers::GoogleDrive::FileSync'.constantize
+  end
+
+  # Set thumbnail from sync adapter, either by finding an existing thumbnail for
+  # this file and its thumbnail version id or by creating a new one and fetching
+  # the thumbnail
+  def thumbnail_from_sync_adapter
+    return unless sync_adapter.thumbnail?
+
+    self.thumbnail =
+      VCS::FileThumbnail
+      .create_with(raw_image: proc { sync_adapter.thumbnail })
+      .find_or_initialize_by_staged_file(self)
+  end
+end

--- a/app/models/notifications/vcs/commit.rb
+++ b/app/models/notifications/vcs/commit.rb
@@ -1,0 +1,48 @@
+module Notifications
+  module VCS
+    class Commit
+      include Rails.application.routes.url_helpers
+      attr_accessor :commit
+      attr_writer :source
+
+      def initialize(commit, source: nil)
+        self.commit = commit
+        self.source = source
+      end
+
+      # The path to the notifying object
+      def path
+        profile_project_revisions_path(project.owner, project)
+      end
+
+      # The recipients for this notification
+      def recipients
+        recipient_users.map(&:account)
+      end
+
+      # The source/originator for this notification
+      def source
+        @source ||= commit.author
+      end
+
+      # The notification's title
+      def title
+        "#{source.name} created a revision in #{project.title}"
+      end
+
+      private
+
+      def project
+        Project.find_by_repository_id(commit.repository.id)
+      end
+
+      def collaborators_in_project
+        [project.owner] + project.collaborators.includes(:account)
+      end
+
+      def recipient_users
+        (collaborators_in_project - [commit.author]).uniq
+      end
+    end
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -71,6 +71,7 @@ class Project < ApplicationRecord
 
   # Delegations
   delegate :in_progress?, :completed?, to: :setup, prefix: true, allow_nil: true
+  delegate :staged_files, to: :master_branch
 
   # Callbacks
   # Auto-generate slug from title

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -11,6 +11,14 @@ class Project < ApplicationRecord
 
   has_one :setup, class_name: 'Project::Setup', dependent: :destroy
 
+  belongs_to :master_branch, class_name: 'VCS::Branch',
+                             optional: true,
+                             dependent: :destroy
+
+  belongs_to :repository, class_name: 'VCS::Repository',
+                          dependent: :destroy,
+                          optional: true
+
   has_one :staged_root_folder,
           -> { where is_root: true },
           class_name: 'StagedFile',

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -73,7 +73,10 @@ class Project < ApplicationRecord
   # Callbacks
   # Auto-generate slug from title
   before_validation :generate_slug_from_title, if: :title?, unless: :slug?
+  # Set up repository and master branch
+  before_create :setup_repository
   # Set up archive for storing file backups
+  # TODO: Refactor into background job
   after_create :setup_archive, unless: :skip_archive_setup
 
   # Scopes
@@ -180,6 +183,12 @@ class Project < ApplicationRecord
     build_archive unless archive.present?
     archive.setup unless archive.setup_completed?
     archive.save
+  end
+
+  # Set up repository & master branch
+  def setup_repository
+    create_repository
+    create_master_branch(repository: repository)
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/providers/google_drive/api_connection.rb
+++ b/app/models/providers/google_drive/api_connection.rb
@@ -133,7 +133,8 @@ module Providers
         drive_service.list_changes(
           token,
           page_size: page_size,
-          fields: %w[nextPageToken newStartPageToken changes/file_id].join(',')
+          fields: %w[nextPageToken newStartPageToken
+                     changes/file_id changes/file/parents].join(',')
         )
       end
 

--- a/app/models/vcs.rb
+++ b/app/models/vcs.rb
@@ -1,0 +1,5 @@
+module VCS
+  def self.table_name_prefix
+    'vcs_'
+  end
+end

--- a/app/models/vcs/archive.rb
+++ b/app/models/vcs/archive.rb
@@ -1,0 +1,66 @@
+module VCS
+  class Archive < ApplicationRecord
+    belongs_to :repository
+
+    # TODO: Make name & owners updatable
+
+    attr_accessor :name, :owner_account_email
+
+    # Validations
+    validates :repository_id, uniqueness: { message: 'already has an archive' }
+    validates :external_id, presence: true
+
+    def backups
+      repository.file_backups
+    end
+
+    # Set up the archive folder with the provider by creating it and granting
+    # view access to the repository owner
+    def setup
+      raise 'Already set up' if setup_completed?
+
+      create_external_folder
+      grant_view_access_to_repository_owner
+    end
+
+    # Return true if setup has been completed (i.e. file resource is present)
+    def setup_completed?
+      external_id.present?
+    end
+
+    private
+
+    # Creates the archive folder with the provider
+    def create_external_folder
+      folder = sync_adapter_class.create(
+        name: "#{name} (Archive)",
+        parent_id: 'root',
+        mime_type: mime_type_class.folder
+      )
+      self.external_id = folder.id
+    end
+
+    # Grants view access to the archive folder to the repository owner
+    def grant_view_access_to_repository_owner
+      api_connection_class
+        .default
+        .share_file(external_id, owner_account_email, :reader)
+    end
+
+    def api_connection_class
+      "Providers::#{provider}::ApiConnection".constantize
+    end
+
+    def mime_type_class
+      "Providers::#{provider}::MimeType".constantize
+    end
+
+    def provider
+      'GoogleDrive'
+    end
+
+    def sync_adapter_class
+      "Providers::#{provider}::FileSync".constantize
+    end
+  end
+end

--- a/app/models/vcs/branch.rb
+++ b/app/models/vcs/branch.rb
@@ -1,0 +1,39 @@
+module VCS
+  class Branch < ApplicationRecord
+    belongs_to :repository
+
+    has_many :staged_files, dependent: :delete_all do
+      def root
+        find_by(is_root: true)
+      end
+
+      def folders
+        joins_staged_snapshot
+          .where(
+            'staged_snapshots.mime_type = ?',
+            Providers::GoogleDrive::MimeType.folder
+          )
+      end
+    end
+
+    delegate :root, to: :staged_files
+    delegate :folders, to: :staged_files, prefix: :staged
+
+    has_many :staged_file_snapshots,
+             through: :staged_files,
+             source: :current_snapshot do
+               def without_root
+                 where("#{StagedFile.table_name}.is_root = ?", false)
+               end
+             end
+
+    has_many :commits, -> { published }, dependent: :destroy do
+      def create_draft_and_commit_files!(author)
+        Commit.create_draft_and_commit_files_for_branch!(
+          proxy_association.owner,
+          author
+        )
+      end
+    end
+  end
+end

--- a/app/models/vcs/commit.rb
+++ b/app/models/vcs/commit.rb
@@ -39,7 +39,7 @@ module VCS
 
     # Scopes
     scope :preload_file_diffs_with_snapshots, lambda {
-      preload(file_diffs: %i[current_snapshot previous_snapshot])
+      preload(file_diffs: %i[new_snapshot old_snapshot])
     }
 
     scope :last_per_branch, lambda {

--- a/app/models/vcs/commit.rb
+++ b/app/models/vcs/commit.rb
@@ -1,0 +1,191 @@
+module VCS
+  class Commit < ApplicationRecord
+    # TODO: Extract Notifying out
+    include Notifying
+
+    belongs_to :branch
+    has_one :repository, through: :branch
+    belongs_to :parent, class_name: 'Commit', optional: true, autosave: false
+    belongs_to :author, class_name: 'Profiles::User'
+    has_many :children, class_name: 'Commit',
+                        foreign_key: :parent_id,
+                        dependent: :destroy
+    has_many :committed_files, dependent: :delete_all do
+      # Get committed files that belong to the provided folder
+      def in_folder(folder)
+        includes(:file_snapshot)
+          .where(
+            "#{VCS::FileSnapshot.table_name}": {
+              file_record_parent_id: folder.file_record_id
+            }
+          )
+      end
+    end
+    has_many :committed_snapshots, class_name: 'VCS::FileSnapshot',
+                                   through: :committed_files,
+                                   source: :file_snapshot
+    has_many :file_diffs, -> { order_by_name_with_folders_first },
+             inverse_of: :commit, dependent: :delete_all
+
+    # Attributes
+    attr_readonly :branch_id, :parent_id, :author_id
+    # TODO: Remove. Legacy support only
+    alias_attribute :revision, :commit
+
+    # Callbacks
+    before_save :apply_selected_file_changes, if: :publishing?
+    after_save :update_staged_files, if: :publishing?
+    after_save :trigger_notifications, if: %i[publishing? belongs_to_project?]
+
+    # Scopes
+    scope :preload_file_diffs_with_snapshots, lambda {
+      preload(file_diffs: %i[current_snapshot previous_snapshot])
+    }
+
+    scope :last_per_branch, lambda {
+      select('MAX(id) id, branch_id').published.group(:branch_id)
+    }
+
+    scope :published, -> { where(is_published: true) }
+
+    # Validations
+    # Require title for published revisions
+    validates :title, presence: true, if: :is_published
+
+    validate :parent_must_belong_to_same_branch, if: :parent_id
+    validate :can_only_have_one_revision_with_parent, if: :parent_id
+    validate :can_only_have_one_origin_revision_per_branch, unless: :parent_id
+    validate :selected_file_changes_must_be_valid, if: :publishing?
+
+    # Create a non-published revision for the branch and commit all files staged
+    # in the branch
+    def self.create_draft_and_commit_files_for_branch!(branch, author)
+      create!(branch: branch, parent: branch.commits.last, author: author)
+        .tap(&:commit_all_files_staged_in_branch)
+        .tap(&:generate_diffs)
+    end
+
+    # Take ID and current snapshot ID of all (non-root) file resources currently
+    # staged in branch and import them as committed files for this revision.
+    def commit_all_files_staged_in_branch
+      CommittedFile.insert_from_select_query(
+        %i[commit_id file_snapshot_id],
+        branch.staged_file_snapshots
+              .without_root # only commit non-root snapshots
+              .select(id, :id)
+      )
+    end
+
+    # Return the array of individual changes of this revision
+    def file_changes
+      file_diffs.flat_map(&:changes)
+    end
+
+    # Calculate and cache file diffs from parent revision to self
+    def generate_diffs
+      FileDiff.where(commit: self).delete_all # Delete all existing diffs
+      Operations::FileDiffsCalculator.new(commit: self).cache_diffs!
+      file_diffs.reset                          # Reset association
+      true                                      # Return success
+    end
+
+    # Publish this revision, optionally updating the given attributes
+    def publish(attributes_to_update = {})
+      update(attributes_to_update.merge(is_published: true))
+    end
+
+    def published?
+      is_published_in_database
+    end
+
+    # Mark the file changes identified by the given IDs as selected and all other
+    # file changes as unselected
+    def selected_file_change_ids=(ids)
+      file_changes.each do |change|
+        ids.include?(change.id) ? change.select! : change.unselect!
+      end
+    end
+
+    # Return all file changes that are NOT selected
+    def unselected_file_changes
+      file_changes.reject(&:selected?)
+    end
+
+    private
+
+    # TODO: Refactor, extract dependency
+    def belongs_to_project?
+      Project.find_by_repository_id(repository.id).present?
+    end
+
+    # Update committed_snapshot_id of staged files
+    def update_staged_files
+      branch
+        .staged_files
+        .where('committed_snapshots.file_record_id = vcs_staged_files.file_record_id')
+        .update_all(
+          'committed_snapshot_id = committed_snapshots.id ' \
+          'FROM (' \
+          "#{branch.staged_files.joins("LEFT JOIN (#{committed_snapshots.to_sql}) committed_snapshots ON committed_snapshots.file_record_id = vcs_staged_files.file_record_id").select('committed_snapshots.id, vcs_staged_files.file_record_id').to_sql}) committed_snapshots")
+    end
+
+    # Apply selected changes to each file diff
+    def apply_selected_file_changes
+      # Skip if all changes are selected
+      return if unselected_file_changes.none?
+
+      # Apply changes on each diff
+      file_diffs.each(&:apply_selected_changes)
+
+      # Re-generate diffs
+      generate_diffs
+    end
+
+    def can_only_have_one_origin_revision_per_branch
+      return unless published_origin_revision_exists_for_branch?
+
+      errors.add(:base, 'An origin revision already exists for this branch')
+    end
+
+    def can_only_have_one_revision_with_parent
+      return unless published_revision_with_parent_exists?
+
+      errors.add(:base,
+                 'Someone has captured changes to this branch since you ' \
+                 'started reviewing changes. To prevent you and your team from ' \
+                 "overwriting each other's changes, you cannot capture the " \
+                 'changes you are currently reviewing.')
+    end
+
+    def parent_must_belong_to_same_branch
+      return if parent.branch_id == branch_id
+
+      errors.add(:parent, 'must belong to same branch')
+    end
+
+    def published_origin_revision_exists_for_branch?
+      self.class.exists?(branch_id: branch_id, parent: nil, is_published: true)
+    end
+
+    def published_revision_with_parent_exists?
+      self.class.exists?(parent_id: parent_id, is_published: true)
+    end
+
+    # Return true if revision is currently being published
+    def publishing?
+      is_published &&
+        (will_save_change_to_is_published? || saved_change_to_is_published?)
+    end
+
+    def selected_file_changes_must_be_valid
+      # Skip if all changes are selected
+      return if unselected_file_changes.none?
+
+      file_changes.select(&:selected?).each do |file_change|
+        next if file_change.valid?
+
+        errors[:base].push(*file_change.errors.full_messages)
+      end
+    end
+  end
+end

--- a/app/models/vcs/committed_file.rb
+++ b/app/models/vcs/committed_file.rb
@@ -1,0 +1,76 @@
+module VCS
+  class CommittedFile < ApplicationRecord
+    belongs_to :commit
+    belongs_to :file_snapshot
+
+    validates :file_snapshot_id,
+              uniqueness: {
+                scope: %i[commit_id],
+                message: 'file snapshot already exists in this revision'
+              }
+
+    # Scopes
+    # Committed files where snapshot ID changed from commit 1 to commit 2
+    scope :where_snapshot_changed_between_commits, lambda { |commit1, commit2|
+      joins(:file_snapshot)
+        .select(
+          "#{VCS::FileSnapshot.table_name}.file_record_id AS file_record_id",
+          :file_snapshot_id,
+          'min(commit_id) AS commit_id'
+        )
+        .where(commit_id: [commit1, commit2].compact)
+        .group("#{FileSnapshot.table_name}.file_record_id", :file_snapshot_id)
+        .having('count(*) = 1')
+    }
+    scope :distinct_file_resources_between_commits, lambda { |commit1, commit2|
+      joins(:file_snapshot)
+        .select("DISTINCT ON (#{FileSnapshot.table_name}.file_record_id) " \
+                "#{FileSnapshot.table_name}.file_record_id")
+        .where(commit_id: [commit1, commit2].compact)
+        .order("#{FileSnapshot.table_name}.file_record_id", commit_id: :desc)
+    }
+
+    # scope :with_file_record_id, lambda {
+    #   joins(:file_snapshot)
+    #     .select(
+    #       "#{table_name}.*, " \
+    #       "#{VCS::FileSnapshot.table_name}.file_record_id"
+    #     )
+    # }
+
+    # Execute INSERT query based on the SELECT query
+    # Order of columns must match order of select statements.
+    # For example:
+    # CommittedFile.insert_from_select_query(
+    #  [:revision_id, :file_resource_id, :file_resource_snapshot_id],
+    #  FileResource.select(1, :id, :current_snapshot_id)
+    # )
+    # Timestamps (created_at and updated_at) are automatically added.
+    def self.insert_from_select_query(columns, select_query)
+      columns.push(:created_at, :updated_at)
+
+      ActiveRecord::Base.connection.execute(
+        "INSERT INTO #{table_name} (#{columns.join(', ')})\n" +
+        select_query.select('NOW() AS created_at', 'NOW() AS updated_at').to_sql
+      )
+    end
+
+    # Mark record as read only when commit is published
+    def readonly?
+      commit_published?
+    end
+
+    # Has the commit been published?
+    def commit_published?
+      commit&.published?
+    end
+
+    private
+
+    def file_resource_snapshot_belongs_to_file_resource
+      return if file_resource_snapshot&.file_resource_id == file_resource_id
+
+      errors.add(:file_resource_snapshot, 'does not belong to file resource')
+    end
+  end
+end

--- a/app/models/vcs/file_backup.rb
+++ b/app/models/vcs/file_backup.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module VCS
+  # A permanent backup of a file resource snapshot
+  class FileBackup < ApplicationRecord
+    # Associations
+    belongs_to :file_snapshot, class_name: 'VCS::FileSnapshot',
+                               dependent: false, inverse_of: :backup
+
+    # Validations
+    validates :file_snapshot_id,
+              uniqueness: { message: 'already has a backup' }
+    validates :archive, presence: true, on: :capture
+    validates :external_id, presence: true, on: %i[create update]
+
+    # TODO: after_destroy --> destroy backup if this is last reference to it
+
+    # Create a backup for the provided file resource
+    def self.backup(staged_file_to_backup)
+      new(file_snapshot: staged_file_to_backup.current_snapshot)
+        .tap(&:capture)
+        .tap(&:save)
+    end
+
+    # Capture a backup of the file resource snapshot and store in archive
+    def capture
+      return false unless valid?(:capture)
+
+      # Create backup
+      # TODO: Refactor to file_resource.duplicate_remote
+      file = staged_file_remote.duplicate(
+        name: file_snapshot.name,
+        parent_id: archive_folder_id
+      )
+
+      return false unless file.present?
+
+      self.external_id = file.id
+    end
+
+    # TODO: Refactor onto snapshot
+    def external_link
+      Providers::GoogleDrive::Link
+        .for(external_id: external_id, mime_type: file_snapshot.mime_type)
+    end
+
+    private
+
+    def archive
+      @archive ||= file_snapshot.file_record.repository.archive
+    end
+
+    def archive_folder_id
+      archive.external_id
+    end
+
+    def staged_file_remote
+      sync_adapter_class.new(file_snapshot.external_id)
+    end
+
+    def provider
+      'GoogleDrive'
+    end
+
+    def sync_adapter_class
+      "Providers::#{provider}::FileSync".constantize
+    end
+  end
+end

--- a/app/models/vcs/file_diff.rb
+++ b/app/models/vcs/file_diff.rb
@@ -1,0 +1,112 @@
+# query 1 example
+# r = VCS::StagedFile.select('committed_snapshots.id AS committed_snapshot_id', 'vcs_file_snapshots.id AS current_snapshot_id', 'COALESCE(vcs_file_snapshots.id, committed_snapshots.id) AS current_or_committed_snapshot_id').left_joins(:current_snapshot).joins("INNER JOIN (#{VCS::Commit.last_per_branch.to_sql}) last_commits ON last_commits.branch_id = vcs_staged_files.branch_id").joins("INNER JOIN vcs_committed_files ON vcs_committed_files.commit_id = last_commits.id").joins("LEFT JOIN vcs_file_snapshots committed_snapshots ON (committed_snapshots.file_record_id = vcs_staged_files.file_record_id AND committed_snapshots.id = vcs_committed_files.file_snapshot_id)").where('committed_snapshots.id IS NOT NULL OR vcs_file_snapshots.id IS NOT NULL').distinct.first
+
+module VCS
+  class FileDiff < ApplicationRecord
+    include VCS::Diffing
+
+    belongs_to :commit, inverse_of: :file_diffs
+    belongs_to :new_snapshot, class_name: 'FileSnapshot', optional: true
+    belongs_to :old_snapshot, class_name: 'FileSnapshot', optional: true
+
+    # Alias
+    # TODO: This is for legacy support for Diffing concern. Once old FileDiff
+    # => class is deleted, refactor this.
+    alias current_snapshot new_snapshot
+    alias current_snapshot= new_snapshot=
+    alias previous_snapshot old_snapshot
+    alias previous_snapshot= old_snapshot=
+    alias_attribute :current_snapshot_id, :new_snapshot_id
+    alias_attribute :previous_snapshot_id, :old_snapshot_id
+    alias_attribute :revision, :commit
+    delegate :file_record_id, to: :current_or_previous_snapshot, prefix: true
+    alias_method :file_resource_id, :current_or_previous_snapshot_file_record_id
+
+    # Delegations
+    delegate :committed_files, to: :commit
+
+    # Join snapshot on the current snapshot or previous snapshot ID
+    scope :joins_current_or_previous_snapshot, lambda {
+      joins(
+        'INNER JOIN vcs_file_snapshots current_or_previous_snapshot '\
+        "ON COALESCE(#{table_name}.new_snapshot_id, "\
+                    "#{table_name}.old_snapshot_id) "\
+        '= current_or_previous_snapshot.id'
+      )
+    }
+
+    # Order file diffs by
+    # 1) directory first and
+    # 2) file name in ascending alphabetical order, case insensitive
+    scope :order_by_name_with_folders_first, lambda {
+      joins_current_or_previous_snapshot.merge(
+        StagedFile.order_by_name_with_folders_first(
+          table: 'current_or_previous_snapshot'
+        )
+      )
+    }
+
+    # Include file record id
+    scope :with_file_record_id, lambda {
+      joins_current_or_previous_snapshot
+        .select(
+          "#{table_name}.*",
+          'current_or_previous_snapshot.file_record_id AS file_record_id'
+        )
+    }
+
+    # Query diffs by file record ID
+    scope :where_file_record_id, lambda { |file_record_id|
+      with_file_record_id.where('file_record_id = ?', file_record_id)
+    }
+
+    # Validations
+    # Either current or previous snapshot must be present
+    validates :new_snapshot_id, presence: true, unless: :old_snapshot_id
+    validates :old_snapshot_id, presence: true, unless: :new_snapshot_id
+
+    # Apply selected changes to this file diff
+    def apply_selected_changes
+      # Skip if all changes are selected
+      return if changes.all?(&:selected?)
+
+      # apply selected changes
+      changes.each(&:apply)
+
+      # persist changes to committed files
+      persist_file_to_committed_files
+    end
+
+    private
+
+    # Persist current file resource snapshot to the revision's committed files
+    def persist_file_to_committed_files
+      if new_snapshot_id.present? && new_snapshot_id_was.present?
+        update_file_in_committed_files    # Rollback file update
+
+      elsif new_snapshot_id_was.present?
+        delete_file_from_committed_files  # Rollback file addition
+
+      elsif new_snapshot_id.present?
+        add_file_to_committed_files       # Rollback file deletion
+      end
+    end
+
+    # Rollback file addition: Delete the file resource from the committed files
+    def delete_file_from_committed_files
+      committed_files.find_by_file_snapshot_id(new_snapshot_id_was).destroy
+    end
+
+    # Rollback file deletion: Add the file resource to the committed files
+    def add_file_to_committed_files
+      committed_files.create(file_snapshot_id: new_snapshot_id)
+    end
+
+    # Rollback file update: Update the file resource in the committed files
+    def update_file_in_committed_files
+      committed_files
+        .find_by_file_snapshot_id(new_snapshot_id_was)
+        .update!(file_snapshot: new_snapshot.snapshot!)
+    end
+  end
+end

--- a/app/models/vcs/file_record.rb
+++ b/app/models/vcs/file_record.rb
@@ -1,0 +1,16 @@
+module VCS
+  class FileRecord < ApplicationRecord
+    belongs_to :repository
+
+    has_many :repository_branches, through: :repository, source: :branches
+    has_many :staged_instances, ->(file_record) { where(file_record_id: file_record.id) },
+             through: :repository_branches,
+             source: :staged_files
+
+    has_many :file_snapshots,  dependent: :destroy
+    has_many :file_snapshots_of_children,
+             class_name: 'VCS::FileSnapshot',
+             foreign_key: :file_record_parent_id,
+             dependent: :destroy
+  end
+end

--- a/app/models/vcs/file_record.rb
+++ b/app/models/vcs/file_record.rb
@@ -7,7 +7,7 @@ module VCS
              through: :repository_branches,
              source: :staged_files
 
-    has_many :file_snapshots,  dependent: :destroy
+    has_many :file_snapshots, dependent: :destroy
     has_many :file_snapshots_of_children,
              class_name: 'VCS::FileSnapshot',
              foreign_key: :file_record_parent_id,

--- a/app/models/vcs/file_snapshot.rb
+++ b/app/models/vcs/file_snapshot.rb
@@ -11,6 +11,9 @@ module VCS
     has_many :committing_files, class_name: 'CommittedFile',
                                 foreign_key: :file_snapshot_id
 
+    has_one :backup, class_name: 'VCS::FileBackup', dependent: :destroy,
+                     inverse_of: :file_snapshot
+
     # Callbacks
     # Prevent updates to file snapshot; snapshots are immutable.
     before_update do

--- a/app/models/vcs/file_snapshot.rb
+++ b/app/models/vcs/file_snapshot.rb
@@ -1,0 +1,152 @@
+module VCS
+  class FileSnapshot < ApplicationRecord
+    include VCS::Resourceable
+
+    # Associations
+    belongs_to :file_record, autosave: false
+    belongs_to :file_record_parent, class_name: 'FileRecord', optional: true
+
+    has_many :staging_files, class_name: 'VCS::StagedFile', foreign_key: :file_record_id
+
+    has_many :committing_files, class_name: 'CommittedFile',
+                                foreign_key: :file_snapshot_id
+
+    # Callbacks
+    # Prevent updates to file snapshot; snapshots are immutable.
+    before_update do
+      raise ActiveRecord::ReadOnlyRecord
+    end
+
+    # Attributes
+    alias_attribute :snapshotable_id, :file_record_id
+    # TODO: Legacy support, REMOVE soon
+    alias_attribute :parent_id, :file_record_parent_id
+
+    # Scopes
+    scope :joins_current_snapshot, lambda {
+      left_joins(file_record: :current_snapshot)
+    }
+
+    # Snapshots where the file has been deleted (current snapshot is nil)
+    scope :where_current_snapshot_is_nil, lambda {
+      joins_current_snapshot
+        .where('current_snapshots_file_resources IS ?', nil)
+    }
+
+    # Snapshots where the file currently has the given parent
+    scope :where_current_snapshot_parent, lambda { |parent|
+      joins_current_snapshot
+        .where('current_snapshots_file_resources.file_record_parent_id = ?', parent)
+    }
+
+    # Snapshots that are committed in the given revision
+    scope :of_revision, lambda { |revision|
+      joins(:committing_files).where(committed_files: { revision_id: revision })
+    }
+
+    # TODO: Add in support for different providers set on repository level
+    # # Return snapshots with provider ID from file resource
+    # scope :with_provider_id, lambda {
+    #   joins(:file_resource)
+    #     .select('file_resource_snapshots.*')
+    #     .select('file_resources.provider_id')
+    # }
+
+    # Order committed files by
+    # 1) directory first and
+    # 2) file name in ascending alphabetical order, case insensitive
+    scope :order_by_name_with_folders_first, lambda {
+      merge(
+        StagedFile.order_by_name_with_folders_first(
+          table: table_name
+        )
+      )
+    }
+
+    # Validations
+    validates :file_record_id,    presence: true
+    validates :name,              presence: true
+    validates :content_version,   presence: true
+    validates :mime_type,         presence: true
+    validates :external_id,       presence: true
+    validates :file_record_id,
+              uniqueness: {
+                scope: %i[external_id content_version mime_type name file_record_parent_id],
+                message: 'already has a snapshot with these attributes'
+              },
+              if: :new_record?
+
+    # Finds an existing snapshot with the given attributes or creates a new one
+    def self.for(attributes)
+      find_or_create_by_attributes(
+        core_attributes(attributes),
+        supplemental_attributes(attributes)
+      )
+    end
+
+    # The set of core attributes that uniquely identify a snapshot
+    def self.core_attributes(attributes)
+      attributes.symbolize_keys.slice(*core_attribute_keys)
+    end
+
+    # The set of core attributes that uniquely identify a snapshot
+    def self.core_attribute_keys
+      %i[file_record_id name external_id content_version mime_type file_record_parent_id]
+    end
+
+    # Find or create a snapshot from the set of core attributes, optionally
+    # updating its supplemental attributes
+    def self.find_or_create_by_attributes(core, supplements)
+      create_with(supplements).find_or_create_by!(core).tap do |snapshot|
+        snapshot.update_supplemental_attributes(supplements)
+      end
+    end
+
+    # The set of supplemental attributes to a snapshot
+    def self.supplemental_attributes(attributes)
+      attributes.symbolize_keys.slice(*supplemental_attribute_keys)
+    end
+
+    # The set of supplemental attributes to a snapshot
+    def self.supplemental_attribute_keys
+      %i[thumbnail_id]
+    end
+
+    # Return provider ID of file resource, either preloaded or from file
+    # resource
+    def provider_id
+      0
+    end
+
+    # Create a new snapshot from the current snapshot's attributes and set the
+    # current snapshot to the new one
+    def snapshot!
+      self.id = self.class.for(attributes).id
+      reload
+    end
+
+    # Update any new supplemental attributes, such as thumbnail
+    def update_supplemental_attributes(new_attributes)
+      # Return all supplemental attribute key-value pairs that are not
+      # supplemental attributes of current snapshot
+      # h1: {thumbnail: '1', attribute_a: 'abc'}
+      # h2: {thumbnail: '2'}
+      # --> {thumbnail: '1', attribute_a: 'abc'}
+      # See: https://stackoverflow.com/a/24642938/6451879
+      attributes_to_update =
+        (new_attributes.to_a - supplemental_attributes.to_a).to_h
+
+      # If there are no attributes to update, exit
+      return if attributes_to_update.none?
+
+      # Update current snapshot, bypassing callbacks
+      update_columns(attributes_to_update)
+    end
+
+    private
+
+    def supplemental_attributes
+      self.class.supplemental_attributes(attributes)
+    end
+  end
+end

--- a/app/models/vcs/file_thumbnail.rb
+++ b/app/models/vcs/file_thumbnail.rb
@@ -1,0 +1,79 @@
+module VCS
+  class FileThumbnail < ApplicationRecord
+    # Attachments
+    has_attached_file :image,
+                      styles: { original: '200x200#' },
+                      path: ':attachment_path/:class/' \
+                            ':external_id/:version_id/' \
+                            ':hash.:content_type_extension',
+                      url:  ':attachment_url/:class/' \
+                            ':external_id/:version_id/' \
+                            ':hash.:content_type_extension',
+                      default_url: '/fallback/file_resources/thumbnail.png',
+                      hash_secret: ENV['THUMBNAIL_HASH_SECRET']
+
+    # Validations
+    validates_with AttachmentPresenceValidator,
+                   attributes: :image
+    validates_with AttachmentSizeValidator,
+                   attributes: :image,
+                   less_than: 1.megabytes
+    validates_with AttachmentContentTypeValidator,
+                   attributes: :image,
+                   content_type: %w[image/jpeg image/gif image/png],
+                   message: 'must be JPEG, PNG, or GIF'
+    validates :version_id, uniqueness: {
+      scope: %i[external_id],
+      message: 'with external ID already exists'
+    }, if: :new_record?
+
+    # Callbacks
+    # Prevent updates to file thumbnail; thumbnails are immutable.
+    before_update do
+      raise ActiveRecord::ReadOnlyRecord
+    end
+
+    # Parse the file resource to a hash of attributes
+    def self.attributes_from_staged_file(staged_file)
+      {
+        external_id: staged_file.external_id,
+        version_id:  staged_file.thumbnail_version_id
+      }
+    end
+
+    # Find or initialize a Thumbnail instance by provider ID, external ID, and
+    # version ID
+    def self.find_or_initialize_by_staged_file(staged_file)
+      find_or_initialize_by(
+        attributes_from_staged_file(staged_file)
+      )
+    end
+
+    # Preload thumbnail for the given objects
+    def self.preload_for(objects)
+      # Fetch all thumbnails that belong to objects
+      records = where(id: objects.map(&:thumbnail_id).compact.uniq)
+
+      # Associate thumbnails with the owning objects
+      objects.each do |owner|
+        record = records.find { |r| r.id == owner.thumbnail_id }
+
+        association = owner.association(:thumbnail)
+        association.target = record
+        association.set_inverse_instance(record)
+      end
+    end
+
+    # Set external ID and version ID from the given staged file
+    def staged_file=(staged_file)
+      assign_attributes(
+        self.class.attributes_from_staged_file(staged_file)
+      )
+    end
+
+    # Set the image from proc object that returns a raw image
+    def raw_image=(raw_image)
+      self.image = StringIO.new(raw_image.call)
+    end
+  end
+end

--- a/app/models/vcs/operations/file_ancestry_tree.rb
+++ b/app/models/vcs/operations/file_ancestry_tree.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module VCS::Operations
+  # Generate the ancestor tree for a set of files at a given revision
+  class FileAncestryTree
+    # Initialize and generate tree
+    # MUST PASS file_record_ids!
+    def self.generate(commit:, file_record_ids:, depth:)
+      tree = new(commit: commit, file_ids: file_record_ids)
+      # Load generations depth + 1 times because 1st generation is just current
+      # files
+      tree.recursively_load_generations(depth: depth + 1)
+      tree
+    end
+
+    def initialize(commit:, file_ids:)
+      self.commit = commit
+      initialize_tree(file_ids)
+    end
+
+    # Return the ancestor names for a given file ID
+    def ancestors_names_for(file_record_id, depth:)
+      ancestor_names = []
+      file = find(file_record_id)
+
+      (1..depth).each do
+        file = find(file[:parent])
+        break unless file.present?
+
+        ancestor_names << file[:name]
+      end
+
+      ancestor_names
+    end
+
+    # Load records for all nil entries
+    def load_generation
+      return unless nil_entries.any?
+
+      parents = fetch_records_for(nil_entries.keys)
+
+      # add parents fetched from database
+      add_entries(parents)
+
+      # set nil entries to false (these records were not found)
+      update_entries(nil_entries.keys, false)
+
+      # add parents' parent IDs as nil entries (these records will be fetched
+      # next time)
+      add_nil_entries(parents.map { |parent| parent[:parent] }.compact)
+    end
+
+    # Recursively call #load_generation depth number of times
+    def recursively_load_generations(depth:)
+      depth.times do
+        load_generation
+      end
+    end
+
+    private
+
+    attr_accessor :commit, :tree
+
+    # Add entries, must be an array of hashes in format:
+    # {id: _, name: _, parent: _}
+    def add_entries(entries)
+      new_entries =
+        entries
+        .map { |hash| [hash[:id], hash.slice(:name, :parent)] }
+        .to_h
+      tree.merge!(new_entries)
+    end
+
+    # Find an entry by ID or return nil
+    def find(id)
+      tree[id] || nil
+    end
+
+    # Set up tree with nil entrie
+    def initialize_tree(file_ids)
+      self.tree = {}
+      add_nil_entries(file_ids)
+    end
+
+    # Return all hashes with nil value
+    def nil_entries
+      tree.select { |_, entry| entry.nil? }
+    end
+
+    # Add IDs with nil value
+    def add_nil_entries(ids)
+      nil_entry_hash = ids.map { |id| [id, nil] }.to_h
+      tree.reverse_merge!(nil_entry_hash)
+    end
+
+    # Update entries of IDs with new value
+    def update_entries(ids, new_value)
+      updated_entries = ids.map { |id| [id, new_value] }.to_h
+      tree.merge!(updated_entries)
+    end
+
+    # Fetch file snapshot records for the given IDs
+    def fetch_records_for(ids)
+      VCS::CommittedFile
+        .connection
+        .select_all(distinct_file_resources_between_revisions_with_ids(ids))
+        .rows.map { |id, name, parent| { id: id, name: name, parent: parent } }
+    end
+
+    # ActiveRecord query for distinct file resources between revision and its
+    # parent revision for a given array of IDs
+    def distinct_file_resources_between_revisions_with_ids(ids)
+      VCS::CommittedFile
+        .distinct_file_resources_between_commits(commit, commit.parent_id)
+        .joins(:file_snapshot)
+        .select("#{snapshot_table_name}.name",
+                "#{snapshot_table_name}.file_record_parent_id")
+        .where("#{snapshot_table_name}": { file_record_id: ids })
+    end
+
+    def snapshot_table_name
+      VCS::FileSnapshot.table_name
+    end
+  end
+end

--- a/app/models/vcs/operations/file_diffs_calculator.rb
+++ b/app/models/vcs/operations/file_diffs_calculator.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module VCS::Operations
+  # Calculate and cache file diffs from one commit to another
+  class FileDiffsCalculator
+    # Initialize a new instance of FileDiffCalculator to calculate file diffs
+    # between commit and its parent commit
+    def initialize(commit:)
+      self.commit = commit
+    end
+
+    # Persist diffs to database in FileDiffs table
+    def cache_diffs!
+      VCS::FileDiff.import(diffs, validate: false)
+    end
+
+    # Return diffs as attribute hashes
+    def diffs
+      @diffs ||= calculate_diffs
+    end
+
+    private
+
+    attr_accessor :commit
+
+    # Number of ancestors to load for each diff
+    def ancestor_depth
+      3
+    end
+
+    # Return an array of ancestors names for a given diff, up to default depth
+    def ancestors_names_for(diff)
+      ancestry_tree.ancestors_names_for(diff['file_record_id'],
+                                        depth: ancestor_depth)
+    end
+
+    # Return (or load) ancestry tree for diffs
+    def ancestry_tree
+      @ancestry_tree ||=
+        FileAncestryTree.generate(
+          commit: commit,
+          file_record_ids: raw_diffs.map { |diff| diff['file_record_id'] },
+          depth: ancestor_depth
+        )
+    end
+
+    # Calculate diffs by converting raw diffs to attribute hashes and adding
+    # ancestor names up to default depth
+    def calculate_diffs
+      raw_diffs.map do |raw_diff|
+        raw_diff_to_diff(raw_diff)
+          .merge('first_three_ancestors' => ancestors_names_for(raw_diff))
+          .except('file_record_id')
+      end
+    end
+
+    # Return committed files where snapshot changed from commit parent to
+    # commit
+    def committed_files_where_snapshot_changed
+      VCS::CommittedFile
+        .where_snapshot_changed_between_commits(commit, commit.parent_id)
+    end
+
+    # Parse a single raw diff to an attribute diff
+    def raw_diff_to_diff(raw_diff)
+      raw_diff
+        .slice('file_record_id')
+        .merge(
+          'commit_id' => commit.id,
+          'new_snapshot_id' =>
+            snapshot_id_from_raw_diff(raw_diff, commit.id),
+          'old_snapshot_id' =>
+            snapshot_id_from_raw_diff(raw_diff, commit.parent_id)
+        )
+    end
+
+    # Return committed files where snapshot changed from commit parent to
+    # commit grouped into a single row for every file resource
+    def raw_diffs
+      @raw_diffs ||=
+        VCS::FileDiff
+        .select('file_record_id', 'json_agg(subquery) AS snapshots')
+        .from(committed_files_where_snapshot_changed)
+        .group('file_record_id')
+        .reorder('subquery.file_record_id')
+        .map(&:attributes)
+    end
+
+    # Retrieve the file resource snapshot from the given raw diff and commit
+    def snapshot_id_from_raw_diff(raw_diff, commit_id)
+      raw_diff['snapshots']
+        .find { |snapshots| snapshots['commit_id'] == commit_id }
+        &.fetch('file_snapshot_id', nil)
+        &.to_i
+    end
+  end
+end

--- a/app/models/vcs/repository.rb
+++ b/app/models/vcs/repository.rb
@@ -1,5 +1,10 @@
 module VCS
   class Repository < ApplicationRecord
     has_many :branches, dependent: :destroy
+
+    has_one :archive, dependent: :destroy
+    has_many :file_records, dependent: :destroy
+    has_many :file_snapshots, through: :file_records
+    has_many :file_backups, through: :file_snapshots, source: :backup
   end
 end

--- a/app/models/vcs/repository.rb
+++ b/app/models/vcs/repository.rb
@@ -1,0 +1,5 @@
+module VCS
+  class Repository < ApplicationRecord
+    has_many :branches, dependent: :destroy
+  end
+end

--- a/app/models/vcs/staged_file.rb
+++ b/app/models/vcs/staged_file.rb
@@ -177,11 +177,13 @@ module VCS
       current_snapshot || committed_snapshot
     end
 
-    def diff
-      VCS::FileDiff.new(
-        new_snapshot_id: current_snapshot_id,
-        old_snapshot_id: committed_snapshot_id
-      )
+    def diff(with_ancestry: false)
+      VCS::FileDiff.new.tap do |diff|
+        diff.new_snapshot_id = current_snapshot_id
+        diff.old_snapshot_id = committed_snapshot_id
+        # TODO: Add depth option for ancestry. Should be max 3
+        diff.first_three_ancestors = ancestors.map(&:name) if with_ancestry
+      end
     end
 
     def deleted?

--- a/app/models/vcs/staged_file.rb
+++ b/app/models/vcs/staged_file.rb
@@ -12,7 +12,7 @@ module VCS
     # include Stageable
     include VCS::Syncable
     # must be last, so that backup is made after snapshot is persisted
-    # include Backupable
+    include VCS::Backupable
 
     # Associations
     # has_one :parent, ->(staged_file) { where(file_record_id: staged_file.file_record_parent_id) },
@@ -164,7 +164,7 @@ module VCS
         self.file_record_parent_id = new_parent.file_record_id
         @parent = new_parent
       else
-        mark_as_removed
+        mark_as_removed unless root?
       end
     end
 
@@ -202,7 +202,7 @@ module VCS
 
     # Return all children that are folders
     def subfolders
-      children.select(&:folder?)
+      staged_children.select(&:folder?)
     end
 
     private

--- a/app/models/vcs/staged_file.rb
+++ b/app/models/vcs/staged_file.rb
@@ -1,0 +1,230 @@
+module VCS
+  class StagedFile < ApplicationRecord
+    belongs_to :branch
+    belongs_to :file_record
+    belongs_to :file_record_parent, class_name: 'FileRecord', optional: true
+
+    belongs_to :committed_snapshot, class_name: 'VCS::FileSnapshot', optional: true
+    belongs_to :current_snapshot, class_name: 'VCS::FileSnapshot', optional: true
+
+    include VCS::Resourceable
+    include VCS::Snapshotable
+    # include Stageable
+    include VCS::Syncable
+    # must be last, so that backup is made after snapshot is persisted
+    # include Backupable
+
+    # Associations
+    # has_one :parent, ->(staged_file) { where(file_record_id: staged_file.file_record_parent_id) },
+    #         class_name: model_name,
+    #         through: :branch,
+    #         source: :staged_files
+    # has_many :children, ->(staged_file) { where(file_record_parent_id: staged_file.file_record_id) },
+    #          through: :branch,
+    #          source: :staged_files
+
+    scope :joins_staged_snapshot, lambda {
+      joins(
+        'INNER JOIN vcs_file_snapshots staged_snapshots ' \
+        "ON (COALESCE(#{table_name}.current_snapshot_id, "\
+                     "#{table_name}.committed_snapshot_id) "\
+        '= staged_snapshots.id)'
+      )
+    }
+
+    # TODO: Move to a different class
+    # for this model, add joins_staged_snapshot
+    scope :order_by_name_with_folders_first, lambda { |table: nil|
+      folder_mime_type = Providers::GoogleDrive::MimeType.folder
+      table ||= 'staged_snapshots'
+
+      order(
+        Arel.sql(
+          "#{table}.mime_type IN (#{connection.quote(folder_mime_type)}) desc, " \
+          "#{table}.name asc"
+        )
+      )
+    }
+
+    # has_many :snapshots, class_name: 'VCS::FileSnapshot', foreign_key: :file_record_id
+
+    # scope :with_committed_snapshot, lambda {
+    #   select("#{table_name}.*", 'committed_snapshots.id AS committed_snapshot_id')
+    #     .joins("INNER JOIN (#{VCS::Commit.last_per_branch.to_sql}) last_commits ON last_commits.branch_id = vcs_staged_files.branch_id")
+    #     .joins("INNER JOIN vcs_committed_files ON vcs_committed_files.commit_id = last_commits.id")
+    #     .joins("INNER JOIN vcs_file_snapshots committed_snapshots ON (committed_snapshots.file_record_id = vcs_staged_files.file_record_id AND committed_snapshots.id = vcs_committed_files.file_snapshot_id)")
+    # }
+    #
+    # scope :with_current_or_committed_snapshot, lambda {
+    #   select(
+    #     "#{table_name}.*",
+    #     'files_in_last_commit.committed_snapshot_id AS committed_snapshot_id'
+    #   )
+    #     .left_joins(:current_snapshot)
+    #     .joins(<<-SQL.squish
+    #       LEFT JOIN (#{VCS::StagedFile.with_committed_snapshot.to_sql})
+    #       files_in_last_commit ON files_in_last_commit.id = vcs_staged_files.id
+    #       SQL
+    #     ).where('vcs_staged_files.current_snapshot_id IS NOT NULL OR files_in_last_commit.id IS NOT NULL')
+    # }
+    #
+    # scope :joins_current_or_committed_snapshot, lambda {
+    #   with_current_or_committed_snapshot
+    #     .joins(
+    #       'INNER JOIN vcs_file_snapshots current_or_previous_snapshots ' \
+    #       "ON (COALESCE(#{table_name}.current_snapshot_id, "\
+    #                    'committed_snapshot_id) '\
+    #       '= current_or_previous_snapshots.id)'
+    #     )
+    # }
+    #
+    # scope :with_current_or_committed_snapshot_in_folder, lambda { |folder|
+    #   joins_current_or_committed_snapshot
+    #     .where(
+    #       'current_or_previous_snapshots.file_record_parent_id = ?',
+    #       folder.file_record_id
+    #     )
+    # }
+
+    # Validations
+    validates :external_id, presence: true
+    validates :external_id, uniqueness: { scope: :branch_id },
+                            if: :will_save_change_to_external_id?
+
+    # validate :cannot_be_its_own_parent, if: :parent_association_loaded?
+
+    # Only perform validation if no errors have been encountered
+    with_options unless: :any_errors? do
+      validate :cannot_be_its_own_ancestor,
+               if: :will_save_change_to_file_record_parent_id?
+    end
+
+    # Require presence of metadata unless file resource is deleted
+    with_options unless: :deleted? do
+      # TODO: Refactor. Must use if: :not_root? because unless: :root? would
+      # => overwrite top level condition.
+      # See: https://stackoverflow.com/a/15388137/6451879
+      validates :file_record_parent_id, presence: true, if: :not_root?
+      validates :name, presence: true
+      validates :mime_type, presence: true
+      validates :content_version, presence: true
+    end
+
+    # Recursively collect parents
+    def ancestors
+      return [] if parent.nil? || parent.root?
+
+      [parent.staged_snapshot] + parent.ancestors
+    end
+
+    # Recursively collect ids of parents
+    def ancestors_ids
+      ancestors.map(&:file_record_id)
+    end
+
+    def children
+      @children ||=
+        branch
+        .staged_files
+        .joins_staged_snapshot
+        .where('staged_snapshots.file_record_parent_id = ?', file_record_id)
+    end
+
+    def staged_children=(new_children)
+      new_children.each { |child| child.update(parent: self) }
+
+      staged_children.where.not(id: new_children.map(&:id)).find_each(&:pull)
+
+      # Clear children because they are no longer accurate, as STAGED children
+      # have changed and status of committed children is unclear
+      @children = nil
+    end
+
+    def staged_children
+      branch
+        .staged_files
+        .joins(:current_snapshot)
+        .where(
+          "#{VCS::FileSnapshot.table_name}": {
+            file_record_parent_id: file_record_id
+          }
+        )
+    end
+
+    def parent
+      @parent ||=
+        branch
+        .staged_files
+        .joins_staged_snapshot
+        .find_by('staged_snapshots.file_record_id = ?', staged_snapshot&.file_record_parent_id)
+    end
+
+    def parent=(new_parent)
+      if new_parent.present?
+        self.file_record_parent_id = new_parent.file_record_id
+        @parent = new_parent
+      else
+        mark_as_removed
+      end
+    end
+
+    # TODO: Rename is_deleted to is_removed
+    def mark_as_removed
+      assign_attributes(file_record_parent_id: nil, name: nil, mime_type: nil, content_version: nil, is_deleted: true)
+    end
+
+    def staged_snapshot
+      current_snapshot || committed_snapshot
+    end
+
+    def diff
+      VCS::FileDiff.new(
+        new_snapshot_id: current_snapshot_id,
+        old_snapshot_id: committed_snapshot_id
+      )
+    end
+
+    def deleted?
+      is_deleted
+    end
+
+    def folder?
+      Object.const_get("#{provider}::MimeType").folder?(mime_type)
+    end
+
+    def root?
+      is_root
+    end
+
+    def not_root?
+      !root?
+    end
+
+    # Return all children that are folders
+    def subfolders
+      children.select(&:folder?)
+    end
+
+    private
+
+    def any_errors?
+      errors.any?
+    end
+
+    def cannot_be_its_own_ancestor
+      return unless ancestors_ids.include? file_record_id
+
+      errors.add(:base, 'File resource cannot be its own ancestor')
+    end
+
+    def cannot_be_its_own_parent
+      return unless self == parent
+
+      errors.add(:base, 'File resource cannot be its own parent')
+    end
+
+    def parent_association_loaded?
+      association(:parent).loaded?
+    end
+  end
+end

--- a/app/views/file_infos/_file_version_history.slim
+++ b/app/views/file_infos/_file_version_history.slim
@@ -5,7 +5,7 @@ h3.with-separator.no-margin-bottom: span File History
 - committed_file_diffs.each do |diff|
 
   = render partial: 'revisions/revision',
-           object: diff.revision,
+           object: diff.commit,
            locals: { project: project,
                      file_changes: diff.changes,
                      show_link_to_file_info: false }

--- a/app/views/file_infos/_link_to_parent_folder.slim
+++ b/app/views/file_infos/_link_to_parent_folder.slim
@@ -1,11 +1,12 @@
 / render a button to the file's parent folder
 
 / Link to root folder if parent is root, otherwise, link to parent folder
-- if file.parent.id == project.root_folder.id
+- if file.file_record_parent_id == @master_branch.root.file_record_id
   - path =  profile_project_root_folder_path(project.owner, project)
   - label = 'Home'
 - else
-  - path = profile_project_folder_path(project.owner, project, file.parent.external_id)
+  / TODO: REFACTOR!
+  - path = profile_project_folder_path(project.owner, project, @master_branch.staged_files.find_by(file_record_id: file.file_record_parent_id).external_id)
   - label = 'Parent'
 
 = link_to path,

--- a/app/views/folders/_ancestors.slim
+++ b/app/views/folders/_ancestors.slim
@@ -15,5 +15,5 @@ nav.breadcrumbs.truncate.gray.lighten-3.black-text.z-depth-0
 
         / print each ancestor
         = render partial: 'ancestor',
-                collection: ancestors.reverse.push(current_folder),
+                collection: ancestors.reverse.push(current_folder.staged_snapshot),
                 locals: { current_folder: current_folder, project: project }

--- a/app/views/folders/show.slim
+++ b/app/views/folders/show.slim
@@ -9,7 +9,7 @@
   - @children.each do |child|
 
     = render partial: 'file_diff',
-             object: child,
+             object: child.diff,
              locals: { project: @project }
 
 / button for committing changes

--- a/app/views/notifications/_vcs_commit_notification.slim
+++ b/app/views/notifications/_vcs_commit_notification.slim
@@ -1,0 +1,15 @@
+= link_to notification_path(revision_notification),
+          class: 'notification collection-item avatar' do
+
+  = image_tag revision_notification.notifier.picture.url, class: 'circle'
+
+  - if vcs_commit_notification.unread?
+    .right.chip.primary-color.primary-color-text.slim-on-mobile new
+
+  .title.black-text = vcs_commit_notification.title
+
+  p.gray-text.text-darken-3 = vcs_commit_notification.notifiable.title
+
+  p.gray-text
+    => time_ago_in_words(vcs_commit_notification.created_at)
+    | ago

--- a/app/views/notifications_mailer/_vcs_commit_notification.inky-slim
+++ b/app/views/notifications_mailer/_vcs_commit_notification.inky-slim
@@ -1,0 +1,12 @@
+row
+  columns large="3"
+    center
+      = image_tag vcs_commit_notification.notifier.picture.url,
+                  size: '100', alt: "Picture of #{vcs_commit_notification.notifier.name}"
+  columns large="9"
+    h5 = vcs_commit_notification.title
+    p = vcs_commit_notification.notifiable.title
+    p.dark-gray-text
+      = vcs_commit_notification.created_at.strftime("%a, %d %b %Y at %l:%M%P %Z")
+    button.large href=notification_url(vcs_commit_notification)
+      | Open Notification

--- a/app/views/notifications_mailer/_vcs_commit_notification_text.text.erb
+++ b/app/views/notifications_mailer/_vcs_commit_notification_text.text.erb
@@ -1,0 +1,8 @@
+** <%= vcs_commit_notification.title %>
+-------------------------------------------------------------------------------
+<%= vcs_commit_notification.notifiable.title %>
+
+(<%= vcs_commit_notification.created_at.strftime("%a, %d %b %Y at %l:%M%P %Z") %>)
+
+
+Open Notification: <%= notification_url(vcs_commit_notification) %>

--- a/app/views/project_setups/show.slim
+++ b/app/views/project_setups/show.slim
@@ -12,7 +12,7 @@
     .col.s12
       h4.no-margin-bottom
         .file-import-count
-          => @project.staged_non_root_files.count
+          => @master_branch.staged_files.count
         .file-import-count-description files imported so far.
 
   .spacing.v48px

--- a/app/views/projects/_head.slim
+++ b/app/views/projects/_head.slim
@@ -34,7 +34,7 @@
                 = link_to 'Revisions', profile_project_revisions_path(project.owner, project),
                           class: ('active' if active_tab == :revisions)
               div.tab
-                = link_to project.root_folder.external_link, target: '_blank' do
+                = link_to project.master_branch.root.external_link, target: '_blank' do
                   svg style="width:24px;height:24px" viewBox="0 0 24 24" class="left"
                     path fill="currentColor" d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
                   | Open in Drive

--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -18,10 +18,10 @@ if defined? Bullet
     Bullet.raise = true
   end
 
-  Bullet.add_whitelist type: :unused_eager_loading, class_name: 'FileDiff',
-                       association: :previous_snapshot
-  Bullet.add_whitelist type: :unused_eager_loading, class_name: 'FileDiff',
-                       association: :current_snapshot
+  Bullet.add_whitelist type: :unused_eager_loading, class_name: 'VCS::FileDiff',
+                       association: :new_snapshot
+  Bullet.add_whitelist type: :unused_eager_loading, class_name: 'VCS::FileDiff',
+                       association: :old_snapshot
 
   Bullet.add_whitelist type: :unused_eager_loading,
                        class_name: 'Profiles::User',
@@ -56,7 +56,7 @@ if defined? Bullet
                        association: :thumbnail
 
   Bullet.add_whitelist type: :unused_eager_loading,
-                       class_name: 'FileResources::GoogleDrive',
+                       class_name: 'VCS::StagedFile',
                        association: :current_snapshot
 
   Bullet.add_whitelist type: :unused_eager_loading,

--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -39,7 +39,7 @@ if defined? Bullet
 
   # Bullet complains when we browse committed files that all have no backups
   Bullet.add_whitelist type: :unused_eager_loading,
-                       class_name: 'FileResource::Snapshot',
+                       class_name: 'VCS::FileSnapshot',
                        association: :backup
 
   # Bullet complains about Ahoy including user

--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -52,7 +52,7 @@ if defined? Bullet
                        association: :parent
 
   Bullet.add_whitelist type: :unused_eager_loading,
-                       class_name: 'FileResources::GoogleDrive',
+                       class_name: 'VCS::StagedFile',
                        association: :thumbnail
 
   Bullet.add_whitelist type: :unused_eager_loading,

--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -60,6 +60,6 @@ if defined? Bullet
                        association: :current_snapshot
 
   Bullet.add_whitelist type: :unused_eager_loading,
-                       class_name: 'CommittedFile',
-                       association: :file_resource_snapshot
+                       class_name: 'VCS::CommittedFile',
+                       association: :file_snapshot
 end

--- a/db/migrate/20181027030827_create_vcs_repositories.rb
+++ b/db/migrate/20181027030827_create_vcs_repositories.rb
@@ -1,0 +1,8 @@
+class CreateVcsRepositories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :vcs_repositories do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20181027031156_create_vcs_branches.rb
+++ b/db/migrate/20181027031156_create_vcs_branches.rb
@@ -1,0 +1,9 @@
+class CreateVcsBranches < ActiveRecord::Migration[5.2]
+  def change
+    create_table :vcs_branches do |t|
+      t.belongs_to :repository, null: false, foreign_key: { to_table: :vcs_repositories }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20181027032134_create_vcs_file_records.rb
+++ b/db/migrate/20181027032134_create_vcs_file_records.rb
@@ -1,0 +1,9 @@
+class CreateVcsFileRecords < ActiveRecord::Migration[5.2]
+  def change
+    create_table :vcs_file_records do |t|
+      t.belongs_to :repository, null: false, foreign_key: { to_table: :vcs_repositories }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20181027032150_create_vcs_file_thumbnails.rb
+++ b/db/migrate/20181027032150_create_vcs_file_thumbnails.rb
@@ -1,0 +1,11 @@
+class CreateVcsFileThumbnails < ActiveRecord::Migration[5.2]
+  def change
+    create_table :vcs_file_thumbnails do |t|
+      t.text :external_id, null: false
+      t.text :version_id, null: false
+      t.attachment :image
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20181027032160_create_vcs_file_snapshots.rb
+++ b/db/migrate/20181027032160_create_vcs_file_snapshots.rb
@@ -1,0 +1,24 @@
+class CreateVcsFileSnapshots < ActiveRecord::Migration[5.2]
+  def change
+    create_table :vcs_file_snapshots do |t|
+      t.belongs_to :file_record, null: false, foreign_key: { to_table: :vcs_file_records }
+      t.belongs_to :file_record_parent, foreign_key: { to_table: :vcs_file_records }
+      t.text :name, null: false
+      t.text :content_version, null: false
+      t.text :external_id, null: false
+      t.string :mime_type, null: false
+      t.belongs_to :thumbnail, foreign_key: { to_table: :vcs_file_thumbnails }
+
+      t.index %i[file_record_id external_id content_version mime_type name
+                 file_record_parent_id],
+              name: 'index_vcs_file_snapshots_on_metadata',
+              unique: true
+      t.index %i[file_record_id external_id content_version mime_type name],
+              name: 'index_vcs_file_snapshots_on_metadata_without_parent',
+              unique: true,
+              where: 'file_record_parent_id IS NULL'
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20181027032236_create_vcs_staged_files.rb
+++ b/db/migrate/20181027032236_create_vcs_staged_files.rb
@@ -1,0 +1,32 @@
+class CreateVcsStagedFiles < ActiveRecord::Migration[5.2]
+  def change
+    create_table :vcs_staged_files do |t|
+      t.belongs_to :branch, null: false, foreign_key: { to_table: :vcs_branches }
+      t.belongs_to :file_record, null: false, foreign_key: { to_table: :vcs_file_records }
+      t.text :external_id, null: false
+      t.belongs_to :file_record_parent, foreign_key: { to_table: :vcs_file_records }
+      t.text :name
+      t.text :content_version
+      t.string :mime_type
+      t.boolean :is_deleted, default: false, null: false
+      t.belongs_to :current_snapshot
+      t.belongs_to :committed_snapshot, foreign_key: { to_table: :vcs_file_snapshots }
+      t.belongs_to :thumbnail, foreign_key: { to_table: :vcs_file_thumbnails }
+
+      t.boolean :is_root, null: false, default: false
+
+      # Can only have one instance of each file record per branch
+      t.index %i[branch_id file_record_id], unique: true
+
+      # Can only have one root file per branch
+      t.index :branch_id,
+              name: 'index_vcs_staged_files_on_root',
+              unique: true,
+              where: 'is_root IS TRUE'
+
+      t.index %i[branch_id external_id], unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20181028004939_create_vcs_commits.rb
+++ b/db/migrate/20181028004939_create_vcs_commits.rb
@@ -1,0 +1,26 @@
+class CreateVcsCommits < ActiveRecord::Migration[5.2]
+  def change
+    create_table :vcs_commits do |t|
+      t.belongs_to :branch, null: false, foreign_key: { to_table: :vcs_branches }
+      t.belongs_to :parent, foreign_key: { to_table: :vcs_commits }
+      t.belongs_to :author, null: false, foreign_key: { to_table: :profiles }
+      t.boolean :is_published, null: false, default: false
+      t.string :title
+      t.text :summary
+
+      # Can only have one published revision per parent
+      t.index :parent_id,
+              name: 'index_commits_on_published_parent_id',
+              unique: true,
+              where: 'is_published IS TRUE'
+
+      # Can only have one root commit (commit without a parent)
+      t.index :branch_id,
+              name: 'index_commits_on_published_root_commit',
+              unique: true,
+              where: 'parent_id IS NULL AND is_published IS TRUE'
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20181028005035_create_vcs_committed_files.rb
+++ b/db/migrate/20181028005035_create_vcs_committed_files.rb
@@ -1,0 +1,13 @@
+class CreateVcsCommittedFiles < ActiveRecord::Migration[5.2]
+  def change
+    create_table :vcs_committed_files do |t|
+      t.belongs_to :commit, null: false, foreign_key: { to_table: :vcs_commits }
+      t.belongs_to :file_snapshot, null: false, foreign_key: { to_table: :vcs_file_snapshots }
+
+      # Each snapshot can exist only once per revision
+      t.index %i[commit_id file_snapshot_id], unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20181028021022_create_vcs_file_diffs.rb
+++ b/db/migrate/20181028021022_create_vcs_file_diffs.rb
@@ -1,0 +1,12 @@
+class CreateVcsFileDiffs < ActiveRecord::Migration[5.2]
+  def change
+    create_table :vcs_file_diffs do |t|
+      t.belongs_to :commit, null: false, foreign_key: { to_table: :vcs_commits }
+      t.belongs_to :new_snapshot, foreign_key: { to_table: :vcs_file_snapshots }
+      t.belongs_to :old_snapshot, foreign_key: { to_table: :vcs_file_snapshots }
+      t.text :first_three_ancestors, array: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20181028132411_add_repository_to_project.rb
+++ b/db/migrate/20181028132411_add_repository_to_project.rb
@@ -1,0 +1,12 @@
+class AddRepositoryToProject < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :projects,
+                  :repository,
+                  foreign_key: { to_table: :vcs_repositories },
+                  unique: true
+    add_reference :projects,
+                  :master_branch,
+                  foreign_key: { to_table: :vcs_branches },
+                  unique: true
+  end
+end

--- a/db/migrate/20181029180902_create_vcs_file_backups.rb
+++ b/db/migrate/20181029180902_create_vcs_file_backups.rb
@@ -1,0 +1,12 @@
+class CreateVcsFileBackups < ActiveRecord::Migration[5.2]
+  def change
+    create_table :vcs_file_backups do |t|
+      t.belongs_to :file_snapshot,
+                   null: false, unique: true,
+                   foreign_key: { to_table: :vcs_file_snapshots }
+      t.text :external_id, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20181029183425_create_vcs_archives.rb
+++ b/db/migrate/20181029183425_create_vcs_archives.rb
@@ -1,0 +1,12 @@
+class CreateVcsArchives < ActiveRecord::Migration[5.2]
+  def change
+    create_table :vcs_archives do |t|
+      t.belongs_to :repository,
+                   null: false, unique: true,
+                   foreign_key: { to_table: :vcs_repositories }
+      t.text :external_id, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_28_132411) do
+ActiveRecord::Schema.define(version: 2018_10_29_183425) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -298,6 +298,14 @@ ActiveRecord::Schema.define(version: 2018_10_28_132411) do
     t.index ["project_id"], name: "index_staged_files_on_root", unique: true, where: "(is_root IS TRUE)"
   end
 
+  create_table "vcs_archives", force: :cascade do |t|
+    t.bigint "repository_id", null: false
+    t.text "external_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["repository_id"], name: "index_vcs_archives_on_repository_id"
+  end
+
   create_table "vcs_branches", force: :cascade do |t|
     t.bigint "repository_id", null: false
     t.datetime "created_at", null: false
@@ -329,6 +337,14 @@ ActiveRecord::Schema.define(version: 2018_10_28_132411) do
     t.index ["commit_id", "file_snapshot_id"], name: "index_vcs_committed_files_on_commit_id_and_file_snapshot_id", unique: true
     t.index ["commit_id"], name: "index_vcs_committed_files_on_commit_id"
     t.index ["file_snapshot_id"], name: "index_vcs_committed_files_on_file_snapshot_id"
+  end
+
+  create_table "vcs_file_backups", force: :cascade do |t|
+    t.bigint "file_snapshot_id", null: false
+    t.text "external_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["file_snapshot_id"], name: "index_vcs_file_backups_on_file_snapshot_id"
   end
 
   create_table "vcs_file_diffs", force: :cascade do |t|
@@ -436,12 +452,14 @@ ActiveRecord::Schema.define(version: 2018_10_28_132411) do
   add_foreign_key "revisions", "revisions", column: "parent_id"
   add_foreign_key "staged_files", "file_resources"
   add_foreign_key "staged_files", "projects"
+  add_foreign_key "vcs_archives", "vcs_repositories", column: "repository_id"
   add_foreign_key "vcs_branches", "vcs_repositories", column: "repository_id"
   add_foreign_key "vcs_commits", "profiles", column: "author_id"
   add_foreign_key "vcs_commits", "vcs_branches", column: "branch_id"
   add_foreign_key "vcs_commits", "vcs_commits", column: "parent_id"
   add_foreign_key "vcs_committed_files", "vcs_commits", column: "commit_id"
   add_foreign_key "vcs_committed_files", "vcs_file_snapshots", column: "file_snapshot_id"
+  add_foreign_key "vcs_file_backups", "vcs_file_snapshots", column: "file_snapshot_id"
   add_foreign_key "vcs_file_diffs", "vcs_commits", column: "commit_id"
   add_foreign_key "vcs_file_diffs", "vcs_file_snapshots", column: "new_snapshot_id"
   add_foreign_key "vcs_file_diffs", "vcs_file_snapshots", column: "old_snapshot_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181018222521) do
+ActiveRecord::Schema.define(version: 2018_10_28_132411) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
   enable_extension "citext"
+  enable_extension "plpgsql"
 
   create_table "accounts", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -32,8 +32,8 @@ ActiveRecord::Schema.define(version: 20181018222521) do
     t.string "name"
     t.jsonb "properties"
     t.datetime "time"
-    t.index "properties jsonb_path_ops", name: "index_ahoy_events_on_properties_jsonb_path_ops", using: :gin
     t.index ["name", "time"], name: "index_ahoy_events_on_name_and_time"
+    t.index ["properties"], name: "index_ahoy_events_on_properties_jsonb_path_ops", opclass: :jsonb_path_ops, using: :gin
     t.index ["user_id"], name: "index_ahoy_events_on_user_id"
     t.index ["visit_id"], name: "index_ahoy_events_on_visit_id"
   end
@@ -246,8 +246,12 @@ ActiveRecord::Schema.define(version: 20181018222521) do
     t.citext "tags", default: [], array: true
     t.boolean "is_public", default: false, null: false
     t.bigint "owner_id", null: false
+    t.bigint "repository_id"
+    t.bigint "master_branch_id"
+    t.index ["master_branch_id"], name: "index_projects_on_master_branch_id"
     t.index ["owner_id", "slug"], name: "index_projects_on_owner_id_and_slug", unique: true
     t.index ["owner_id"], name: "index_projects_on_owner_id"
+    t.index ["repository_id"], name: "index_projects_on_repository_id"
   end
 
   create_table "resources", force: :cascade do |t|
@@ -294,6 +298,117 @@ ActiveRecord::Schema.define(version: 20181018222521) do
     t.index ["project_id"], name: "index_staged_files_on_root", unique: true, where: "(is_root IS TRUE)"
   end
 
+  create_table "vcs_branches", force: :cascade do |t|
+    t.bigint "repository_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["repository_id"], name: "index_vcs_branches_on_repository_id"
+  end
+
+  create_table "vcs_commits", force: :cascade do |t|
+    t.bigint "branch_id", null: false
+    t.bigint "parent_id"
+    t.bigint "author_id", null: false
+    t.boolean "is_published", default: false, null: false
+    t.string "title"
+    t.text "summary"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["author_id"], name: "index_vcs_commits_on_author_id"
+    t.index ["branch_id"], name: "index_commits_on_published_root_commit", unique: true, where: "((parent_id IS NULL) AND (is_published IS TRUE))"
+    t.index ["branch_id"], name: "index_vcs_commits_on_branch_id"
+    t.index ["parent_id"], name: "index_commits_on_published_parent_id", unique: true, where: "(is_published IS TRUE)"
+    t.index ["parent_id"], name: "index_vcs_commits_on_parent_id"
+  end
+
+  create_table "vcs_committed_files", force: :cascade do |t|
+    t.bigint "commit_id", null: false
+    t.bigint "file_snapshot_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["commit_id", "file_snapshot_id"], name: "index_vcs_committed_files_on_commit_id_and_file_snapshot_id", unique: true
+    t.index ["commit_id"], name: "index_vcs_committed_files_on_commit_id"
+    t.index ["file_snapshot_id"], name: "index_vcs_committed_files_on_file_snapshot_id"
+  end
+
+  create_table "vcs_file_diffs", force: :cascade do |t|
+    t.bigint "commit_id", null: false
+    t.bigint "new_snapshot_id"
+    t.bigint "old_snapshot_id"
+    t.text "first_three_ancestors", null: false, array: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["commit_id"], name: "index_vcs_file_diffs_on_commit_id"
+    t.index ["new_snapshot_id"], name: "index_vcs_file_diffs_on_new_snapshot_id"
+    t.index ["old_snapshot_id"], name: "index_vcs_file_diffs_on_old_snapshot_id"
+  end
+
+  create_table "vcs_file_records", force: :cascade do |t|
+    t.bigint "repository_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["repository_id"], name: "index_vcs_file_records_on_repository_id"
+  end
+
+  create_table "vcs_file_snapshots", force: :cascade do |t|
+    t.bigint "file_record_id", null: false
+    t.bigint "file_record_parent_id"
+    t.text "name", null: false
+    t.text "content_version", null: false
+    t.text "external_id", null: false
+    t.string "mime_type", null: false
+    t.bigint "thumbnail_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["file_record_id", "external_id", "content_version", "mime_type", "name", "file_record_parent_id"], name: "index_vcs_file_snapshots_on_metadata", unique: true
+    t.index ["file_record_id", "external_id", "content_version", "mime_type", "name"], name: "index_vcs_file_snapshots_on_metadata_without_parent", unique: true, where: "(file_record_parent_id IS NULL)"
+    t.index ["file_record_id"], name: "index_vcs_file_snapshots_on_file_record_id"
+    t.index ["file_record_parent_id"], name: "index_vcs_file_snapshots_on_file_record_parent_id"
+    t.index ["thumbnail_id"], name: "index_vcs_file_snapshots_on_thumbnail_id"
+  end
+
+  create_table "vcs_file_thumbnails", force: :cascade do |t|
+    t.text "external_id", null: false
+    t.text "version_id", null: false
+    t.string "image_file_name"
+    t.string "image_content_type"
+    t.bigint "image_file_size"
+    t.datetime "image_updated_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "vcs_repositories", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "vcs_staged_files", force: :cascade do |t|
+    t.bigint "branch_id", null: false
+    t.bigint "file_record_id", null: false
+    t.text "external_id", null: false
+    t.bigint "file_record_parent_id"
+    t.text "name"
+    t.text "content_version"
+    t.string "mime_type"
+    t.boolean "is_deleted", default: false, null: false
+    t.bigint "current_snapshot_id"
+    t.bigint "committed_snapshot_id"
+    t.bigint "thumbnail_id"
+    t.boolean "is_root", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["branch_id", "external_id"], name: "index_vcs_staged_files_on_branch_id_and_external_id", unique: true
+    t.index ["branch_id", "file_record_id"], name: "index_vcs_staged_files_on_branch_id_and_file_record_id", unique: true
+    t.index ["branch_id"], name: "index_vcs_staged_files_on_branch_id"
+    t.index ["branch_id"], name: "index_vcs_staged_files_on_root", unique: true, where: "(is_root IS TRUE)"
+    t.index ["committed_snapshot_id"], name: "index_vcs_staged_files_on_committed_snapshot_id"
+    t.index ["current_snapshot_id"], name: "index_vcs_staged_files_on_current_snapshot_id"
+    t.index ["file_record_id"], name: "index_vcs_staged_files_on_file_record_id"
+    t.index ["file_record_parent_id"], name: "index_vcs_staged_files_on_file_record_parent_id"
+    t.index ["thumbnail_id"], name: "index_vcs_staged_files_on_thumbnail_id"
+  end
+
   add_foreign_key "committed_files", "file_resource_snapshots"
   add_foreign_key "committed_files", "file_resources"
   add_foreign_key "committed_files", "revisions"
@@ -313,10 +428,30 @@ ActiveRecord::Schema.define(version: 20181018222521) do
   add_foreign_key "project_archives", "file_resources"
   add_foreign_key "project_archives", "projects"
   add_foreign_key "project_setups", "projects"
+  add_foreign_key "projects", "vcs_branches", column: "master_branch_id"
+  add_foreign_key "projects", "vcs_repositories", column: "repository_id"
   add_foreign_key "resources", "profiles", column: "owner_id"
   add_foreign_key "revisions", "profiles", column: "author_id"
   add_foreign_key "revisions", "projects"
   add_foreign_key "revisions", "revisions", column: "parent_id"
   add_foreign_key "staged_files", "file_resources"
   add_foreign_key "staged_files", "projects"
+  add_foreign_key "vcs_branches", "vcs_repositories", column: "repository_id"
+  add_foreign_key "vcs_commits", "profiles", column: "author_id"
+  add_foreign_key "vcs_commits", "vcs_branches", column: "branch_id"
+  add_foreign_key "vcs_commits", "vcs_commits", column: "parent_id"
+  add_foreign_key "vcs_committed_files", "vcs_commits", column: "commit_id"
+  add_foreign_key "vcs_committed_files", "vcs_file_snapshots", column: "file_snapshot_id"
+  add_foreign_key "vcs_file_diffs", "vcs_commits", column: "commit_id"
+  add_foreign_key "vcs_file_diffs", "vcs_file_snapshots", column: "new_snapshot_id"
+  add_foreign_key "vcs_file_diffs", "vcs_file_snapshots", column: "old_snapshot_id"
+  add_foreign_key "vcs_file_records", "vcs_repositories", column: "repository_id"
+  add_foreign_key "vcs_file_snapshots", "vcs_file_records", column: "file_record_id"
+  add_foreign_key "vcs_file_snapshots", "vcs_file_records", column: "file_record_parent_id"
+  add_foreign_key "vcs_file_snapshots", "vcs_file_thumbnails", column: "thumbnail_id"
+  add_foreign_key "vcs_staged_files", "vcs_branches", column: "branch_id"
+  add_foreign_key "vcs_staged_files", "vcs_file_records", column: "file_record_id"
+  add_foreign_key "vcs_staged_files", "vcs_file_records", column: "file_record_parent_id"
+  add_foreign_key "vcs_staged_files", "vcs_file_snapshots", column: "committed_snapshot_id"
+  add_foreign_key "vcs_staged_files", "vcs_file_thumbnails", column: "thumbnail_id"
 end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -28,5 +28,10 @@ FactoryBot.define do
     trait :skip_archive_setup do
       skip_archive_setup { true }
     end
+
+    trait :with_repository do
+      association :master_branch, factory: :vcs_branch
+      repository { master_branch.repository }
+    end
   end
 end

--- a/spec/factories/vcs/vcs_archives.rb
+++ b/spec/factories/vcs/vcs_archives.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :vcs_archive, class: 'VCS::Archive' do
+    association :repository, factory: :vcs_repository
+  end
+end

--- a/spec/factories/vcs/vcs_branches.rb
+++ b/spec/factories/vcs/vcs_branches.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :vcs_branch, class: 'VCS::Branch' do
+    association :repository, factory: :vcs_repository
+  end
+end

--- a/spec/factories/vcs/vcs_commits.rb
+++ b/spec/factories/vcs/vcs_commits.rb
@@ -1,0 +1,27 @@
+FactoryBot.define do
+  factory :vcs_commit, class: 'VCS::Commit' do
+    author
+    association :branch, factory: :vcs_branch
+    title         { Faker::HarryPotter.quote }
+    summary       { Faker::Lorem.paragraph }
+    is_published  { false }
+
+    trait :drafted do
+      is_published { false }
+    end
+
+    trait :published do
+      is_published { true }
+    end
+
+    trait :with_parent do
+      parent { create(:vcs_commit, branch: branch) }
+    end
+
+    after(:build) do |commit|
+      next if commit.parent&.branch.nil?
+
+      commit.branch = commit.parent.branch
+    end
+  end
+end

--- a/spec/factories/vcs/vcs_committed_files.rb
+++ b/spec/factories/vcs/vcs_committed_files.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :vcs_committed_file, class: 'VCS::CommittedFile' do
+    transient do
+      parent { nil }
+    end
+
+    association :commit, factory: :vcs_commit
+    file_snapshot { create(:vcs_file_snapshot, parent: parent) }
+  end
+end

--- a/spec/factories/vcs/vcs_file_backups.rb
+++ b/spec/factories/vcs/vcs_file_backups.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :vcs_file_backup, class: 'VCS::FileBackup' do
+    association :file_snapshot, factory: :vcs_file_snapshot
+    external_id { Faker::Crypto.unique.sha1 }
+  end
+end

--- a/spec/factories/vcs/vcs_file_diffs.rb
+++ b/spec/factories/vcs/vcs_file_diffs.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :vcs_file_diff, class: 'VCS::FileDiff' do
+    association :commit, factory: :vcs_commit
+    association :new_snapshot, factory: :vcs_file_snapshot
+    first_three_ancestors { Faker::Lorem.words(3) }
+
+    trait :with_previous_snapshot do
+      association :old_snapshot, factory: :vcs_file_snapshot
+    end
+  end
+end

--- a/spec/factories/vcs/vcs_file_records.rb
+++ b/spec/factories/vcs/vcs_file_records.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :vcs_file_record, class: 'VCS::FileRecord' do
+    association :repository, factory: :vcs_repository
+  end
+end

--- a/spec/factories/vcs/vcs_file_snapshots.rb
+++ b/spec/factories/vcs/vcs_file_snapshots.rb
@@ -1,0 +1,29 @@
+FactoryBot.define do
+  factory :vcs_file_snapshot, class: 'VCS::FileSnapshot' do
+    transient do
+      parent { nil }
+    end
+
+    association :file_record, factory: :vcs_file_record
+    external_id         { Faker::Crypto.unique.sha1 }
+    file_record_parent  { parent&.file_record || create(:vcs_file_record) }
+    name                { Faker::File.file_name('', nil, nil, '') }
+    content_version     { rand(1..1000) }
+    mime_type           { 'application/vnd.google-apps.document' }
+
+    trait :folder do
+      mime_type { 'application/vnd.google-apps.folder' }
+    end
+
+    trait :pdf do
+      mime_type { Providers::GoogleDrive::MimeType.pdf }
+    end
+
+    trait :with_backup do
+      backup do
+        build(:file_resource_backup,
+              file_resource_snapshot: FileResource::Snapshot.new)
+      end
+    end
+  end
+end

--- a/spec/factories/vcs/vcs_file_thumbnails.rb
+++ b/spec/factories/vcs/vcs_file_thumbnails.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :vcs_file_thumbnail, class: 'VCS::FileThumbnail' do
+    external_id { Faker::Crypto.unique.sha1 }
+    version_id  { "v#{rand(0..1000)}" }
+    image do
+      File.new(
+        "#{Rails.root}/spec/support/fixtures/file_resource/thumbnail.png"
+      )
+    end
+  end
+end

--- a/spec/factories/vcs/vcs_repositories.rb
+++ b/spec/factories/vcs/vcs_repositories.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :vcs_repository, class: 'VCS::Repository' do
+  end
+end

--- a/spec/factories/vcs/vcs_staged_files.rb
+++ b/spec/factories/vcs/vcs_staged_files.rb
@@ -28,9 +28,9 @@ FactoryBot.define do
       file_record_parent_id { nil }
     end
 
-    # trait :with_thumbnail do
-    #   association :thumbnail, factory: :file_resource_thumbnail
-    # end
+    trait :with_thumbnail do
+      association :thumbnail, factory: :vcs_file_thumbnail
+    end
 
     trait :deleted do
       name { nil }
@@ -39,12 +39,11 @@ FactoryBot.define do
       is_deleted { true }
     end
 
-    # trait :with_backup do
-    #   after(:create) do |file_resource|
-    #     create(:file_resource_backup,
-    #            file_resource_snapshot: file_resource.current_snapshot)
-    #     file_resource.current_snapshot.reload_backup
-    #   end
-    # end
+    trait :with_backup do
+      after(:create) do |staged_file|
+        create(:vcs_file_backup, file_snapshot: staged_file.current_snapshot)
+        staged_file.current_snapshot.reload_backup
+      end
+    end
   end
 end

--- a/spec/factories/vcs/vcs_staged_files.rb
+++ b/spec/factories/vcs/vcs_staged_files.rb
@@ -1,0 +1,50 @@
+FactoryBot.define do
+  factory :vcs_staged_file, class: 'VCS::StagedFile' do
+    transient do
+      parent { nil }
+    end
+
+    association :file_record, factory: :vcs_file_record
+    with_parent
+
+    branch          { parent&.branch || create(:vcs_branch) }
+    external_id     { Faker::Crypto.unique.sha1 }
+    name            { Faker::File.file_name('', nil, nil, '') }
+    content_version { rand(1..1000) }
+    mime_type       { 'application/vnd.google-apps.document' }
+    is_root         { false }
+
+    trait :folder do
+      mime_type { 'application/vnd.google-apps.folder' }
+    end
+
+    trait :with_parent do
+      file_record_parent { parent&.file_record || create(:vcs_file_record) }
+    end
+
+    trait :root do
+      is_root { true }
+      folder
+      file_record_parent_id { nil }
+    end
+
+    # trait :with_thumbnail do
+    #   association :thumbnail, factory: :file_resource_thumbnail
+    # end
+
+    trait :deleted do
+      name { nil }
+      content_version { nil }
+      mime_type { nil }
+      is_deleted { true }
+    end
+
+    # trait :with_backup do
+    #   after(:create) do |file_resource|
+    #     create(:file_resource_backup,
+    #            file_resource_snapshot: file_resource.current_snapshot)
+    #     file_resource.current_snapshot.reload_backup
+    #   end
+    # end
+  end
+end

--- a/spec/features/collaborator_spec.rb
+++ b/spec/features/collaborator_spec.rb
@@ -68,9 +68,8 @@ feature 'Collaborators' do
     # who is added to that project's Collaborators
     project.collaborators << me
     # and the project has some files
-    root = create :file_resource, :folder
-    project.root_folder = root
-    create_list :file_resource, 5, parent: root
+    root = create :vcs_staged_file, :root, branch: project.master_branch
+    create_list :vcs_staged_file, 5, parent: root
 
     # when I visit the project page
     visit "#{project.owner.to_param}/#{project.to_param}"
@@ -90,7 +89,7 @@ feature 'Collaborators' do
     # and see a success message
     expect(page).to have_text 'Revision successfully created.'
     # and have the revision persisted to the repository
-    expect(project.revisions).to be_any
+    expect(project.master_branch.commits).to be_any
     # and see no file modification icons
     expect(page).to have_css '.file.no-change', count: 5
   end

--- a/spec/features/file_info_spec.rb
+++ b/spec/features/file_info_spec.rb
@@ -2,13 +2,12 @@
 
 feature 'File Info' do
   let(:project) { create :project, :setup_complete, :skip_archive_setup }
-  let(:root)    { create :file_resource, :folder }
-  before { project.root_folder = root }
+  let!(:root) { create :vcs_staged_file, :root, branch: project.master_branch }
   before { sign_in_as project.owner.account }
 
   scenario 'User can see file info' do
     # given there is a file and it is committed
-    file = create :file_resource, name: 'File1', parent: root
+    file = create :vcs_staged_file, name: 'File1', parent: root
     create_revision
 
     # when I visit the project page
@@ -25,7 +24,7 @@ feature 'File Info' do
     )
     # and see one revision
     expect(page.find_all('.revision .metadata .title b').map(&:text))
-      .to eq [project.revisions.last].map(&:title)
+      .to eq [project.master_branch.commits.last].map(&:title)
     # and see A file change entry for the file
     expect(page.find_all('.revision-diff').map(&:text)).to eq(
       ['File1 added to Home']
@@ -34,7 +33,7 @@ feature 'File Info' do
 
   scenario 'User can see file info for newly added files' do
     # given there is an uncommitted file
-    file = create :file_resource, name: 'File1', parent: root
+    file = create :vcs_staged_file, name: 'File1', parent: root
 
     # when I visit the project page
     visit "#{project.owner.to_param}/#{project.to_param}"
@@ -54,7 +53,7 @@ feature 'File Info' do
 
   scenario 'User can see file info of deleted files' do
     # given there is a file that has been deleted since the last revision
-    file = create :file_resource, name: 'File1', parent: root
+    file = create :vcs_staged_file, name: 'File1', parent: root
     create_revision
     file.update(is_deleted: true)
     create_revision
@@ -64,7 +63,7 @@ feature 'File Info' do
     # and click on Revisions
     click_on 'Revisions'
     # and click on the file info button
-    within ".revision[id='#{project.revisions.last.id}']" do
+    within ".revision[id='#{project.master_branch.commits.last.id}']" do
       click_on 'More'
     end
 
@@ -75,7 +74,7 @@ feature 'File Info' do
     )
     # and see two revisions
     expect(page.find_all('.revision .metadata .title b').map(&:text))
-      .to eq project.revisions.order(id: :desc).map(&:title)
+      .to eq project.master_branch.commits.order(id: :desc).map(&:title)
     # and see A file change entry for the file
     expect(page.find_all('.revision-diff').map(&:text)).to eq(
       ['File1 deleted from Home', 'File1 added to Home']
@@ -83,7 +82,7 @@ feature 'File Info' do
   end
 
   def create_revision
-    r = project.revisions.create_draft_and_commit_files!(project.owner)
+    r = project.master_branch.commits.create_draft_and_commit_files!(project.owner)
     r.update(is_published: true, title: 'revision')
   end
 end

--- a/spec/features/file_update_spec.rb
+++ b/spec/features/file_update_spec.rb
@@ -49,8 +49,8 @@ feature 'File Update', :vcr do
     # then I should see the file among my project's files
     then_i_should_see_file_in_project(name: 'My New File', status: 'addition')
     # and have a backup of the file snapshot
-    file_resource = FileResource.find_by_external_id(file.id)
-    and_have_a_backup_of_file_snapshot(file_resource.current_snapshot)
+    staged = project.staged_files.find_by_external_id(file.id)
+    and_have_a_backup_of_file_snapshot(staged.current_snapshot)
   end
 
   scenario 'In Google Drive, user updates file content' do
@@ -74,11 +74,11 @@ feature 'File Update', :vcr do
     then_i_should_see_file_in_project(name: 'File', status: 'modification')
 
     # and have a backup of the file snapshot as it is now
-    file_resource = FileResource.find_by_external_id(file_to_modify.id)
-    and_have_a_backup_of_file_snapshot(file_resource.current_snapshot)
+    staged = project.staged_files.find_by_external_id(file_to_modify.id)
+    and_have_a_backup_of_file_snapshot(staged.current_snapshot)
 
     # and have a backup of the file snapshot as it was before
-    and_have_a_backup_of_file_snapshot(file_resource.snapshots.first)
+    and_have_a_backup_of_file_snapshot(staged.file_record.file_snapshots.first)
   end
 
   scenario 'In Google Drive, user renames file' do
@@ -102,11 +102,11 @@ feature 'File Update', :vcr do
     then_i_should_see_file_in_project(name: 'New File Name', status: 'rename')
 
     # and have a backup of the file snapshot as it is now
-    file_resource = FileResource.find_by_external_id(file_to_rename.id)
-    and_have_a_backup_of_file_snapshot(file_resource.current_snapshot)
+    staged = project.staged_files.find_by_external_id(file_to_rename.id)
+    and_have_a_backup_of_file_snapshot(staged.current_snapshot)
 
     # and have a backup of the file snapshot as it was before
-    and_have_a_backup_of_file_snapshot(file_resource.snapshots.first)
+    and_have_a_backup_of_file_snapshot(staged.file_record.file_snapshots.first)
   end
 
   scenario 'In Google Drive, user moves file within project folder' do
@@ -285,11 +285,11 @@ end
 # rubocop:disable Metrics/AbcSize
 # TODO: Reduce complexity
 def and_have_a_backup_of_file_snapshot(file_snapshot)
-  external_id_of_backup = file_snapshot.backup.file_resource.external_id
+  external_id_of_backup = file_snapshot.backup.external_id
   external_backup = Providers::GoogleDrive::FileSync.new(external_id_of_backup)
   expect(external_backup.name).to eq(file_snapshot.name)
   expect(external_backup.parent_id)
-    .to eq(project.archive.file_resource.external_id)
+    .to eq(project.archive.external_id)
 end
 # rubocop:enable Metrics/AbcSize
 

--- a/spec/features/folder_import_spec.rb
+++ b/spec/features/folder_import_spec.rb
@@ -55,7 +55,7 @@ feature 'Folder Import', :vcr do
     expect(project.archive.backups.count).to eq 3
     external_archive =
       Providers::GoogleDrive::FileSync
-      .new(project.archive.file_resource.external_id)
+      .new(project.archive.external_id)
     expect(external_archive.children.count).to eq 3
   end
 end

--- a/spec/features/force_sync_spec.rb
+++ b/spec/features/force_sync_spec.rb
@@ -62,12 +62,12 @@ feature 'Force Sync', :vcr do
 
     # and have a backup of the file
     # TODO: Refactor
-    file_snapshot = FileResource.find_by_external_id(file.id).current_snapshot
-    external_id_of_backup = file_snapshot.backup.file_resource.external_id
+    staged = project.staged_files.find_by_external_id(file.id)
+    external_id_of_backup = staged.current_snapshot.backup.external_id
     external_backup =
       Providers::GoogleDrive::FileSync.new(external_id_of_backup)
-    expect(external_backup.name).to eq(file_snapshot.name)
+    expect(external_backup.name).to eq(staged.name)
     expect(external_backup.parent_id)
-      .to eq(project.archive.file_resource.external_id)
+      .to eq(project.archive.external_id)
   end
 end

--- a/spec/features/project_spec.rb
+++ b/spec/features/project_spec.rb
@@ -35,6 +35,9 @@ feature 'Project' do
     expect(page).to have_text 'Project successfully created.'
     # and have set up an archive folder on Google Drive
     expect(Project.first.archive).to be_present
+    # and a repository and master branch
+    expect(Project.first.repository).to be_present
+    expect(Project.first.master_branch).to be_present
   end
 
   scenario 'User can view project' do

--- a/spec/features/revision_spec.rb
+++ b/spec/features/revision_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 feature 'Revision' do
-  let(:project) { create :project, :setup_complete, :skip_archive_setup, :with_repository }
+  let(:project) { create :project, :setup_complete, :skip_archive_setup }
   let!(:root)   { create :vcs_staged_file, :root, branch: project.master_branch }
   let(:create_revision) do
     c = project.master_branch.commits.create_draft_and_commit_files!(project.owner)
@@ -46,7 +46,7 @@ feature 'Revision' do
     # given I am signed in as the project owner
     sign_in_as project.owner.account
     # and the project has some files
-    create_list :file_resource, 5, parent: root
+    create_list :vcs_staged_file, 5, parent: root
 
     # when I visit the project page
     visit "#{project.owner.to_param}/#{project.to_param}"
@@ -66,25 +66,25 @@ feature 'Revision' do
     # and see a success message
     expect(page).to have_text 'Revision successfully created.'
     # and have the revision persisted to the repository
-    expect(project.revisions.last).to be_present
+    expect(project.master_branch.commits.last).to be_present
     # and see no file modification icons
     expect(page).to have_css '.file.no-change', count: 5
   end
 
   context 'Selective capture' do
     let(:unchanged) do
-      create_list :file_resource, 2, name: 'unchanged', parent: root
+      create_list :vcs_staged_file, 2, name: 'unchanged', parent: root
     end
-    let(:folder)          { create :file_resource, :folder, parent: root }
-    let(:added_file)      { create :file_resource, parent: folder }
-    let(:modified_file)   { create :file_resource, parent: folder }
-    let(:moved_out_file)  { create :file_resource, parent: folder }
-    let(:moved_in_file)   { create :file_resource, parent: root }
-    let(:moved_in_and_modified_file) { create :file_resource, parent: root }
-    let(:removed_file)  { create :file_resource, parent: folder }
-    let(:moved_folder)  { create :file_resource, :folder, parent: root }
+    let(:folder)          { create :vcs_staged_file, :folder, parent: root }
+    let(:added_file)      { create :vcs_staged_file, parent: folder }
+    let(:modified_file)   { create :vcs_staged_file, parent: folder }
+    let(:moved_out_file)  { create :vcs_staged_file, parent: folder }
+    let(:moved_in_file)   { create :vcs_staged_file, parent: root }
+    let(:moved_in_and_modified_file) { create :vcs_staged_file, parent: root }
+    let(:removed_file)  { create :vcs_staged_file, parent: folder }
+    let(:moved_folder)  { create :vcs_staged_file, :folder, parent: root }
     let(:in_moved_folder) do
-      create_list :file_resource, 2, parent: moved_folder
+      create_list :vcs_staged_file, 2, parent: moved_folder
     end
 
     scenario 'User can review changes' do
@@ -159,7 +159,7 @@ feature 'Revision' do
       click_on 'Capture'
 
       # then the latest revision should have no diffs
-      expect(project.revisions.last.file_diffs).to be_none
+      expect(project.master_branch.commits.last.file_diffs).to be_none
     end
 
     scenario 'User can unselect some changes' do
@@ -190,9 +190,9 @@ feature 'Revision' do
       click_on 'Capture'
 
       # then the latest revision should have two file changes
-      expect(project.revisions.last.file_changes.count).to eq 2
-      expect(project.revisions.last.file_changes).to be_one(&:modification?)
-      expect(project.revisions.last.file_changes).to be_one(&:addition?)
+      expect(project.master_branch.commits.last.file_changes.count).to eq 2
+      expect(project.master_branch.commits.last.file_changes).to be_one(&:modification?)
+      expect(project.master_branch.commits.last.file_changes).to be_one(&:addition?)
     end
   end
 end

--- a/spec/features/time_travel_spec.rb
+++ b/spec/features/time_travel_spec.rb
@@ -1,82 +1,77 @@
 # frozen_string_literal: true
 
 feature 'Time Travel' do
-  let(:project)   { create :project, :setup_complete, :skip_archive_setup }
-  let(:root)      { create :file_resource, :folder }
-  let(:files)     { create_list :file_resource, 5, :with_backup, parent: root }
-  let(:revision) do
-    project.revisions.create_draft_and_commit_files!(project.owner)
+  let(:project) { create :project, :setup_complete, :skip_archive_setup }
+  let(:root) { create :vcs_staged_file, :root, branch: project.master_branch }
+  let!(:files) { create_list :vcs_staged_file, 5, :with_backup, parent: root }
+  let(:commit) do
+    project.master_branch.commits.create_draft_and_commit_files!(project.owner)
   end
-  let(:publish_revision) do
-    revision.update(is_published: true, title: 'origin revision')
-  end
-
-  before do
-    project.root_folder = root
-    files
+  let(:publish_commit) do
+    commit.update(is_published: true, title: 'origin revision')
   end
 
   before { sign_in_as project.owner.account }
 
   scenario 'User can view committed root-folder' do
     # given there is a published revision with files
-    publish_revision
+    publish_commit
 
-    # when I visit the revisions page
+    # when I visit the commits page
     visit profile_project_revisions_path(project.owner, project)
 
     # and click on the revision title
-    click_on revision.title
+    click_on commit.title
 
     # then I should be on the revision's files page
     expect(page).to have_current_path(
       "/#{project.owner.to_param}/#{project.to_param}/" \
-      "revisions/#{revision.id}/files"
+      "revisions/#{commit.id}/files"
     )
     # and see the revision title
-    expect(page).to have_text(revision.title)
+    expect(page).to have_text(commit.title)
     # and see the files in the project root folder
     files.each do |file|
       expect(page).to have_link(
         file.name,
-        href: file.current_snapshot.backup.file_resource.external_link
+        href: file.current_snapshot.backup.external_link
       )
     end
   end
 
   scenario 'User can see files in correct order' do
     # given I also have folders in my revision
-    folders = create_list :file_resource, 5, :folder, parent: root
-    # and my revision is published
-    publish_revision
+    folders = create_list :vcs_staged_file, 5, :folder, parent: root
+    # and my commit is published
+    publish_commit
 
-    # when I visit the revisions page
+    # when I visit the commits page
     visit profile_project_revisions_path(project.owner, project)
 
-    # and click on the revision title
-    click_on revision.title
+    # and click on the commit title
+    click_on commit.title
 
     # then I should see files in the correct order
-    file_order = FileResource.where(id: folders).order(:name).pluck(:name) +
-                 FileResource.where(id: files).order(:name).pluck(:name)
+    file_order = VCS::StagedFile.where(id: folders).order(:name).pluck(:name) +
+                 VCS::StagedFile.where(id: files).order(:name).pluck(:name)
     expect(page.all('.file').map(&:text)).to eq file_order
   end
 
   scenario 'User can view committed sub-folder' do
     # given a variety of sub-folders and files
-    folder    = create :file_resource, :folder, name: 'Fol', parent: root
-    docs      = create :file_resource, :folder, name: 'Docs', parent: folder
-    code      = create :file_resource, :folder, name: 'Code', parent: docs
-    subfiles  = create_list :file_resource, 5, parent: code
+    folder    = create :vcs_staged_file, :folder, name: 'Fol', parent: root
+    docs      = create :vcs_staged_file, :folder, name: 'Docs', parent: folder
+    code      = create :vcs_staged_file, :folder, name: 'Code', parent: docs
+    subfiles  = create_list :vcs_staged_file, 5, parent: code
 
-    # and a published revision
-    publish_revision
+    # and a published commit
+    publish_commit
 
-    # when I visit the revisions page
+    # when I visit the commits page
     visit profile_project_revisions_path(project.owner, project)
 
-    # and click on the revision title
-    click_on revision.title
+    # and click on the commit title
+    click_on commit.title
 
     # and click on the folder folder
     click_on folder.name
@@ -88,7 +83,7 @@ feature 'Time Travel' do
     # then I should be on the project's subfolder page
     expect(page).to have_current_path(
       "/#{project.owner.to_param}/#{project.to_param}/" \
-      "revisions/#{revision.id}/folders/#{code.external_id}"
+      "revisions/#{commit.id}/folders/#{code.external_id}"
     )
     # and see the files in the project subfolder
     subfiles.each do |file|

--- a/spec/integrations/shared_examples/vcs/including_syncable_integration.rb
+++ b/spec/integrations/shared_examples/vcs/including_syncable_integration.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'vcs: including syncable integration', :vcr do
+  let(:file_sync) do
+    file_sync_class.create(
+      name: 'Test File',
+      parent_id: parent_id,
+      mime_type: mime_type
+    )
+  end
+
+  describe '#fetch' do
+    subject(:fetch)         { syncable.fetch }
+    let(:external_id)       { file_sync.id }
+    let(:before_fetch_hook) { nil }
+    let(:update_content) do
+      Providers::GoogleDrive::ApiConnection
+        .default
+        .update_file_content(file_sync.id, 'new file content')
+    end
+
+    # Generate thumbnail and wait
+    before { update_content }
+    before { sleep 5 if VCR.current_cassette.recording? }
+    before { before_fetch_hook }
+    before { fetch }
+
+    it 'sets correct attributes' do
+      expect(syncable.name).to eq 'Test File'
+      expect(syncable.mime_type).to eq mime_type
+      expect(syncable.content_version.to_i).to be > 1
+      expect(syncable.parent).to eq root
+      expect(syncable.thumbnail).to be_present
+      expect(syncable).not_to be_deleted
+    end
+
+    context 'when file is trashed' do
+      let(:before_fetch_hook) { api.trash_file(file_sync.id) }
+      it                      { expect(file).to be_deleted }
+    end
+
+    context 'when file is removed' do
+      let(:before_fetch_hook) { api.delete_file(file_sync.id) }
+      it                      { expect(file).to be_deleted }
+    end
+  end
+
+  describe '#pull' do
+    subject(:pull)          { syncable.pull }
+    let(:external_id)       { file_sync.id }
+    let(:before_pull_hook)  { nil }
+    let(:syncable_from_db) do
+      described_class.find_by!(external_id: file_sync.id)
+    end
+    let(:update_content) do
+      Providers::GoogleDrive::ApiConnection
+        .default
+        .update_file_content(file_sync.id, 'new file content')
+    end
+
+    # Generate thumbnail and wait
+    before { update_content }
+    before { sleep 5 if VCR.current_cassette.recording? }
+    before { before_pull_hook }
+    before { pull }
+
+    it 'sets correct attributes' do
+      expect(syncable_from_db.name).to eq 'Test File'
+      expect(syncable_from_db.mime_type).to eq mime_type
+      expect(syncable_from_db.content_version.to_i).to be > 1
+      expect(syncable_from_db.parent).to eq root
+      expect(syncable_from_db.thumbnail).to be_present
+      expect(syncable_from_db).not_to be_deleted
+    end
+
+    context 'when file is trashed' do
+      let(:before_pull_hook) { api.trash_file(file_sync.id) }
+      it do
+        expect(syncable_from_db.name).to eq nil
+        expect(syncable_from_db.mime_type).to eq nil
+        expect(syncable_from_db.content_version).to eq nil
+        expect(syncable_from_db.parent).to eq nil
+        expect(syncable_from_db.thumbnail).to eq nil
+        expect(syncable).to be_deleted
+      end
+    end
+
+    context 'when file is removed' do
+      let(:before_pull_hook) { api.delete_file(file_sync.id) }
+      it do
+        expect(syncable_from_db.name).to eq nil
+        expect(syncable_from_db.mime_type).to eq nil
+        expect(syncable_from_db.content_version).to eq nil
+        expect(syncable_from_db.parent).to eq nil
+        expect(syncable_from_db.thumbnail).to eq nil
+        expect(syncable).to be_deleted
+      end
+    end
+  end
+
+  describe '#pull_children' do
+    let(:external_id) { file_sync.id }
+    let(:mime_type)   { folder_mime_type }
+    let(:syncable_from_db) do
+      described_class.find_by!(external_id: external_id)
+    end
+
+    let(:subfile1) { file_sync_class.create(attributes.merge(name: 'sub1')) }
+    let(:subfile2) { file_sync_class.create(attributes.merge(name: 'sub2')) }
+    let(:attributes) { { parent_id: external_id, mime_type: mime_type } }
+
+    before { subfile1 && subfile2 }
+    before { syncable.pull && syncable.pull_children }
+
+    it 'has children subfile1 and subfile2' do
+      expect(syncable_from_db.children.map(&:external_id))
+        .to contain_exactly subfile1.id, subfile2.id
+    end
+
+    context 'when subfile1 is deleted and subfile3 is added' do
+      let(:subfile3) { file_sync_class.create(attributes.merge(name: 'sub3')) }
+      before { api.delete_file(subfile1.id) }
+      before { subfile3 }
+
+      it 'updates children to subfile2 and subfile3' do
+        syncable.reload.pull_children
+        expect(syncable_from_db.children.map(&:external_id))
+          .to contain_exactly subfile2.id, subfile3.id
+      end
+    end
+  end
+end

--- a/spec/integrations/vcs/archive_spec.rb
+++ b/spec/integrations/vcs/archive_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe VCS::Archive, type: :model do
+  subject(:archive) do
+    VCS::Archive.new(name: name, owner_account_email: account_email)
+  end
+  let(:account_email)   { ENV['GOOGLE_DRIVE_USER_ACCOUNT'] }
+  let(:name)            { 'DEMO' }
+  let(:external_folder) { archive.file_resource }
+
+  describe '#setup', :vcr do
+    before  { prepare_google_drive_test }
+    after   { tear_down_google_drive_test }
+
+    let(:remote_folder_id) { archive.external_id }
+
+    before { archive.setup }
+    after do
+      # cleanup
+      Providers::GoogleDrive::ApiConnection
+        .default.delete_file(remote_folder_id)
+    end
+
+    it 'creates a folder in Google Drive' do
+      folder = Providers::GoogleDrive::FileSync.new(remote_folder_id)
+      root = Providers::GoogleDrive::FileSync.new('root')
+      expect(folder).to have_attributes(
+        name: "#{name} (Archive)",
+        mime_type: Providers::GoogleDrive::MimeType.folder,
+        parent_id: root.send(:file).id
+      )
+    end
+
+    it 'shares view access to the archive with the repository owner' do
+      folder = Providers::GoogleDrive::FileSync.new(remote_folder_id)
+      expect(folder.permissions.count).to eq 2
+      expect(folder.permissions).to be_any do |permission|
+        permission.role == 'reader' &&
+          permission.email_address == account_email
+      end
+    end
+  end
+end

--- a/spec/integrations/vcs/commit_spec.rb
+++ b/spec/integrations/vcs/commit_spec.rb
@@ -1,0 +1,273 @@
+# frozen_string_literal: true
+
+require 'integrations/shared_contexts/skip_project_archive_setup'
+
+RSpec.describe VCS::Commit, type: :model do
+  include_context 'skip project archive setup'
+
+  subject(:commit) { build(:vcs_commit) }
+
+  describe 'notifications' do
+    subject(:commit) do
+      create(:vcs_commit, :drafted, branch: branch, author: author)
+    end
+    let(:branch)        { project.master_branch }
+    let(:project) { create(:project, :skip_archive_setup, :with_repository) }
+    let(:owner)         { project.owner }
+    let(:collaborator1) { create :user }
+    let(:collaborator2) { create :user }
+    let(:collaborator3) { create :user }
+    let(:author)        { collaborator1 }
+    let(:publish)       { true }
+
+    before do
+      project.collaborators << [collaborator1, collaborator2, collaborator3]
+      commit.update(is_published: publish, title: 'Revision')
+    end
+
+    it 'creates a notification for owner + collaborators, except the author' do
+      expect(Notification.count).to eq 3
+      expect(Notification.all.map(&:target))
+        .to match_array [owner, collaborator2, collaborator3].map(&:account)
+      expect(Notification.all.map(&:notifier).uniq)
+        .to contain_exactly author
+      expect(Notification.all.map(&:notifiable).uniq)
+        .to contain_exactly commit
+    end
+
+    it 'sends an email to each notification recipient' do
+      expect(ActionMailer::Base.deliveries.map(&:to).flatten)
+        .to match_array(
+          [owner, collaborator2, collaborator3].map(&:account).map(&:email)
+        )
+    end
+
+    context 'when commit is not published' do
+      let(:publish) { false }
+
+      it 'does not create notifications' do
+        expect(Notification).to be_none
+      end
+    end
+
+    context 'when commit is destroyed' do
+      it 'deletes all notifications' do
+        expect { commit.destroy }.to change(Notification, :count).to(0)
+      end
+    end
+  end
+
+  describe 'validation: parent must belong to same project' do
+    let(:parent)        { create(:vcs_commit) }
+    before              { commit.parent = parent }
+
+    context 'when parent commit belongs to different branch' do
+      before  { commit.branch = create(:vcs_branch) }
+      it      { is_expected.to be_invalid }
+    end
+
+    context 'when parent commit belongs to same branch' do
+      before  { commit.branch = parent.branch }
+      it      { is_expected.to be_valid }
+    end
+  end
+
+  describe 'validation: can have only one origin commit per branch' do
+    subject(:new_origin)  { build(:vcs_commit, branch: branch) }
+    let(:branch)          { create(:vcs_branch) }
+
+    context 'when published origin commit exists in branch' do
+      let!(:existing_origin) { create :vcs_commit, :published, branch: branch }
+      it                     { is_expected.to be_invalid }
+    end
+
+    context 'when origin commit in branch is not published' do
+      let!(:existing_origin) { create :vcs_commit, branch: branch }
+      it                     { is_expected.to be_valid }
+    end
+
+    context 'when origin commit exists in another branch' do
+      let!(:existing_origin) do
+        create :vcs_commit, :published, branch: other_branch
+      end
+      let(:other_branch)  { create(:vcs_branch) }
+
+      it { is_expected.to be_valid }
+    end
+  end
+
+  describe 'validation: can have only one commit with parent' do
+    subject(:commit)    { build(:vcs_commit, parent: parent, branch: branch) }
+    let(:parent)        { create(:vcs_commit, branch: branch) }
+    let(:branch)        { create(:vcs_branch) }
+
+    context 'when commit with same parent exists' do
+      let!(:existing) do
+        create :vcs_commit, :published, parent: parent, branch: branch
+      end
+
+      it                { is_expected.to be_invalid }
+    end
+
+    context 'when commit with same parent is not published' do
+      let!(:existing) { create :vcs_commit, parent: parent }
+      it              { is_expected.to be_valid }
+    end
+
+    context 'when commit with same parent does not exist' do
+      let!(:existing) { create :vcs_commit, :with_parent }
+      it              { is_expected.to be_valid }
+    end
+  end
+
+  describe 'callback: apply_selected_changes' do
+    let(:apply_changes) { commit.publish(title: 'new commit') }
+    let(:author)    { create(:user) }
+    let(:branch)    { create(:vcs_branch) }
+    let(:origin)    { branch.commits.create_draft_and_commit_files!(author) }
+    let(:commit)    { branch.commits.create_draft_and_commit_files!(author) }
+    let(:parent)    { create :vcs_staged_file, :folder, branch: branch }
+    let(:update)    { create :vcs_staged_file, branch: branch }
+    let(:deletion)  { create :vcs_staged_file, branch: branch }
+    let(:addition)  { create :vcs_staged_file, branch: branch }
+
+    before do
+      parent && update && deletion
+      origin.publish(title: 'origin')
+
+      update.update(
+        name: 'new-name',
+        content_version: 5,
+        file_record_parent: parent.file_record
+      )
+      deletion.update(is_deleted: true)
+      addition
+      commit
+
+      action
+      apply_changes
+    end
+
+    context 'when all changes are unselected and applied' do
+      let(:action) { commit.file_changes.each(&:unselect!) }
+
+      it 'has the same committed files as previous commit' do
+        files_in_commit   = commit.committed_snapshot_ids
+        files_in_origin   = origin.committed_snapshot_ids
+        expect(files_in_commit).to match_array files_in_origin
+      end
+
+      it 'has no file diffs' do
+        expect(commit.file_diffs.reload).to be_empty
+      end
+    end
+
+    context 'when addition is unselected and applied' do
+      let(:action) { commit.file_changes.find(&:addition?).unselect! }
+      it { expect(commit.file_changes).not_to be_any(&:addition?) }
+    end
+
+    context 'when movement is unselected and applied' do
+      let(:action) { commit.file_changes.find(&:movement?).unselect! }
+      it { expect(commit.file_changes).not_to be_any(&:movement?) }
+    end
+
+    context 'when rename is unselected and applied' do
+      let(:action) { commit.file_changes.find(&:rename?).unselect! }
+      it { expect(commit.file_changes).not_to be_any(&:rename?) }
+    end
+
+    context 'when modification is unselected and applied' do
+      let(:action) { commit.file_changes.find(&:modification?).unselect! }
+      it { expect(commit.file_changes).not_to be_any(&:modification?) }
+    end
+
+    context 'when deletion is unselected and applied' do
+      let(:action) { commit.file_changes.find(&:deletion?).unselect! }
+      it { expect(commit.file_changes).not_to be_any(&:deletion?) }
+    end
+  end
+
+  describe 'association extension: committed_files#in_folder(folder)' do
+    subject(:method) do
+      commit.committed_files.in_folder(folder).map(&:file_snapshot)
+    end
+
+    let(:commit)    { create :vcs_commit, branch: branch }
+    let(:branch)    { create(:vcs_branch) }
+    let(:folder)    { create :vcs_file_snapshot, :folder }
+    let(:parent)    { folder }
+    let!(:f1)       { create :vcs_file_snapshot, parent: parent }
+    let!(:f2)       { create :vcs_file_snapshot, parent: parent }
+    let!(:f3)       { create :vcs_file_snapshot, parent: parent }
+
+    before do
+      [f1, f2, f3].each do |snapshot|
+        create :vcs_committed_file, commit: commit, file_snapshot: snapshot
+      end
+      commit.update(is_published: true, title: 'origin')
+    end
+
+    it 'returns files in folder' do
+      is_expected.to contain_exactly(f1, f2, f3)
+    end
+
+    context 'when folder has no children' do
+      let(:parent) { create(:vcs_file_snapshot, :folder) }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when folder does not exist' do
+      let(:folder) { build(:vcs_file_snapshot, :folder) }
+      let(:parent) { create(:vcs_file_snapshot, :folder) }
+
+      it { is_expected.to be_empty }
+    end
+  end
+
+  describe '#commit_all_files_staged_in_branch' do
+    subject(:committed_files) { commit.committed_files }
+    let(:commit)              { create :vcs_commit }
+    let(:branch)              { commit.branch }
+    let!(:staged_files) { create_list :vcs_staged_file, 10, branch: branch }
+    let!(:root_folder)  { create :vcs_staged_file, :root, branch: branch }
+    let(:commit_files) { commit.commit_all_files_staged_in_branch }
+
+    # Create staged files in another branch
+    # This is to ensure that committing affects only the files staged for the
+    # specific branch we are staging for
+    before do
+      other_branch = create(:vcs_branch)
+      create_list(:vcs_staged_file, 10, branch: other_branch)
+    end
+
+    before { commit_files }
+
+    it { expect(subject.count).to eq 10 }
+
+    it 'has the correct file snapshot IDs' do
+      expect(committed_files.map(&:file_snapshot_id))
+        .to match_array(staged_files.map(&:current_snapshot_id))
+    end
+
+    it 'does not commit the root file' do
+      is_expected.not_to be_exists(file_snapshot: root_folder.current_snapshot)
+    end
+
+    context 'when no files are staged' do
+      let(:staged_files) { [] }
+
+      it { is_expected.to be_none }
+    end
+
+    context 'when a staged file has current_snapshot=nil' do
+      let(:staged_files)                  { [file_without_current_snapshot] }
+      let(:file_without_current_snapshot) { create :vcs_staged_file, :deleted }
+
+      it 'does not commit that file' do
+        is_expected.to be_none
+      end
+    end
+  end
+end

--- a/spec/integrations/vcs/file_backup_spec.rb
+++ b/spec/integrations/vcs/file_backup_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+RSpec.describe VCS::FileBackup, type: :model do
+  let(:project)         { build(:project, title: 'Demo', owner: owner) }
+  let(:owner)           { build(:user, account: account) }
+  let(:account)         { build(:account, email: account_email) }
+  let(:account_email)   { ENV['GOOGLE_DRIVE_USER_ACCOUNT'] }
+  let(:external_folder) { archive.file_resource }
+
+  describe '#capture', :vcr do
+    before  { prepare_google_drive_test }
+    after   { tear_down_google_drive_test }
+
+    subject(:backup) do
+      described_class.new(file_snapshot: snapshot)
+    end
+
+    let(:user_acct)     { ENV['GOOGLE_DRIVE_USER_ACCOUNT'] }
+    let(:snapshot)      { staged_file.current_snapshot }
+    let(:file_name)     { 'An Awesome File' }
+    let(:staged_file) do
+      project.master_branch.staged_files.build(
+        external_id: external_file.id,
+        file_record: VCS::FileRecord.new(repository: project.repository)
+      )
+    end
+    let(:external_file) do
+      Providers::GoogleDrive::FileSync.create(
+        name: file_name,
+        parent_id: google_drive_test_folder_id,
+        mime_type: Providers::GoogleDrive::MimeType.document
+      )
+    end
+    let(:archive_folder_id) { archive.external_id }
+    let(:archive)           { project.archive }
+    let(:project)           { create(:project, owner_account_email: user_acct) }
+
+    before do
+      create :vcs_staged_file, :root,
+             branch: project.master_branch,
+             external_id: google_drive_test_folder_id
+
+      # Prevent automatic backup
+      allow(staged_file).to receive(:backup_on_save?).and_return(false)
+      staged_file.pull
+      backup.capture
+    end
+
+    after do
+      # cleanup
+      Providers::GoogleDrive::ApiConnection
+        .default.delete_file(archive_folder_id)
+    end
+
+    it 'stores a copy of the file snapshot in archive' do
+      copy = Providers::GoogleDrive::FileSync.new(backup.external_id)
+      expect(copy).to have_attributes(
+        name: file_name,
+        parent_id: archive.external_id
+      )
+    end
+
+    it 'inherits access permissions from archive folder' do
+      archive_permissions_hash =
+        Providers::GoogleDrive::FileSync
+        .new(archive.external_id)
+        .permissions
+        .map(&:to_h)
+      backup_permissions_hash =
+        Providers::GoogleDrive::FileSync
+        .new(backup.external_id)
+        .permissions
+        .map(&:to_h)
+      expect(backup_permissions_hash).to match_array(archive_permissions_hash)
+    end
+  end
+end

--- a/spec/integrations/vcs/file_diff_spec.rb
+++ b/spec/integrations/vcs/file_diff_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+RSpec.describe VCS::FileDiff, type: :model do
+  describe 'scope: joins_current_or_previous_snapshot' do
+    subject { scoped_query.first.id_from_query }
+    let(:scoped_query) do
+      described_class.joins_current_or_previous_snapshot
+                     .select('current_or_previous_snapshot.id AS id_from_query')
+    end
+    let!(:diff) do
+      create :vcs_file_diff, new_snapshot: new_snapshot,
+                             old_snapshot: old_snapshot
+    end
+    let(:new_snapshot)  { create :vcs_file_snapshot }
+    let(:old_snapshot)  { create :vcs_file_snapshot }
+
+    it { is_expected.to eq new_snapshot.id }
+
+    context 'when current snapshot is nil' do
+      let(:new_snapshot) { nil }
+      it { is_expected.to eq old_snapshot.id }
+    end
+
+    context 'when previous snapshot is nil' do
+      let(:old_snapshot) { nil }
+      it { is_expected.to eq new_snapshot.id }
+    end
+  end
+
+  describe 'scope: order_by_name_with_folders_first' do
+    subject(:scoped_query)  { described_class.order_by_name_with_folders_first }
+    let(:folders)           { scoped_query.select(&:folder?) }
+    let(:files)             { scoped_query.reject(&:folder?) }
+
+    before do
+      create :vcs_file_diff,
+             new_snapshot: create(:vcs_file_snapshot, :folder, name: 'XYZ')
+      create :vcs_file_diff,
+             new_snapshot: create(:vcs_file_snapshot, :folder, name: 'abc')
+      create :vcs_file_diff,
+             new_snapshot: create(:vcs_file_snapshot, name: 'HELLO')
+      create :vcs_file_diff,
+             new_snapshot: create(:vcs_file_snapshot, name: 'beta')
+      create :vcs_file_diff,
+             new_snapshot: create(:vcs_file_snapshot, name: 'zebra')
+    end
+
+    it 'returns folders first' do
+      expect(scoped_query.first).to be_folder
+      expect(scoped_query.second).to be_folder
+    end
+
+    it 'returns elements in case insensitive alphabetical order' do
+      expect(folders).to eq(folders.sort_by { |file| file.name.downcase })
+      expect(files).to eq(files.sort_by { |file| file.name.downcase })
+    end
+  end
+end

--- a/spec/integrations/vcs/file_snapshot_spec.rb
+++ b/spec/integrations/vcs/file_snapshot_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+RSpec.describe VCS::FileSnapshot, type: :model do
+  xdescribe 'scope: where_current_snapshot_is_nil' do
+    subject { described_class.where_current_snapshot_is_nil }
+
+    let!(:files_to_delete)          { create_list :file_resource, 2 }
+    let!(:other_files)              { create_list :file_resource, 2 }
+    let!(:without_current_snapshot) { files_to_delete.map(&:current_snapshot) }
+
+    before do
+      files_to_delete.each do |file|
+        file.update!(is_deleted: true)
+      end
+    end
+
+    it { is_expected.to match_array without_current_snapshot }
+  end
+
+  xdescribe 'scope: where_current_snapshot_parent(parent)' do
+    subject { described_class.where_current_snapshot_parent(parent) }
+
+    let(:parent)          { create :file_resource }
+    let!(:in_parent)      { create_list :file_resource, 2, parent: parent }
+    let!(:not_in_parent)  { create_list :file_resource, 2 }
+    let!(:snapshot1)      { in_parent[0].current_snapshot }
+    let!(:snapshot2)      { in_parent[1].current_snapshot }
+
+    before { in_parent[0].update(name: 'new name') }
+
+    let(:snapshot3) { in_parent[0].current_snapshot }
+
+    it { is_expected.to contain_exactly snapshot1, snapshot2, snapshot3 }
+  end
+
+  xdescribe 'scope: of_revision(revision)' do
+    subject         { described_class.of_revision(revision) }
+    let(:revision)  { create :revision }
+    let(:snapshot1) { create :file_resource_snapshot }
+    let(:snapshot2) { create :file_resource_snapshot }
+    let(:snapshot3) { create :file_resource_snapshot }
+    let(:snapshot4) { create :file_resource_snapshot }
+    let(:file1)     { snapshot1.file_resource }
+    let(:file2)     { snapshot2.file_resource }
+    let(:file3)     { snapshot3.file_resource }
+    let(:file4)     { snapshot4.file_resource }
+
+    before do
+      create :committed_file, revision: revision, file_resource: file1,
+                              file_resource_snapshot: snapshot1
+      create :committed_file, revision: revision, file_resource: file2,
+                              file_resource_snapshot: snapshot2
+      create :committed_file, file_resource: file3,
+                              file_resource_snapshot: snapshot3
+      create :committed_file, file_resource: file4,
+                              file_resource_snapshot: snapshot4
+    end
+
+    it { is_expected.to contain_exactly snapshot1, snapshot2 }
+  end
+
+  # describe 'scope: with_provider_id' do
+  #   subject(:snapshots) { described_class.with_provider_id }
+  #   let!(:snapshot1)    { create :file_resource_snapshot }
+  #   let!(:snapshot2)    { create :file_resource_snapshot }
+  #
+  #   it 'fetches provider id' do
+  #     expect(snapshots.first['provider_id']).to eq snapshot1.provider_id
+  #     expect(snapshots.second['provider_id']).to eq snapshot2.provider_id
+  #   end
+  # end
+
+  describe 'scope: order_by_name_with_folders_first' do
+    subject(:scoped_query) { described_class.order_by_name_with_folders_first }
+    let(:folders) { scoped_query.select(&:folder?) }
+    let(:files)   { scoped_query.reject(&:folder?) }
+
+    before do
+      create :vcs_file_snapshot, :folder, name: 'abc'
+      create :vcs_file_snapshot, :folder, name: 'XYZ'
+      create :vcs_file_snapshot
+      create :vcs_file_snapshot
+      create :vcs_file_snapshot
+    end
+
+    it 'returns folders first' do
+      expect(scoped_query.first).to be_folder
+      expect(scoped_query.second).to be_folder
+    end
+
+    it 'returns elements in case insensitive alphabetical order' do
+      expect(folders).to eq(folders.sort_by { |file| file.name.downcase })
+      expect(files).to eq(files.sort_by { |file| file.name.downcase })
+    end
+  end
+
+  describe '.for(attributes)' do
+    subject           { described_class.for(attributes) }
+    let!(:file)       { create :vcs_staged_file }
+    let(:file_record) { file.file_record }
+    let(:attributes) do
+      attributes_for(:vcs_file_snapshot,
+                     file_record: file_record, file_record_id: file_record.id)
+    end
+
+    it 'creates a new snapshot' do
+      expect { subject }.to change(described_class, :count).by(1)
+    end
+
+    describe 'when snapshot already exists' do
+      let!(:existing_snapshot) { described_class.for(attributes) }
+
+      it 'does not create a new snapshot' do
+        expect { subject }
+          .not_to change(described_class, :count)
+      end
+
+      context 'when supplemental attributes change' do
+        let(:thumbnail) { create :vcs_file_thumbnail }
+        let(:snapshot)  { described_class.order(:created_at).first }
+        before          { attributes[:thumbnail_id] = thumbnail.id }
+
+        it 'updates thumbnail on the snapshot' do
+          expect { subject }
+            .to change { existing_snapshot.reload.thumbnail_id }.from(nil)
+        end
+      end
+    end
+  end
+
+  describe '#snapshot!' do
+    subject         { snapshot.snapshot! }
+    let(:snapshot)  { create :vcs_file_snapshot }
+
+    before { snapshot.name = 'new-name' }
+
+    it 'creates a new snapshot' do
+      expect { subject }.to change(described_class, :count).by(1)
+    end
+
+    it 'acquires ID of new snapshot and reloads' do
+      subject
+      expect(snapshot).to eq described_class.order(:created_at).last
+      expect(snapshot).not_to be_changed
+    end
+  end
+end

--- a/spec/integrations/vcs/file_thumbnail_spec.rb
+++ b/spec/integrations/vcs/file_thumbnail_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+RSpec.describe VCS::FileThumbnail, type: :model do
+  describe 'attachment path for image' do
+    subject           { thumbnail.image.path }
+    let(:thumbnail)   { create :vcs_file_thumbnail }
+    let(:external_id) { thumbnail.external_id }
+    let(:version_id)  { thumbnail.version_id }
+
+    it 'interpolates correctly' do
+      is_expected.to start_with("#{Rails.root}/public/spec/system")
+      is_expected.to match(
+        %r{vcs/file_thumbnails/#{external_id}/#{version_id}/\w+.png$}
+      )
+    end
+  end
+
+  describe 'attachment url for image' do
+    subject           { thumbnail.image.url }
+    let(:thumbnail)   { create :vcs_file_thumbnail }
+    let(:external_id) { thumbnail.external_id }
+    let(:version_id)  { thumbnail.version_id }
+
+    it 'interpolates correctly' do
+      is_expected.to start_with('/spec/system')
+      is_expected.to match(
+        %r{vcs/file_thumbnails/#{external_id}/#{version_id}/\w+.png}
+      )
+    end
+  end
+
+  describe 'fallback path for image' do
+    subject(:url)   { thumbnail.image.url(:original, timestamp: false) }
+    let(:thumbnail) { described_class.new }
+
+    it 'is a valid path' do
+      expect(File).to be_exists("#{Rails.root}/public#{url}")
+    end
+  end
+
+  describe '.preload_for(objects)' do
+    let(:file1) { create :file_resource, :with_thumbnail }
+    let(:file2) { create :file_resource, :with_thumbnail }
+    let(:file3) { create :file_resource, :with_thumbnail }
+
+    before { [file1, file2, file3].each(&:reload) }
+
+    it 'preloads all thumbnails' do
+      expect(file1.association(:thumbnail)).not_to be_loaded
+      expect(file2.association(:thumbnail)).not_to be_loaded
+      expect(file3.association(:thumbnail)).not_to be_loaded
+
+      described_class.preload_for([file1, file2, file3])
+
+      expect(file1.association(:thumbnail)).to be_loaded
+      expect(file2.association(:thumbnail)).to be_loaded
+      expect(file3.association(:thumbnail)).to be_loaded
+    end
+  end
+end

--- a/spec/integrations/vcs/operations/file_ancestry_tree_spec.rb
+++ b/spec/integrations/vcs/operations/file_ancestry_tree_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe VCS::Operations::FileAncestryTree, type: :model do
+  describe '.generate(commit:, file_ids:, depth:)' do
+    subject(:tree) do
+      described_class.generate(
+        commit: commit,
+        file_record_ids: [f5.file_record_id],
+        depth: 3
+      )
+    end
+    let(:commit) { create :vcs_commit }
+    let(:f1) { create :vcs_file_snapshot, name: 'f1' }
+    let(:f2) do
+      create :vcs_file_snapshot, name: 'f2', parent: f1
+    end
+    let(:f3) do
+      create :vcs_file_snapshot, name: 'f3', parent: f2
+    end
+    let(:f4) do
+      create :vcs_file_snapshot, name: 'f4', parent: f3
+    end
+    let(:f5) do
+      create :vcs_file_snapshot, name: 'f5', parent: f4
+    end
+
+    before do
+      # committed files in current revision
+      [f1, f2, f3, f4, f5].each do |file|
+        create :vcs_committed_file, commit: commit, file_snapshot: file
+      end
+    end
+
+    it 'has ancestors names f4, f3, f2' do
+      expect(tree.ancestors_names_for(f5.file_record_id, depth: 3))
+        .to eq %w[f4 f3 f2]
+    end
+  end
+end

--- a/spec/integrations/vcs/operations/file_diffs_calculator_spec.rb
+++ b/spec/integrations/vcs/operations/file_diffs_calculator_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+RSpec.describe VCS::Operations::FileDiffsCalculator, type: :model do
+  subject(:calculator)  { described_class.new(commit: commit) }
+  let(:commit)          { create :vcs_commit, :with_parent }
+  let(:parent_commit)   { commit.parent }
+
+  describe '#cache_diffs!' do
+    let(:diffs) { VCS::FileDiff.where(commit: commit) }
+    let(:diff1) { diffs.where_file_record_id(f1.file_record_id).first }
+    let(:diff2) { diffs.where_file_record_id(f2.file_record_id).first }
+    let(:diff3) { diffs.where_file_record_id(f3.file_record_id).first }
+    let(:diff4) { diffs.where_file_record_id(f4.file_record_id).first }
+    let(:diff5) { diffs.where_file_record_id(f5.file_record_id).first }
+    let(:diff6) { diffs.where_file_record_id(f6.file_record_id).first }
+    let(:diff7) { diffs.where_file_record_id(f7.file_record_id).first }
+    let(:diff8) { diffs.where_file_record_id(f8.file_record_id).first }
+    let(:diff9) { diffs.where_file_record_id(f9.file_record_id).first }
+
+    let(:f1) { create :vcs_file_snapshot, name: 'f1' }
+    let(:f2) { create :vcs_file_snapshot, name: 'f2', parent: f1 }
+    let(:f3) { create :vcs_file_snapshot, name: 'f3', parent: f2 }
+    let(:f4) { create :vcs_file_snapshot, name: 'f4', parent: f3 }
+    let(:f5) { create :vcs_file_snapshot, name: 'f5', parent: f4 }
+    let(:f6) { create :vcs_file_snapshot, name: 'f6' }
+    let(:f7) { create :vcs_file_snapshot, name: 'f7', parent: f6 }
+    let(:f8) { create :vcs_file_snapshot, name: 'f8', parent: f2 }
+    let(:f9) { create :vcs_file_snapshot, name: 'f9', parent: f8 }
+
+    before do
+      # committed files in parent commit
+      [f1, f2, f3, f4, f5, f6, f7].each do |file|
+        create :vcs_committed_file, commit: parent_commit, file_snapshot: file
+      end
+
+      # update parents of f3 and f6
+      f3.assign_attributes(file_record_parent: f6.file_record)
+      f3.snapshot!
+      f6.assign_attributes(file_record_parent: f2.file_record)
+      f6.snapshot!
+
+      # committed files in current commit
+      [f1, f2, f3, f6, f7, f8, f9].each do |file|
+        create :vcs_committed_file, commit: commit, file_snapshot: file
+      end
+
+      # calculate and cache diffs!
+      calculator.cache_diffs!
+    end
+
+    it 'has diffs for f3, f4, f5, f6, f8, f9' do
+      expect(diffs.with_file_record_id.map(&:file_record_id))
+        .to match_array [f3, f4, f5, f6, f8, f9].map(&:file_record_id)
+
+      expect(diff3).to be_update
+      expect(diff3.first_three_ancestors).to eq %w[f6 f2 f1]
+
+      expect(diff4).to be_deletion
+      expect(diff4.first_three_ancestors).to eq %w[f3 f6 f2]
+
+      expect(diff5).to be_deletion
+      expect(diff5.first_three_ancestors).to eq %w[f4 f3 f6]
+
+      expect(diff8).to be_addition
+      expect(diff8.first_three_ancestors).to eq %w[f2 f1]
+
+      expect(diff9).to be_addition
+      expect(diff9.first_three_ancestors).to eq %w[f8 f2 f1]
+    end
+
+    context 'when revision is origin revision (parent is nil)' do
+      let(:commit)        { create :vcs_commit }
+      let(:parent_commit) { create :vcs_commit }
+
+      it 'has diffs for f1, f2, f3, f6, f7, f8, f9' do
+        expect(diffs.with_file_record_id.map(&:file_record_id))
+          .to match_array [f1, f2, f3, f6, f7, f8, f9].map(&:file_record_id)
+
+        expect(diff1).to be_addition
+        expect(diff1.first_three_ancestors).to eq %w[]
+
+        expect(diff2).to be_addition
+        expect(diff2.first_three_ancestors).to eq %w[f1]
+
+        expect(diff3).to be_addition
+        expect(diff3.first_three_ancestors).to eq %w[f6 f2 f1]
+
+        expect(diff6).to be_addition
+        expect(diff6.first_three_ancestors).to eq %w[f2 f1]
+
+        expect(diff7).to be_addition
+        expect(diff7.first_three_ancestors).to eq %w[f6 f2 f1]
+
+        expect(diff8).to be_addition
+        expect(diff8.first_three_ancestors).to eq %w[f2 f1]
+
+        expect(diff9).to be_addition
+        expect(diff9.first_three_ancestors).to eq %w[f8 f2 f1]
+      end
+    end
+  end
+end

--- a/spec/integrations/vcs/staged_file_spec.rb
+++ b/spec/integrations/vcs/staged_file_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'integrations/shared_contexts/skip_project_archive_setup'
+require 'integrations/shared_examples/including_snapshotable_integration.rb'
+require 'integrations/shared_examples/vcs/including_syncable_integration.rb'
+
+RSpec.describe VCS::StagedFile, type: :model do
+  subject(:file) do
+    described_class.new(
+      external_id: external_id,
+      branch: branch,
+      file_record: file_record
+    )
+  end
+  let(:branch) { create :vcs_branch }
+  let(:file_record) { create :vcs_file_record }
+  let(:external_id) { 'id' }
+
+  it_should_behave_like 'including snapshotable integration' do
+    let(:file)                    { build :file_resources_google_drive }
+    let(:snapshotable)            { file }
+    let(:snapshotable_model_name) { 'FileResources::GoogleDrive' }
+  end
+
+  it_should_behave_like 'vcs: including syncable integration' do
+    let(:api)      { Providers::GoogleDrive::ApiConnection.default }
+    let(:syncable) { file }
+    let(:parent_id) { google_drive_test_folder_id }
+    let(:mime_type) { Providers::GoogleDrive::MimeType.document }
+    let(:folder_mime_type)  { Providers::GoogleDrive::MimeType.folder }
+    let(:file_sync_class)   { Providers::GoogleDrive::FileSync }
+
+    before { prepare_google_drive_test }
+    after  { tear_down_google_drive_test }
+
+    let!(:root) do
+      create(:vcs_staged_file, :root, :folder,
+             branch: branch, external_id: parent_id)
+    end
+  end
+
+  describe 'snapshotable + syncable', :vcr do
+    include_context 'skip project archive setup'
+
+    before { prepare_google_drive_test }
+    after  { tear_down_google_drive_test }
+    let!(:file_sync) do
+      Providers::GoogleDrive::FileSync.create(
+        name: 'Test File',
+        parent_id: google_drive_test_folder_id,
+        mime_type: Providers::GoogleDrive::MimeType.document
+      )
+    end
+    let!(:parent) do
+      described_class.new(
+        external_id: google_drive_test_folder_id,
+        branch: branch,
+        file_record: file_record_parent,
+        is_root: true
+      )
+    end
+    let(:file_record_parent)  { create :vcs_file_record }
+    let(:projects)            { create_list :project, 3 }
+    let(:api)                 { Providers::GoogleDrive::ApiConnection.default }
+    let(:external_id)         { file_sync.id }
+    let(:file_from_database) do
+      described_class.find_by_external_id!(external_id)
+    end
+    let(:file_attributes)     { file_from_database.attributes }
+    let(:snapshot_attributes) { file_from_database.current_snapshot.attributes }
+    let(:expected_attributes) do
+      {
+        'name' => 'Test File',
+        'file_record_parent_id' => parent.file_record_id,
+        'content_version' => '1',
+        'mime_type' => Providers::GoogleDrive::MimeType.document,
+        'external_id' => external_id,
+        'thumbnail_id' => nil
+      }
+    end
+
+    # Pull parent resource & set staged projects
+    before do
+      parent.pull
+    end
+
+    it 'can pull a snapshot of a new file' do
+      file.pull
+      expect(file_attributes).to include(expected_attributes)
+      expect(snapshot_attributes).to include(expected_attributes)
+    end
+
+    it 'can pull a snapshot of an existing file' do
+      file.pull
+      file_sync.rename('my new file name')
+
+      # Update file content for thumbnail
+      Providers::GoogleDrive::ApiConnection
+        .default.update_file_content(file_sync.id, 'new file content')
+      sleep 5 if VCR.current_cassette.recording?
+
+      file.reload.pull
+      expected_attributes['name'] = 'my new file name'
+      expected_attributes.delete('content_version')
+      expected_attributes['thumbnail_id'] = VCS::FileThumbnail.first.id
+      expect(file_attributes).to include(expected_attributes)
+      expect(snapshot_attributes).to include(expected_attributes)
+    end
+
+    it 'can pull a snapshot of a removed file' do
+      file.pull
+      api.delete_file(file.external_id)
+      file.reload.pull
+      expect(file_from_database).to be_deleted
+      expect(file_from_database.current_snapshot).to be nil
+    end
+  end
+end

--- a/spec/integrations/vcs/staged_file_test_spec.rb
+++ b/spec/integrations/vcs/staged_file_test_spec.rb
@@ -1,0 +1,57 @@
+# TODO: DELETE ME
+# frozen_string_literal: true
+#
+# require 'integrations/shared_contexts/skip_project_archive_setup'
+#
+# RSpec.describe VCS::StagedFile, type: :model do
+#   include_context 'skip project archive setup'
+#
+#   describe '.with_current_or_committed_snapshot' do
+#     subject(:staged_files) do
+#       described_class.with_current_or_committed_snapshot
+#     end
+#
+#     let(:project) { create :project, :with_repository }
+#     let(:repo)    { project.repository }
+#     let(:branch)  { project.master_branch }
+#     # file records
+#     let!(:f1)     { create :vcs_file_record, repository: repo }
+#     let!(:f2)     { create :vcs_file_record, repository: repo }
+#     let!(:f3)     { create :vcs_file_record, repository: repo }
+#     let!(:f4)     { create :vcs_file_record, repository: repo }
+#     # have snapshots
+#     let!(:f1s1)   { create :vcs_file_snapshot, file_record: f1 }
+#     # snapshots fo file record 2
+#     let!(:f2s1)   { create :vcs_file_snapshot, file_record: f2 }
+#     let!(:f2s2)   { create :vcs_file_snapshot, file_record: f2 }
+#     # file record 3
+#     let!(:f3s1)   { create :vcs_file_snapshot, file_record: f3 }
+#     # file record 4
+#     let!(:f4s1)   { create :vcs_file_snapshot, file_record: f4 }
+#
+#     let(:commit1) { create :vcs_commit, branch: branch }
+#     let(:commit2) { create :vcs_commit, branch: branch, parent: commit1 }
+#
+#     before do
+#       commit1.committed_snapshots = [f1s1, f2s1]
+#       commit1.update!(is_published: true)
+#
+#       commit2.committed_snapshots = [f2s2, f3s1]
+#       commit2.update!(is_published: true)
+#
+#       create(:vcs_staged_file, :deleted, branch: branch, file_record: f1)
+#       create(:vcs_staged_file, branch: branch, file_record: f2)
+#       create(:vcs_staged_file, :deleted, branch: branch, file_record: f3)
+#       create(:vcs_staged_file, branch: branch, file_record: f4)
+#     end
+#
+#     it 'returns staged files that have a current or committed snapshot' do
+#       expect(staged_files.map(&:file_record)).to contain_exactly(f2, f3, f4)
+#     end
+#
+#     it 'returns the correct snapshots' do
+#       expect(staged_files.map(&:committed_snapshot_id))
+#         .to contain_exactly(f2s2.id, f3s1.id, nil)
+#     end
+#   end
+# end

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_creates_file_within_project_folder.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_creates_file_within_project_folder.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Sat, 27 Oct 2018 00:08:42 GMT
+      - Mon, 29 Oct 2018 21:19:05 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:42 GMT
+  recorded_at: Mon, 29 Oct 2018 21:19:05 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Sat, 27 Oct 2018 00:08:43 GMT
+      - Mon, 29 Oct 2018 21:19:06 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:43 GMT
+  recorded_at: Mon, 29 Oct 2018 21:19:06 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-27
-        00:08:43 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-29
+        21:19:06 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:08:43 GMT
+      - Mon, 29 Oct 2018 21:19:06 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:08:43 GMT
+      - Mon, 29 Oct 2018 21:19:07 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1GpzbsR_TmXIWfljnDwg2Ug6iSuDgUfkl",
-         "name": "Test @ 2018-10-27 00:08:43 UTC",
+         "id": "1wl5uY8ltXj23hkx-uUG7NIOq0QWwtaXE",
+         "name": "Test @ 2018-10-29 21:19:06 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:43 GMT
+  recorded_at: Mon, 29 Oct 2018 21:19:07 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1GpzbsR_TmXIWfljnDwg2Ug6iSuDgUfkl/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1wl5uY8ltXj23hkx-uUG7NIOq0QWwtaXE/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:08:43 GMT
+      - Mon, 29 Oct 2018 21:19:07 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:08:44 GMT
+      - Mon, 29 Oct 2018 21:19:08 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:44 GMT
+  recorded_at: Mon, 29 Oct 2018 21:19:08 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:08:44 GMT
+      - Mon, 29 Oct 2018 21:19:08 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:08:44 GMT
+      - Mon, 29 Oct 2018 21:19:08 GMT
       Date:
-      - Sat, 27 Oct 2018 00:08:44 GMT
+      - Mon, 29 Oct 2018 21:19:08 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,17 +302,17 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "11047"
+         "startPageToken": "13067"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:44 GMT
+  recorded_at: Mon, 29 Oct 2018 21:19:08 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"9 Starship
-        Titanic (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"1 Bistromath
+        (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -321,7 +321,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:08:45 GMT
+      - Mon, 29 Oct 2018 21:19:09 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -338,7 +338,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:08:45 GMT
+      - Mon, 29 Oct 2018 21:19:10 GMT
       Vary:
       - Origin
       - X-Origin
@@ -362,8 +362,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1_3p7zHi0e6y28PCuwbTwfVigFSY3ITje",
-         "name": "9 Starship Titanic (Archive)",
+         "id": "1Pv05E_4HyG8KPewRh8d5vpEJxPfRvD4E",
+         "name": "1 Bistromath (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -383,10 +383,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:45 GMT
+  recorded_at: Mon, 29 Oct 2018 21:19:10 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1_3p7zHi0e6y28PCuwbTwfVigFSY3ITje/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1Pv05E_4HyG8KPewRh8d5vpEJxPfRvD4E/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -398,7 +398,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:08:45 GMT
+      - Mon, 29 Oct 2018 21:19:10 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -415,7 +415,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:08:46 GMT
+      - Mon, 29 Oct 2018 21:19:11 GMT
       Vary:
       - Origin
       - X-Origin
@@ -445,10 +445,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:46 GMT
+  recorded_at: Mon, 29 Oct 2018 21:19:11 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1_3p7zHi0e6y28PCuwbTwfVigFSY3ITje?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1wl5uY8ltXj23hkx-uUG7NIOq0QWwtaXE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -460,7 +460,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:08:46 GMT
+      - Mon, 29 Oct 2018 21:19:11 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -471,9 +471,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:08:46 GMT
+      - Mon, 29 Oct 2018 21:19:12 GMT
       Date:
-      - Sat, 27 Oct 2018 00:08:46 GMT
+      - Mon, 29 Oct 2018 21:19:12 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -499,159 +499,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1_3p7zHi0e6y28PCuwbTwfVigFSY3ITje",
-         "name": "9 Starship Titanic (Archive)",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:46 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1_3p7zHi0e6y28PCuwbTwfVigFSY3ITje/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:08:46 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:08:46 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:08:46 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:46 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1GpzbsR_TmXIWfljnDwg2Ug6iSuDgUfkl?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:08:46 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:08:47 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:08:47 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1GpzbsR_TmXIWfljnDwg2Ug6iSuDgUfkl",
-         "name": "Test @ 2018-10-27 00:08:43 UTC",
+         "id": "1wl5uY8ltXj23hkx-uUG7NIOq0QWwtaXE",
+         "name": "Test @ 2018-10-29 21:19:06 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -677,10 +526,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:47 GMT
+  recorded_at: Mon, 29 Oct 2018 21:19:12 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1GpzbsR_TmXIWfljnDwg2Ug6iSuDgUfkl/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1wl5uY8ltXj23hkx-uUG7NIOq0QWwtaXE/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -692,7 +541,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:08:47 GMT
+      - Mon, 29 Oct 2018 21:19:12 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -710,9 +559,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:08:47 GMT
+      - Mon, 29 Oct 2018 21:19:12 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:08:47 GMT
+      - Mon, 29 Oct 2018 21:19:12 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -744,10 +593,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:47 GMT
+  recorded_at: Mon, 29 Oct 2018 21:19:12 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271GpzbsR_TmXIWfljnDwg2Ug6iSuDgUfkl%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files/1wl5uY8ltXj23hkx-uUG7NIOq0QWwtaXE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -759,7 +608,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:08:47 GMT
+      - Mon, 29 Oct 2018 21:19:12 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -770,9 +619,305 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:08:47 GMT
+      - Mon, 29 Oct 2018 21:19:12 GMT
       Date:
-      - Sat, 27 Oct 2018 00:08:47 GMT
+      - Mon, 29 Oct 2018 21:19:12 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1wl5uY8ltXj23hkx-uUG7NIOq0QWwtaXE",
+         "name": "Test @ 2018-10-29 21:19:06 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:19:12 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1wl5uY8ltXj23hkx-uUG7NIOq0QWwtaXE/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:19:12 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 29 Oct 2018 21:19:12 GMT
+      Expires:
+      - Mon, 29 Oct 2018 21:19:12 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:19:12 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1wl5uY8ltXj23hkx-uUG7NIOq0QWwtaXE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:19:13 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:19:13 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:19:13 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1wl5uY8ltXj23hkx-uUG7NIOq0QWwtaXE",
+         "name": "Test @ 2018-10-29 21:19:06 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:19:13 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1wl5uY8ltXj23hkx-uUG7NIOq0QWwtaXE/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:19:13 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 29 Oct 2018 21:19:13 GMT
+      Expires:
+      - Mon, 29 Oct 2018 21:19:13 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:19:13 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271wl5uY8ltXj23hkx-uUG7NIOq0QWwtaXE%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:19:13 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:19:13 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:19:13 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -801,13 +946,13 @@ http_interactions:
          "files": []
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:47 GMT
+  recorded_at: Mon, 29 Oct 2018 21:19:13 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"My New File","parents":["1GpzbsR_TmXIWfljnDwg2Ug6iSuDgUfkl"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"My New File","parents":["1wl5uY8ltXj23hkx-uUG7NIOq0QWwtaXE"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -816,7 +961,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:08:47 GMT
+      - Mon, 29 Oct 2018 21:19:13 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -833,7 +978,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:08:48 GMT
+      - Mon, 29 Oct 2018 21:19:15 GMT
       Vary:
       - Origin
       - X-Origin
@@ -857,12 +1002,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1_NWxM97RWgFKaSr-u2OR0Mpa-WKE5QArhmrq5pK5Guk",
+         "id": "1nZrJh5XYVeWarEIF9ENoCaGohy0GDcHzV3ZnA25t40o",
          "name": "My New File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1GpzbsR_TmXIWfljnDwg2Ug6iSuDgUfkl"
+          "1wl5uY8ltXj23hkx-uUG7NIOq0QWwtaXE"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -887,10 +1032,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:48 GMT
+  recorded_at: Mon, 29 Oct 2018 21:19:15 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=11047
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId,changes/file/parents&pageSize=100&pageToken=13067
     body:
       encoding: UTF-8
       string: ''
@@ -902,7 +1047,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:09:48 GMT
+      - Mon, 29 Oct 2018 21:20:15 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -913,9 +1058,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:09:49 GMT
+      - Mon, 29 Oct 2018 21:20:16 GMT
       Date:
-      - Sat, 27 Oct 2018 00:09:49 GMT
+      - Mon, 29 Oct 2018 21:20:16 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -941,175 +1086,34 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "11051",
+         "newStartPageToken": "13071",
          "changes": [
           {
-           "fileId": "1_3p7zHi0e6y28PCuwbTwfVigFSY3ITje"
-          },
-          {
-           "fileId": "1_NWxM97RWgFKaSr-u2OR0Mpa-WKE5QArhmrq5pK5Guk"
-          },
-          {
-           "fileId": "1GpzbsR_TmXIWfljnDwg2Ug6iSuDgUfkl"
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:09:49 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1_3p7zHi0e6y28PCuwbTwfVigFSY3ITje?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:09:49 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:09:49 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:09:49 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1_3p7zHi0e6y28PCuwbTwfVigFSY3ITje",
-         "name": "9 Starship Titanic (Archive)",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:09:49 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1_3p7zHi0e6y28PCuwbTwfVigFSY3ITje/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:09:49 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:09:49 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:09:49 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
+           "fileId": "1Pv05E_4HyG8KPewRh8d5vpEJxPfRvD4E",
+           "file": {
+            "parents": [
+             "0AIeK5UAEPQfeUk9PVA"
+            ]
            }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
+          },
+          {
+           "fileId": "1nZrJh5XYVeWarEIF9ENoCaGohy0GDcHzV3ZnA25t40o",
+           "file": {
+            "parents": [
+             "1wl5uY8ltXj23hkx-uUG7NIOq0QWwtaXE"
+            ]
+           }
+          },
+          {
+           "fileId": "1wl5uY8ltXj23hkx-uUG7NIOq0QWwtaXE"
+          }
+         ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:09:49 GMT
+  recorded_at: Mon, 29 Oct 2018 21:20:16 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1_NWxM97RWgFKaSr-u2OR0Mpa-WKE5QArhmrq5pK5Guk?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1nZrJh5XYVeWarEIF9ENoCaGohy0GDcHzV3ZnA25t40o?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1121,7 +1125,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:09:49 GMT
+      - Mon, 29 Oct 2018 21:20:16 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1132,9 +1136,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:09:49 GMT
+      - Mon, 29 Oct 2018 21:20:16 GMT
       Date:
-      - Sat, 27 Oct 2018 00:09:49 GMT
+      - Mon, 29 Oct 2018 21:20:16 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1160,14 +1164,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1_NWxM97RWgFKaSr-u2OR0Mpa-WKE5QArhmrq5pK5Guk",
+         "id": "1nZrJh5XYVeWarEIF9ENoCaGohy0GDcHzV3ZnA25t40o",
          "name": "My New File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1GpzbsR_TmXIWfljnDwg2Ug6iSuDgUfkl"
+          "1wl5uY8ltXj23hkx-uUG7NIOq0QWwtaXE"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1_NWxM97RWgFKaSr-u2OR0Mpa-WKE5QArhmrq5pK5Guk&v=1&s=AMedNnoAAAAAW9PI7TY6SHkq9KIbn6y1luOufGy_3BDG&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1nZrJh5XYVeWarEIF9ENoCaGohy0GDcHzV3ZnA25t40o&v=1&s=AMedNnoAAAAAW9eVsMwLw-M3KMMgb1WuTQr_-_jN-hjo&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -1191,10 +1195,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:09:49 GMT
+  recorded_at: Mon, 29 Oct 2018 21:20:16 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1_NWxM97RWgFKaSr-u2OR0Mpa-WKE5QArhmrq5pK5Guk/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1nZrJh5XYVeWarEIF9ENoCaGohy0GDcHzV3ZnA25t40o/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1206,7 +1210,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:09:49 GMT
+      - Mon, 29 Oct 2018 21:20:16 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1217,9 +1221,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:09:50 GMT
+      - Mon, 29 Oct 2018 21:20:16 GMT
       Date:
-      - Sat, 27 Oct 2018 00:09:50 GMT
+      - Mon, 29 Oct 2018 21:20:16 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1248,13 +1252,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:08:47.939Z"
+         "modifiedTime": "2018-10-29T21:19:14.203Z"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:09:50 GMT
+  recorded_at: Mon, 29 Oct 2018 21:20:16 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1_NWxM97RWgFKaSr-u2OR0Mpa-WKE5QArhmrq5pK5Guk&s=AMedNnoAAAAAW9PI7TY6SHkq9KIbn6y1luOufGy_3BDG&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1nZrJh5XYVeWarEIF9ENoCaGohy0GDcHzV3ZnA25t40o&s=AMedNnoAAAAAW9eVsMwLw-M3KMMgb1WuTQr_-_jN-hjo&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1266,7 +1270,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:09:50 GMT
+      - Mon, 29 Oct 2018 21:20:16 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1297,7 +1301,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Sat, 27 Oct 2018 00:09:50 GMT
+      - Mon, 29 Oct 2018 21:20:17 GMT
       Server:
       - fife
       Content-Length:
@@ -1311,13 +1315,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:09:50 GMT
+  recorded_at: Mon, 29 Oct 2018 21:20:17 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1_NWxM97RWgFKaSr-u2OR0Mpa-WKE5QArhmrq5pK5Guk/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1nZrJh5XYVeWarEIF9ENoCaGohy0GDcHzV3ZnA25t40o/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"My New File","parents":["1_3p7zHi0e6y28PCuwbTwfVigFSY3ITje"]}'
+      string: '{"name":"My New File","parents":["1Pv05E_4HyG8KPewRh8d5vpEJxPfRvD4E"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1326,7 +1330,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:09:50 GMT
+      - Mon, 29 Oct 2018 21:20:17 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1343,7 +1347,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:09:52 GMT
+      - Mon, 29 Oct 2018 21:20:19 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1367,12 +1371,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1sLha22MrRbCI0GFvLQnV70AbldsD2DPnGl19OVlDpEI",
+         "id": "1OfrpMqhurXGGf-rd8_40y54SqyVUFSfTrMi_wFCI5W0",
          "name": "My New File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1_3p7zHi0e6y28PCuwbTwfVigFSY3ITje"
+          "1Pv05E_4HyG8KPewRh8d5vpEJxPfRvD4E"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1397,10 +1401,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:09:52 GMT
+  recorded_at: Mon, 29 Oct 2018 21:20:19 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1GpzbsR_TmXIWfljnDwg2Ug6iSuDgUfkl?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1wl5uY8ltXj23hkx-uUG7NIOq0QWwtaXE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1412,7 +1416,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:09:52 GMT
+      - Mon, 29 Oct 2018 21:20:19 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1423,9 +1427,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:09:52 GMT
+      - Mon, 29 Oct 2018 21:20:19 GMT
       Date:
-      - Sat, 27 Oct 2018 00:09:52 GMT
+      - Mon, 29 Oct 2018 21:20:19 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1451,8 +1455,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1GpzbsR_TmXIWfljnDwg2Ug6iSuDgUfkl",
-         "name": "Test @ 2018-10-27 00:08:43 UTC",
+         "id": "1wl5uY8ltXj23hkx-uUG7NIOq0QWwtaXE",
+         "name": "Test @ 2018-10-29 21:19:06 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -1478,10 +1482,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:09:52 GMT
+  recorded_at: Mon, 29 Oct 2018 21:20:19 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1GpzbsR_TmXIWfljnDwg2Ug6iSuDgUfkl/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1wl5uY8ltXj23hkx-uUG7NIOq0QWwtaXE/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1493,7 +1497,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:09:52 GMT
+      - Mon, 29 Oct 2018 21:20:19 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1511,9 +1515,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:09:52 GMT
+      - Mon, 29 Oct 2018 21:20:20 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:09:52 GMT
+      - Mon, 29 Oct 2018 21:20:20 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1545,10 +1549,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:09:52 GMT
+  recorded_at: Mon, 29 Oct 2018 21:20:20 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1sLha22MrRbCI0GFvLQnV70AbldsD2DPnGl19OVlDpEI?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1OfrpMqhurXGGf-rd8_40y54SqyVUFSfTrMi_wFCI5W0?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1560,7 +1564,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:09:52 GMT
+      - Mon, 29 Oct 2018 21:20:20 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1571,9 +1575,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:09:53 GMT
+      - Mon, 29 Oct 2018 21:20:20 GMT
       Date:
-      - Sat, 27 Oct 2018 00:09:53 GMT
+      - Mon, 29 Oct 2018 21:20:20 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1599,12 +1603,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1sLha22MrRbCI0GFvLQnV70AbldsD2DPnGl19OVlDpEI",
+         "id": "1OfrpMqhurXGGf-rd8_40y54SqyVUFSfTrMi_wFCI5W0",
          "name": "My New File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1_3p7zHi0e6y28PCuwbTwfVigFSY3ITje"
+          "1Pv05E_4HyG8KPewRh8d5vpEJxPfRvD4E"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1629,10 +1633,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:09:53 GMT
+  recorded_at: Mon, 29 Oct 2018 21:20:20 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1GpzbsR_TmXIWfljnDwg2Ug6iSuDgUfkl
+    uri: https://www.googleapis.com/drive/v3/files/1wl5uY8ltXj23hkx-uUG7NIOq0QWwtaXE
     body:
       encoding: UTF-8
       string: ''
@@ -1644,7 +1648,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:09:53 GMT
+      - Mon, 29 Oct 2018 21:20:20 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1661,7 +1665,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:09:53 GMT
+      - Mon, 29 Oct 2018 21:20:21 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1673,5 +1677,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:09:53 GMT
+  recorded_at: Mon, 29 Oct 2018 21:20:23 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_deletes_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_deletes_file.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Sat, 27 Oct 2018 00:04:58 GMT
+      - Mon, 29 Oct 2018 21:35:08 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:04:58 GMT
+  recorded_at: Mon, 29 Oct 2018 21:35:08 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Sat, 27 Oct 2018 00:04:58 GMT
+      - Mon, 29 Oct 2018 21:35:08 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:04:58 GMT
+  recorded_at: Mon, 29 Oct 2018 21:35:08 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-27
-        00:04:58 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-29
+        21:35:08 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:04:58 GMT
+      - Mon, 29 Oct 2018 21:35:08 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:04:59 GMT
+      - Mon, 29 Oct 2018 21:35:09 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1net75sBMZLadeSMVYJknVfmgxmzrvsBf",
-         "name": "Test @ 2018-10-27 00:04:58 UTC",
+         "id": "1dbII15aQBxyXj5q61mj4gQXws3UOgs1o",
+         "name": "Test @ 2018-10-29 21:35:08 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:04:59 GMT
+  recorded_at: Mon, 29 Oct 2018 21:35:09 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1net75sBMZLadeSMVYJknVfmgxmzrvsBf/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1dbII15aQBxyXj5q61mj4gQXws3UOgs1o/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:04:59 GMT
+      - Mon, 29 Oct 2018 21:35:09 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:05:00 GMT
+      - Mon, 29 Oct 2018 21:35:10 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:05:00 GMT
+  recorded_at: Mon, 29 Oct 2018 21:35:10 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:05:00 GMT
+      - Mon, 29 Oct 2018 21:35:10 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:05:00 GMT
+      - Mon, 29 Oct 2018 21:35:10 GMT
       Date:
-      - Sat, 27 Oct 2018 00:05:00 GMT
+      - Mon, 29 Oct 2018 21:35:10 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,16 +302,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "11005"
+         "startPageToken": "13193"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:05:00 GMT
+  recorded_at: Mon, 29 Oct 2018 21:35:10 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"To Delete","parents":["1net75sBMZLadeSMVYJknVfmgxmzrvsBf"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"To Delete","parents":["1dbII15aQBxyXj5q61mj4gQXws3UOgs1o"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -320,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:05:00 GMT
+      - Mon, 29 Oct 2018 21:35:10 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -337,7 +337,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:05:02 GMT
+      - Mon, 29 Oct 2018 21:35:11 GMT
       Vary:
       - Origin
       - X-Origin
@@ -361,12 +361,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1wieqPBP2ix_P5SFMdDc4NgWaB_DHicsM7BxI6HLGS0o",
+         "id": "1MazWvyThMoeQaDcxEf4EJQNjWNZ_iLY9Xs5wBgwcPI4",
          "name": "To Delete",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1net75sBMZLadeSMVYJknVfmgxmzrvsBf"
+          "1dbII15aQBxyXj5q61mj4gQXws3UOgs1o"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -391,14 +391,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:05:02 GMT
+  recorded_at: Mon, 29 Oct 2018 21:35:11 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"6 Billion
-        Year Bunker (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"6 Krikkit
+        One (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -407,7 +407,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:05:02 GMT
+      - Mon, 29 Oct 2018 21:35:11 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -424,7 +424,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:05:02 GMT
+      - Mon, 29 Oct 2018 21:35:12 GMT
       Vary:
       - Origin
       - X-Origin
@@ -448,8 +448,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1uFSHaA2LB488XOPIiLk1Qlm9owYQ-Ua8",
-         "name": "6 Billion Year Bunker (Archive)",
+         "id": "1MfqyEPxDPGbQvq2FRvZ9R7D1R6ji3eBU",
+         "name": "6 Krikkit One (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -469,10 +469,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:05:03 GMT
+  recorded_at: Mon, 29 Oct 2018 21:35:12 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1uFSHaA2LB488XOPIiLk1Qlm9owYQ-Ua8/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1MfqyEPxDPGbQvq2FRvZ9R7D1R6ji3eBU/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -484,7 +484,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:05:03 GMT
+      - Mon, 29 Oct 2018 21:35:12 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -501,7 +501,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:05:03 GMT
+      - Mon, 29 Oct 2018 21:35:13 GMT
       Vary:
       - Origin
       - X-Origin
@@ -531,10 +531,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:05:04 GMT
+  recorded_at: Mon, 29 Oct 2018 21:35:13 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1uFSHaA2LB488XOPIiLk1Qlm9owYQ-Ua8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1dbII15aQBxyXj5q61mj4gQXws3UOgs1o?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -546,7 +546,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:05:04 GMT
+      - Mon, 29 Oct 2018 21:35:13 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -557,9 +557,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:05:04 GMT
+      - Mon, 29 Oct 2018 21:35:13 GMT
       Date:
-      - Sat, 27 Oct 2018 00:05:04 GMT
+      - Mon, 29 Oct 2018 21:35:13 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -585,159 +585,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1uFSHaA2LB488XOPIiLk1Qlm9owYQ-Ua8",
-         "name": "6 Billion Year Bunker (Archive)",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:05:04 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1uFSHaA2LB488XOPIiLk1Qlm9owYQ-Ua8/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:05:04 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:05:04 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:05:04 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:05:05 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1net75sBMZLadeSMVYJknVfmgxmzrvsBf?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:05:05 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:05:05 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:05:05 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1net75sBMZLadeSMVYJknVfmgxmzrvsBf",
-         "name": "Test @ 2018-10-27 00:04:58 UTC",
+         "id": "1dbII15aQBxyXj5q61mj4gQXws3UOgs1o",
+         "name": "Test @ 2018-10-29 21:35:08 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -763,10 +612,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:05:05 GMT
+  recorded_at: Mon, 29 Oct 2018 21:35:13 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1net75sBMZLadeSMVYJknVfmgxmzrvsBf/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1dbII15aQBxyXj5q61mj4gQXws3UOgs1o/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -778,7 +627,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:05:05 GMT
+      - Mon, 29 Oct 2018 21:35:13 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -796,9 +645,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:05:05 GMT
+      - Mon, 29 Oct 2018 21:35:13 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:05:05 GMT
+      - Mon, 29 Oct 2018 21:35:13 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -830,10 +679,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:05:05 GMT
+  recorded_at: Mon, 29 Oct 2018 21:35:13 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271net75sBMZLadeSMVYJknVfmgxmzrvsBf%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files/1dbII15aQBxyXj5q61mj4gQXws3UOgs1o?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -845,7 +694,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:05:05 GMT
+      - Mon, 29 Oct 2018 21:35:13 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -856,9 +705,305 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:05:05 GMT
+      - Mon, 29 Oct 2018 21:35:13 GMT
       Date:
-      - Sat, 27 Oct 2018 00:05:05 GMT
+      - Mon, 29 Oct 2018 21:35:13 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1dbII15aQBxyXj5q61mj4gQXws3UOgs1o",
+         "name": "Test @ 2018-10-29 21:35:08 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:35:13 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1dbII15aQBxyXj5q61mj4gQXws3UOgs1o/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:35:13 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 29 Oct 2018 21:35:14 GMT
+      Expires:
+      - Mon, 29 Oct 2018 21:35:14 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:35:14 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1dbII15aQBxyXj5q61mj4gQXws3UOgs1o?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:35:14 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:35:14 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:35:14 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1dbII15aQBxyXj5q61mj4gQXws3UOgs1o",
+         "name": "Test @ 2018-10-29 21:35:08 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:35:14 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1dbII15aQBxyXj5q61mj4gQXws3UOgs1o/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:35:14 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 29 Oct 2018 21:35:14 GMT
+      Expires:
+      - Mon, 29 Oct 2018 21:35:14 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:35:14 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271dbII15aQBxyXj5q61mj4gQXws3UOgs1o%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:35:14 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:35:14 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:35:14 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -886,14 +1031,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1wieqPBP2ix_P5SFMdDc4NgWaB_DHicsM7BxI6HLGS0o",
+           "id": "1MazWvyThMoeQaDcxEf4EJQNjWNZ_iLY9Xs5wBgwcPI4",
            "name": "To Delete",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1net75sBMZLadeSMVYJknVfmgxmzrvsBf"
+            "1dbII15aQBxyXj5q61mj4gQXws3UOgs1o"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1wieqPBP2ix_P5SFMdDc4NgWaB_DHicsM7BxI6HLGS0o&v=1&s=AMedNnoAAAAAW9PH0bDU6U1g-JqA99VGAy2NIJ8zUgJe&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1MazWvyThMoeQaDcxEf4EJQNjWNZ_iLY9Xs5wBgwcPI4&v=1&s=AMedNnoAAAAAW9eZMhakQf1_MnLmQtDxaX5Y7lMRzZB2&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -919,10 +1064,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:05:05 GMT
+  recorded_at: Mon, 29 Oct 2018 21:35:14 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1wieqPBP2ix_P5SFMdDc4NgWaB_DHicsM7BxI6HLGS0o/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1MazWvyThMoeQaDcxEf4EJQNjWNZ_iLY9Xs5wBgwcPI4/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -934,7 +1079,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:05:05 GMT
+      - Mon, 29 Oct 2018 21:35:14 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -945,9 +1090,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:05:06 GMT
+      - Mon, 29 Oct 2018 21:35:15 GMT
       Date:
-      - Sat, 27 Oct 2018 00:05:06 GMT
+      - Mon, 29 Oct 2018 21:35:15 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -976,13 +1121,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:05:01.403Z"
+         "modifiedTime": "2018-10-29T21:35:10.920Z"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:05:06 GMT
+  recorded_at: Mon, 29 Oct 2018 21:35:15 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1wieqPBP2ix_P5SFMdDc4NgWaB_DHicsM7BxI6HLGS0o&s=AMedNnoAAAAAW9PH0bDU6U1g-JqA99VGAy2NIJ8zUgJe&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1MazWvyThMoeQaDcxEf4EJQNjWNZ_iLY9Xs5wBgwcPI4&s=AMedNnoAAAAAW9eZMhakQf1_MnLmQtDxaX5Y7lMRzZB2&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -994,7 +1139,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:05:06 GMT
+      - Mon, 29 Oct 2018 21:35:15 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1025,7 +1170,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Sat, 27 Oct 2018 00:05:06 GMT
+      - Mon, 29 Oct 2018 21:35:15 GMT
       Server:
       - fife
       Content-Length:
@@ -1039,13 +1184,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:05:06 GMT
+  recorded_at: Mon, 29 Oct 2018 21:35:15 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1wieqPBP2ix_P5SFMdDc4NgWaB_DHicsM7BxI6HLGS0o/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1MazWvyThMoeQaDcxEf4EJQNjWNZ_iLY9Xs5wBgwcPI4/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"To Delete","parents":["1uFSHaA2LB488XOPIiLk1Qlm9owYQ-Ua8"]}'
+      string: '{"name":"To Delete","parents":["1MfqyEPxDPGbQvq2FRvZ9R7D1R6ji3eBU"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1054,7 +1199,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:05:06 GMT
+      - Mon, 29 Oct 2018 21:35:15 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1071,7 +1216,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:05:07 GMT
+      - Mon, 29 Oct 2018 21:35:17 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1095,12 +1240,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1SSBLOdlVZOghHsng5aVY7RVBZlHuID9PFcxD8yXCaz0",
+         "id": "1dK4huIQGSibt-FNC9SYRVqiWhlt2XgC3T9NjFquMJaI",
          "name": "To Delete",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1uFSHaA2LB488XOPIiLk1Qlm9owYQ-Ua8"
+          "1MfqyEPxDPGbQvq2FRvZ9R7D1R6ji3eBU"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1125,10 +1270,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:05:08 GMT
+  recorded_at: Mon, 29 Oct 2018 21:35:18 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1wieqPBP2ix_P5SFMdDc4NgWaB_DHicsM7BxI6HLGS0o
+    uri: https://www.googleapis.com/drive/v3/files/1MazWvyThMoeQaDcxEf4EJQNjWNZ_iLY9Xs5wBgwcPI4
     body:
       encoding: UTF-8
       string: ''
@@ -1140,7 +1285,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:05:08 GMT
+      - Mon, 29 Oct 2018 21:35:18 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1157,7 +1302,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:05:08 GMT
+      - Mon, 29 Oct 2018 21:35:18 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1169,10 +1314,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:05:08 GMT
+  recorded_at: Mon, 29 Oct 2018 21:35:18 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=11005
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId,changes/file/parents&pageSize=100&pageToken=13193
     body:
       encoding: UTF-8
       string: ''
@@ -1184,7 +1329,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:06:08 GMT
+      - Mon, 29 Oct 2018 21:36:18 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1195,9 +1340,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:06:09 GMT
+      - Mon, 29 Oct 2018 21:36:19 GMT
       Date:
-      - Sat, 27 Oct 2018 00:06:09 GMT
+      - Mon, 29 Oct 2018 21:36:19 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1223,275 +1368,80 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "11019",
+         "newStartPageToken": "13208",
          "changes": [
           {
-           "fileId": "1uFSHaA2LB488XOPIiLk1Qlm9owYQ-Ua8"
+           "fileId": "1zXEkvgwRdAi2YOQM1nqJvje6e6Owo45zg100lexcdVI"
           },
           {
-           "fileId": "18WWLEIMsREk1eOiowkJ5T1IMht1TgaPWC-KqIJAsQGQ"
-          },
-          {
-           "fileId": "1wieqPBP2ix_P5SFMdDc4NgWaB_DHicsM7BxI6HLGS0o"
-          },
-          {
-           "fileId": "1SSBLOdlVZOghHsng5aVY7RVBZlHuID9PFcxD8yXCaz0"
-          },
-          {
-           "fileId": "1Se2UjSeqo6C442ffeH_hK0gecWvX_JLJkJarCigELuM"
-          },
-          {
-           "fileId": "13PlUAEHfMZQCrrl9bfJJrjhQoOjMfUE6pcIGRFZlDR8"
-          },
-          {
-           "fileId": "1kpB9WybD7vh6vPtsl7kuPn6whR6QIzW6MqH93__ecQ4"
-          },
-          {
-           "fileId": "1net75sBMZLadeSMVYJknVfmgxmzrvsBf"
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:09 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1uFSHaA2LB488XOPIiLk1Qlm9owYQ-Ua8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:06:09 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:06:09 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:06:09 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1uFSHaA2LB488XOPIiLk1Qlm9owYQ-Ua8",
-         "name": "6 Billion Year Bunker (Archive)",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:09 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1uFSHaA2LB488XOPIiLk1Qlm9owYQ-Ua8/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:06:09 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:06:09 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:06:09 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
+           "fileId": "1MfqyEPxDPGbQvq2FRvZ9R7D1R6ji3eBU",
+           "file": {
+            "parents": [
+             "0AIeK5UAEPQfeUk9PVA"
+            ]
            }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:09 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/18WWLEIMsREk1eOiowkJ5T1IMht1TgaPWC-KqIJAsQGQ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:06:09 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:06:09 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:06:09 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "18WWLEIMsREk1eOiowkJ5T1IMht1TgaPWC-KqIJAsQGQ",
-         "name": "File",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1h_RSdb_1zKB3cxLwAtprK2OYHfUNszbD"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=18WWLEIMsREk1eOiowkJ5T1IMht1TgaPWC-KqIJAsQGQ&v=1&s=AMedNnoAAAAAW9PIEUsB3mgUnfzV_j0uDxnq9aiKzasd&sz=s220",
-         "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
           },
           {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
+           "fileId": "1Bv_toU4nbkcEM6Z91wIxxOqLEqokXz7fePpzuposmU0",
+           "file": {
+            "parents": [
+             "1YO1aHjn8HAb4Jjaw1GQTXF-IN9kq9HEr"
+            ]
+           }
+          },
+          {
+           "fileId": "1lPeuySl2fIkcTtk8GgZCNPvtCq9ra6lwa2g_kQ2tXUA",
+           "file": {
+            "parents": [
+             "1zihOYT8qtc-1vsHXKGs4ikC8Jd2CBZ8l"
+            ]
+           }
+          },
+          {
+           "fileId": "1MazWvyThMoeQaDcxEf4EJQNjWNZ_iLY9Xs5wBgwcPI4"
+          },
+          {
+           "fileId": "1dK4huIQGSibt-FNC9SYRVqiWhlt2XgC3T9NjFquMJaI",
+           "file": {
+            "parents": [
+             "1MfqyEPxDPGbQvq2FRvZ9R7D1R6ji3eBU"
+            ]
+           }
+          },
+          {
+           "fileId": "1faD2rFFXDNdGvLSHMlXRyeHyvA3aQeDN3BihOU0PA04",
+           "file": {
+            "parents": [
+             "1Flv74-BFXz-kz1KdrHLtw06oQf8CqHzA"
+            ]
+           }
+          },
+          {
+           "fileId": "14f5r_DN_OC6vExxNKN7IBjr-Akf4qiZ-GUoVZV26YVA",
+           "file": {
+            "parents": [
+             "1Flv74-BFXz-kz1KdrHLtw06oQf8CqHzA"
+            ]
+           }
+          },
+          {
+           "fileId": "1GhCfZ1e8HJ-bRkXR6ZZZhwYOGx6xfmQWNpcz4TFKj7E",
+           "file": {
+            "parents": [
+             "1hoAqEhwZWgBnLYaq6pL60jNhAQ7CAW6k"
+            ]
+           }
+          },
+          {
+           "fileId": "1dbII15aQBxyXj5q61mj4gQXws3UOgs1o"
           }
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:09 GMT
+  recorded_at: Mon, 29 Oct 2018 21:36:19 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/18WWLEIMsREk1eOiowkJ5T1IMht1TgaPWC-KqIJAsQGQ/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1MazWvyThMoeQaDcxEf4EJQNjWNZ_iLY9Xs5wBgwcPI4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1503,127 +1453,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:06:09 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:06:10 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:06:10 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "kind": "drive#revision",
-         "id": "1",
-         "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:02:35.456Z"
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:10 GMT
-- request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=18WWLEIMsREk1eOiowkJ5T1IMht1TgaPWC-KqIJAsQGQ&s=AMedNnoAAAAAW9PIEUsB3mgUnfzV_j0uDxnq9aiKzasd&sz=s350&v=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:06:10 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Expose-Headers:
-      - Content-Length
-      Etag:
-      - '"v1"'
-      Expires:
-      - Fri, 01 Jan 1990 00:00:00 GMT
-      Cache-Control:
-      - private, max-age=86400, no-transform
-      Content-Disposition:
-      - inline;filename="unnamed.png"
-      Content-Type:
-      - image/png
-      Vary:
-      - Origin
-      Access-Control-Allow-Origin:
-      - "*"
-      Timing-Allow-Origin:
-      - "*"
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Sat, 27 Oct 2018 00:06:10 GMT
-      Server:
-      - fife
-      Content-Length:
-      - '1022'
-      X-Xss-Protection:
-      - 1; mode=block
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:10 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1wieqPBP2ix_P5SFMdDc4NgWaB_DHicsM7BxI6HLGS0o?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:06:10 GMT
+      - Mon, 29 Oct 2018 21:36:19 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1641,9 +1471,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:06:10 GMT
+      - Mon, 29 Oct 2018 21:36:19 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:06:10 GMT
+      - Mon, 29 Oct 2018 21:36:19 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1667,20 +1497,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1wieqPBP2ix_P5SFMdDc4NgWaB_DHicsM7BxI6HLGS0o.",
+            "message": "File not found: 1MazWvyThMoeQaDcxEf4EJQNjWNZ_iLY9Xs5wBgwcPI4.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1wieqPBP2ix_P5SFMdDc4NgWaB_DHicsM7BxI6HLGS0o."
+          "message": "File not found: 1MazWvyThMoeQaDcxEf4EJQNjWNZ_iLY9Xs5wBgwcPI4."
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:10 GMT
+  recorded_at: Mon, 29 Oct 2018 21:36:19 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1SSBLOdlVZOghHsng5aVY7RVBZlHuID9PFcxD8yXCaz0?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1dbII15aQBxyXj5q61mj4gQXws3UOgs1o?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1692,7 +1522,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:06:10 GMT
+      - Mon, 29 Oct 2018 21:36:19 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1703,9 +1533,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:06:11 GMT
+      - Mon, 29 Oct 2018 21:36:19 GMT
       Date:
-      - Sat, 27 Oct 2018 00:06:11 GMT
+      - Mon, 29 Oct 2018 21:36:19 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1731,828 +1561,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1SSBLOdlVZOghHsng5aVY7RVBZlHuID9PFcxD8yXCaz0",
-         "name": "To Delete",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1uFSHaA2LB488XOPIiLk1Qlm9owYQ-Ua8"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1SSBLOdlVZOghHsng5aVY7RVBZlHuID9PFcxD8yXCaz0&v=1&s=AMedNnoAAAAAW9PIEwZbP0xUWbkvjS8uzdXCXSrV3xxa&sz=s220",
-         "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:11 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1SSBLOdlVZOghHsng5aVY7RVBZlHuID9PFcxD8yXCaz0/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:06:11 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:06:11 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:06:11 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "kind": "drive#revision",
-         "id": "1",
-         "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:05:07.264Z"
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:11 GMT
-- request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1SSBLOdlVZOghHsng5aVY7RVBZlHuID9PFcxD8yXCaz0&s=AMedNnoAAAAAW9PIEwZbP0xUWbkvjS8uzdXCXSrV3xxa&sz=s350&v=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:06:11 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Expose-Headers:
-      - Content-Length
-      Etag:
-      - '"v1"'
-      Expires:
-      - Fri, 01 Jan 1990 00:00:00 GMT
-      Cache-Control:
-      - private, max-age=86400, no-transform
-      Content-Disposition:
-      - inline;filename="unnamed.png"
-      Content-Type:
-      - image/png
-      Vary:
-      - Origin
-      Access-Control-Allow-Origin:
-      - "*"
-      Timing-Allow-Origin:
-      - "*"
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Sat, 27 Oct 2018 00:06:11 GMT
-      Server:
-      - fife
-      Content-Length:
-      - '1022'
-      X-Xss-Protection:
-      - 1; mode=block
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:11 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Se2UjSeqo6C442ffeH_hK0gecWvX_JLJkJarCigELuM?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:06:11 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:06:11 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:06:11 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1Se2UjSeqo6C442ffeH_hK0gecWvX_JLJkJarCigELuM",
-         "name": "File To Move",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1ep-1-2ODj4AYqIx6Y6bLBTGSvH78JsEE"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Se2UjSeqo6C442ffeH_hK0gecWvX_JLJkJarCigELuM&v=1&s=AMedNnoAAAAAW9PIE1NBhAZsKPqHd5MrCw3eo2YSyGiX&sz=s220",
-         "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:11 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Se2UjSeqo6C442ffeH_hK0gecWvX_JLJkJarCigELuM/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:06:11 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:06:12 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:06:12 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "kind": "drive#revision",
-         "id": "1",
-         "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:01:16.624Z"
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:12 GMT
-- request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1Se2UjSeqo6C442ffeH_hK0gecWvX_JLJkJarCigELuM&s=AMedNnoAAAAAW9PIE1NBhAZsKPqHd5MrCw3eo2YSyGiX&sz=s350&v=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:06:12 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Expose-Headers:
-      - Content-Length
-      Etag:
-      - '"v1"'
-      Expires:
-      - Fri, 01 Jan 1990 00:00:00 GMT
-      Cache-Control:
-      - private, max-age=86400, no-transform
-      Content-Disposition:
-      - inline;filename="unnamed.png"
-      Content-Type:
-      - image/png
-      Vary:
-      - Origin
-      Access-Control-Allow-Origin:
-      - "*"
-      Timing-Allow-Origin:
-      - "*"
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Sat, 27 Oct 2018 00:06:12 GMT
-      Server:
-      - fife
-      Content-Length:
-      - '1022'
-      X-Xss-Protection:
-      - 1; mode=block
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:12 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/13PlUAEHfMZQCrrl9bfJJrjhQoOjMfUE6pcIGRFZlDR8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:06:12 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:06:12 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:06:12 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "13PlUAEHfMZQCrrl9bfJJrjhQoOjMfUE6pcIGRFZlDR8",
-         "name": "File To Move",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1ep-1-2ODj4AYqIx6Y6bLBTGSvH78JsEE"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=13PlUAEHfMZQCrrl9bfJJrjhQoOjMfUE6pcIGRFZlDR8&v=1&s=AMedNnoAAAAAW9PIFOYWOglrsop9HtkMZi8uY6Sxwucz&sz=s220",
-         "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:12 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/13PlUAEHfMZQCrrl9bfJJrjhQoOjMfUE6pcIGRFZlDR8/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:06:12 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:06:12 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:06:12 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "kind": "drive#revision",
-         "id": "1",
-         "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:02:23.778Z"
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:12 GMT
-- request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=13PlUAEHfMZQCrrl9bfJJrjhQoOjMfUE6pcIGRFZlDR8&s=AMedNnoAAAAAW9PIFOYWOglrsop9HtkMZi8uY6Sxwucz&sz=s350&v=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:06:12 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Expose-Headers:
-      - Content-Length
-      Etag:
-      - '"v1"'
-      Expires:
-      - Fri, 01 Jan 1990 00:00:00 GMT
-      Cache-Control:
-      - private, max-age=86400, no-transform
-      Content-Disposition:
-      - inline;filename="unnamed.png"
-      Content-Type:
-      - image/png
-      Vary:
-      - Origin
-      Access-Control-Allow-Origin:
-      - "*"
-      Timing-Allow-Origin:
-      - "*"
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Sat, 27 Oct 2018 00:06:12 GMT
-      Server:
-      - fife
-      Content-Length:
-      - '1022'
-      X-Xss-Protection:
-      - 1; mode=block
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:13 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1kpB9WybD7vh6vPtsl7kuPn6whR6QIzW6MqH93__ecQ4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:06:13 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:06:13 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:06:13 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1kpB9WybD7vh6vPtsl7kuPn6whR6QIzW6MqH93__ecQ4",
-         "name": "File",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1nPjlq480aw1IsXPvjBHqHPRDJkKZLegB"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1kpB9WybD7vh6vPtsl7kuPn6whR6QIzW6MqH93__ecQ4&v=1&s=AMedNnoAAAAAW9PIFXEc6Fv5GRj52SztW0H-Izn825yl&sz=s220",
-         "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:13 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1kpB9WybD7vh6vPtsl7kuPn6whR6QIzW6MqH93__ecQ4/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:06:13 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:06:13 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:06:13 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "kind": "drive#revision",
-         "id": "1",
-         "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:03:53.725Z"
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:13 GMT
-- request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1kpB9WybD7vh6vPtsl7kuPn6whR6QIzW6MqH93__ecQ4&s=AMedNnoAAAAAW9PIFXEc6Fv5GRj52SztW0H-Izn825yl&sz=s350&v=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:06:13 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Expose-Headers:
-      - Content-Length
-      Etag:
-      - '"v1"'
-      Expires:
-      - Fri, 01 Jan 1990 00:00:00 GMT
-      Cache-Control:
-      - private, max-age=86400, no-transform
-      Content-Disposition:
-      - inline;filename="unnamed.png"
-      Content-Type:
-      - image/png
-      Vary:
-      - Origin
-      Access-Control-Allow-Origin:
-      - "*"
-      Timing-Allow-Origin:
-      - "*"
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Sat, 27 Oct 2018 00:06:13 GMT
-      Server:
-      - fife
-      Content-Length:
-      - '1022'
-      X-Xss-Protection:
-      - 1; mode=block
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:13 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1net75sBMZLadeSMVYJknVfmgxmzrvsBf?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:06:13 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:06:14 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:06:14 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1net75sBMZLadeSMVYJknVfmgxmzrvsBf",
-         "name": "Test @ 2018-10-27 00:04:58 UTC",
+         "id": "1dbII15aQBxyXj5q61mj4gQXws3UOgs1o",
+         "name": "Test @ 2018-10-29 21:35:08 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -2578,10 +1588,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:14 GMT
+  recorded_at: Mon, 29 Oct 2018 21:36:19 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1net75sBMZLadeSMVYJknVfmgxmzrvsBf/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1dbII15aQBxyXj5q61mj4gQXws3UOgs1o/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -2593,7 +1603,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:06:14 GMT
+      - Mon, 29 Oct 2018 21:36:19 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2611,9 +1621,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:06:14 GMT
+      - Mon, 29 Oct 2018 21:36:19 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:06:14 GMT
+      - Mon, 29 Oct 2018 21:36:19 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -2645,10 +1655,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:14 GMT
+  recorded_at: Mon, 29 Oct 2018 21:36:19 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1net75sBMZLadeSMVYJknVfmgxmzrvsBf
+    uri: https://www.googleapis.com/drive/v3/files/1dbII15aQBxyXj5q61mj4gQXws3UOgs1o
     body:
       encoding: UTF-8
       string: ''
@@ -2660,7 +1670,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:06:14 GMT
+      - Mon, 29 Oct 2018 21:36:19 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -2677,7 +1687,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:06:14 GMT
+      - Mon, 29 Oct 2018 21:36:20 GMT
       Vary:
       - Origin
       - X-Origin
@@ -2689,5 +1699,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:15 GMT
+  recorded_at: Mon, 29 Oct 2018 21:36:20 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_deletes_the_project_folder.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_deletes_the_project_folder.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Sat, 27 Oct 2018 00:03:46 GMT
+      - Mon, 29 Oct 2018 21:38:47 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:46 GMT
+  recorded_at: Mon, 29 Oct 2018 21:38:47 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Sat, 27 Oct 2018 00:03:46 GMT
+      - Mon, 29 Oct 2018 21:38:47 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:46 GMT
+  recorded_at: Mon, 29 Oct 2018 21:38:47 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-27
-        00:03:46 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-29
+        21:38:47 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:03:46 GMT
+      - Mon, 29 Oct 2018 21:38:47 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:03:47 GMT
+      - Mon, 29 Oct 2018 21:38:48 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1amCLdagXCIBt5W5bUXN56DsdT9E_dL9_",
-         "name": "Test @ 2018-10-27 00:03:46 UTC",
+         "id": "159dc6yh_VnU6BBINDyiBaz-vwami1Dk7",
+         "name": "Test @ 2018-10-29 21:38:47 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:47 GMT
+  recorded_at: Mon, 29 Oct 2018 21:38:48 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1amCLdagXCIBt5W5bUXN56DsdT9E_dL9_/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/159dc6yh_VnU6BBINDyiBaz-vwami1Dk7/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:03:47 GMT
+      - Mon, 29 Oct 2018 21:38:48 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:03:48 GMT
+      - Mon, 29 Oct 2018 21:38:49 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:48 GMT
+  recorded_at: Mon, 29 Oct 2018 21:38:49 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:03:48 GMT
+      - Mon, 29 Oct 2018 21:38:49 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:03:48 GMT
+      - Mon, 29 Oct 2018 21:38:49 GMT
       Date:
-      - Sat, 27 Oct 2018 00:03:48 GMT
+      - Mon, 29 Oct 2018 21:38:49 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,16 +302,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "10995"
+         "startPageToken": "13231"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:48 GMT
+  recorded_at: Mon, 29 Oct 2018 21:38:49 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1amCLdagXCIBt5W5bUXN56DsdT9E_dL9_"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["159dc6yh_VnU6BBINDyiBaz-vwami1Dk7"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -320,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:03:48 GMT
+      - Mon, 29 Oct 2018 21:38:49 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -337,7 +337,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:03:49 GMT
+      - Mon, 29 Oct 2018 21:38:51 GMT
       Vary:
       - Origin
       - X-Origin
@@ -361,12 +361,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1wgeIvZ9IPkri22NQGV5FceBRi23mxC-Cu__HY37YMl8",
+         "id": "1GZG74emPj2NXv2d9jp7f0ls_eBG8idPjdDx6GGVUOhg",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1amCLdagXCIBt5W5bUXN56DsdT9E_dL9_"
+          "159dc6yh_VnU6BBINDyiBaz-vwami1Dk7"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -391,14 +391,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:49 GMT
+  recorded_at: Mon, 29 Oct 2018 21:38:51 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"5 Krikkit
-        One (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"9 Billion
+        Year Bunker (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -407,7 +407,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:03:49 GMT
+      - Mon, 29 Oct 2018 21:38:51 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -424,7 +424,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:03:50 GMT
+      - Mon, 29 Oct 2018 21:38:51 GMT
       Vary:
       - Origin
       - X-Origin
@@ -448,8 +448,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1nPjlq480aw1IsXPvjBHqHPRDJkKZLegB",
-         "name": "5 Krikkit One (Archive)",
+         "id": "1JghOEpqRTggqMXzjPgkm4JiIfJYKLDKZ",
+         "name": "9 Billion Year Bunker (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -469,10 +469,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:50 GMT
+  recorded_at: Mon, 29 Oct 2018 21:38:51 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1nPjlq480aw1IsXPvjBHqHPRDJkKZLegB/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1JghOEpqRTggqMXzjPgkm4JiIfJYKLDKZ/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -484,7 +484,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:03:50 GMT
+      - Mon, 29 Oct 2018 21:38:51 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -501,7 +501,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:03:50 GMT
+      - Mon, 29 Oct 2018 21:38:58 GMT
       Vary:
       - Origin
       - X-Origin
@@ -531,10 +531,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:51 GMT
+  recorded_at: Mon, 29 Oct 2018 21:38:59 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1nPjlq480aw1IsXPvjBHqHPRDJkKZLegB?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/159dc6yh_VnU6BBINDyiBaz-vwami1Dk7?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -546,7 +546,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:03:51 GMT
+      - Mon, 29 Oct 2018 21:38:59 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -557,9 +557,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:03:51 GMT
+      - Mon, 29 Oct 2018 21:38:59 GMT
       Date:
-      - Sat, 27 Oct 2018 00:03:51 GMT
+      - Mon, 29 Oct 2018 21:38:59 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -585,159 +585,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1nPjlq480aw1IsXPvjBHqHPRDJkKZLegB",
-         "name": "5 Krikkit One (Archive)",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:51 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1nPjlq480aw1IsXPvjBHqHPRDJkKZLegB/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:03:51 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:03:51 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:03:51 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:51 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1amCLdagXCIBt5W5bUXN56DsdT9E_dL9_?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:03:51 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:03:52 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:03:52 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1amCLdagXCIBt5W5bUXN56DsdT9E_dL9_",
-         "name": "Test @ 2018-10-27 00:03:46 UTC",
+         "id": "159dc6yh_VnU6BBINDyiBaz-vwami1Dk7",
+         "name": "Test @ 2018-10-29 21:38:47 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -763,10 +612,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:52 GMT
+  recorded_at: Mon, 29 Oct 2018 21:38:59 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1amCLdagXCIBt5W5bUXN56DsdT9E_dL9_/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/159dc6yh_VnU6BBINDyiBaz-vwami1Dk7/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -778,7 +627,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:03:52 GMT
+      - Mon, 29 Oct 2018 21:38:59 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -796,9 +645,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:03:52 GMT
+      - Mon, 29 Oct 2018 21:38:59 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:03:52 GMT
+      - Mon, 29 Oct 2018 21:38:59 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -830,10 +679,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:52 GMT
+  recorded_at: Mon, 29 Oct 2018 21:38:59 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271amCLdagXCIBt5W5bUXN56DsdT9E_dL9_%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files/159dc6yh_VnU6BBINDyiBaz-vwami1Dk7?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -845,7 +694,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:03:52 GMT
+      - Mon, 29 Oct 2018 21:38:59 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -856,9 +705,305 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:03:52 GMT
+      - Mon, 29 Oct 2018 21:38:59 GMT
       Date:
-      - Sat, 27 Oct 2018 00:03:52 GMT
+      - Mon, 29 Oct 2018 21:38:59 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "159dc6yh_VnU6BBINDyiBaz-vwami1Dk7",
+         "name": "Test @ 2018-10-29 21:38:47 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:38:59 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/159dc6yh_VnU6BBINDyiBaz-vwami1Dk7/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:38:59 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 29 Oct 2018 21:39:00 GMT
+      Expires:
+      - Mon, 29 Oct 2018 21:39:00 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:39:00 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/159dc6yh_VnU6BBINDyiBaz-vwami1Dk7?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:39:00 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:39:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:39:00 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "159dc6yh_VnU6BBINDyiBaz-vwami1Dk7",
+         "name": "Test @ 2018-10-29 21:38:47 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:39:00 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/159dc6yh_VnU6BBINDyiBaz-vwami1Dk7/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:39:00 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 29 Oct 2018 21:39:00 GMT
+      Expires:
+      - Mon, 29 Oct 2018 21:39:00 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:39:00 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%27159dc6yh_VnU6BBINDyiBaz-vwami1Dk7%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:39:00 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:39:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:39:00 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -886,14 +1031,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1wgeIvZ9IPkri22NQGV5FceBRi23mxC-Cu__HY37YMl8",
+           "id": "1GZG74emPj2NXv2d9jp7f0ls_eBG8idPjdDx6GGVUOhg",
            "name": "File",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1amCLdagXCIBt5W5bUXN56DsdT9E_dL9_"
+            "159dc6yh_VnU6BBINDyiBaz-vwami1Dk7"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1wgeIvZ9IPkri22NQGV5FceBRi23mxC-Cu__HY37YMl8&v=1&s=AMedNnoAAAAAW9PHiMoLW1tulPIVUCc15iQ168nfEHW6&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1GZG74emPj2NXv2d9jp7f0ls_eBG8idPjdDx6GGVUOhg&v=1&s=AMedNnoAAAAAW9eaFLMNGBl6f0py4wkD3sKw5u6IbHa2&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -919,10 +1064,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:52 GMT
+  recorded_at: Mon, 29 Oct 2018 21:39:00 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1wgeIvZ9IPkri22NQGV5FceBRi23mxC-Cu__HY37YMl8/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1GZG74emPj2NXv2d9jp7f0ls_eBG8idPjdDx6GGVUOhg/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -934,7 +1079,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:03:52 GMT
+      - Mon, 29 Oct 2018 21:39:00 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -945,9 +1090,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:03:52 GMT
+      - Mon, 29 Oct 2018 21:39:01 GMT
       Date:
-      - Sat, 27 Oct 2018 00:03:52 GMT
+      - Mon, 29 Oct 2018 21:39:01 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -976,13 +1121,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:03:48.719Z"
+         "modifiedTime": "2018-10-29T21:38:50.099Z"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:52 GMT
+  recorded_at: Mon, 29 Oct 2018 21:39:01 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1wgeIvZ9IPkri22NQGV5FceBRi23mxC-Cu__HY37YMl8&s=AMedNnoAAAAAW9PHiMoLW1tulPIVUCc15iQ168nfEHW6&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1GZG74emPj2NXv2d9jp7f0ls_eBG8idPjdDx6GGVUOhg&s=AMedNnoAAAAAW9eaFLMNGBl6f0py4wkD3sKw5u6IbHa2&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -994,7 +1139,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:03:52 GMT
+      - Mon, 29 Oct 2018 21:39:01 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1025,7 +1170,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Sat, 27 Oct 2018 00:03:52 GMT
+      - Mon, 29 Oct 2018 21:39:01 GMT
       Server:
       - fife
       Content-Length:
@@ -1039,13 +1184,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:52 GMT
+  recorded_at: Mon, 29 Oct 2018 21:39:01 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1wgeIvZ9IPkri22NQGV5FceBRi23mxC-Cu__HY37YMl8/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1GZG74emPj2NXv2d9jp7f0ls_eBG8idPjdDx6GGVUOhg/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"File","parents":["1nPjlq480aw1IsXPvjBHqHPRDJkKZLegB"]}'
+      string: '{"name":"File","parents":["1JghOEpqRTggqMXzjPgkm4JiIfJYKLDKZ"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1054,7 +1199,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:03:53 GMT
+      - Mon, 29 Oct 2018 21:39:01 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1071,7 +1216,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:03:54 GMT
+      - Mon, 29 Oct 2018 21:39:03 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1095,12 +1240,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1kpB9WybD7vh6vPtsl7kuPn6whR6QIzW6MqH93__ecQ4",
+         "id": "1tcp3f-avlZnceU4WokXeILRC_DqCzvKt3J_iSAJ2Kq8",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1nPjlq480aw1IsXPvjBHqHPRDJkKZLegB"
+          "1JghOEpqRTggqMXzjPgkm4JiIfJYKLDKZ"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1125,10 +1270,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:54 GMT
+  recorded_at: Mon, 29 Oct 2018 21:39:03 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1amCLdagXCIBt5W5bUXN56DsdT9E_dL9_
+    uri: https://www.googleapis.com/drive/v3/files/159dc6yh_VnU6BBINDyiBaz-vwami1Dk7
     body:
       encoding: UTF-8
       string: ''
@@ -1140,7 +1285,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:03:54 GMT
+      - Mon, 29 Oct 2018 21:39:03 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1157,7 +1302,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:03:55 GMT
+      - Mon, 29 Oct 2018 21:39:04 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1169,10 +1314,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:55 GMT
+  recorded_at: Mon, 29 Oct 2018 21:39:04 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=10995
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId,changes/file/parents&pageSize=100&pageToken=13231
     body:
       encoding: UTF-8
       string: ''
@@ -1184,7 +1329,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:04:55 GMT
+      - Mon, 29 Oct 2018 21:40:04 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1195,9 +1340,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:04:55 GMT
+      - Mon, 29 Oct 2018 21:40:04 GMT
       Date:
-      - Sat, 27 Oct 2018 00:04:55 GMT
+      - Mon, 29 Oct 2018 21:40:04 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1223,30 +1368,48 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "11005",
+         "newStartPageToken": "13243",
          "changes": [
           {
-           "fileId": "1UzsfkIvPgGZzLNQjZstvePzozvRaZMXUOmaf51YOho8"
+           "fileId": "1IcY8em19Oj5C11s8kGkW4OFKUUmXiHKhWlhIYCI0A14"
           },
           {
-           "fileId": "1nPjlq480aw1IsXPvjBHqHPRDJkKZLegB"
+           "fileId": "1JghOEpqRTggqMXzjPgkm4JiIfJYKLDKZ",
+           "file": {
+            "parents": [
+             "0AIeK5UAEPQfeUk9PVA"
+            ]
+           }
           },
           {
-           "fileId": "1amCLdagXCIBt5W5bUXN56DsdT9E_dL9_"
+           "fileId": "159dc6yh_VnU6BBINDyiBaz-vwami1Dk7"
           },
           {
-           "fileId": "1kpB9WybD7vh6vPtsl7kuPn6whR6QIzW6MqH93__ecQ4"
+           "fileId": "1tcp3f-avlZnceU4WokXeILRC_DqCzvKt3J_iSAJ2Kq8",
+           "file": {
+            "parents": [
+             "1JghOEpqRTggqMXzjPgkm4JiIfJYKLDKZ"
+            ]
+           }
           },
           {
-           "fileId": "1wgeIvZ9IPkri22NQGV5FceBRi23mxC-Cu__HY37YMl8"
+           "fileId": "1GZG74emPj2NXv2d9jp7f0ls_eBG8idPjdDx6GGVUOhg"
+          },
+          {
+           "fileId": "1dK4huIQGSibt-FNC9SYRVqiWhlt2XgC3T9NjFquMJaI",
+           "file": {
+            "parents": [
+             "1MfqyEPxDPGbQvq2FRvZ9R7D1R6ji3eBU"
+            ]
+           }
           }
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:04:55 GMT
+  recorded_at: Mon, 29 Oct 2018 21:40:04 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1UzsfkIvPgGZzLNQjZstvePzozvRaZMXUOmaf51YOho8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/159dc6yh_VnU6BBINDyiBaz-vwami1Dk7?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1258,7 +1421,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:04:55 GMT
+      - Mon, 29 Oct 2018 21:40:05 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1276,9 +1439,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:04:55 GMT
+      - Mon, 29 Oct 2018 21:40:05 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:04:55 GMT
+      - Mon, 29 Oct 2018 21:40:05 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1302,20 +1465,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1UzsfkIvPgGZzLNQjZstvePzozvRaZMXUOmaf51YOho8.",
+            "message": "File not found: 159dc6yh_VnU6BBINDyiBaz-vwami1Dk7.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1UzsfkIvPgGZzLNQjZstvePzozvRaZMXUOmaf51YOho8."
+          "message": "File not found: 159dc6yh_VnU6BBINDyiBaz-vwami1Dk7."
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:04:55 GMT
+  recorded_at: Mon, 29 Oct 2018 21:40:05 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1nPjlq480aw1IsXPvjBHqHPRDJkKZLegB?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1GZG74emPj2NXv2d9jp7f0ls_eBG8idPjdDx6GGVUOhg?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1327,158 +1490,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:04:55 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:04:55 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:04:55 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1nPjlq480aw1IsXPvjBHqHPRDJkKZLegB",
-         "name": "5 Krikkit One (Archive)",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:04:55 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1nPjlq480aw1IsXPvjBHqHPRDJkKZLegB/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:04:55 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:04:56 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:04:56 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:04:56 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1amCLdagXCIBt5W5bUXN56DsdT9E_dL9_?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:04:56 GMT
+      - Mon, 29 Oct 2018 21:40:05 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1496,9 +1508,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:04:56 GMT
+      - Mon, 29 Oct 2018 21:40:05 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:04:56 GMT
+      - Mon, 29 Oct 2018 21:40:05 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1522,289 +1534,15 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1amCLdagXCIBt5W5bUXN56DsdT9E_dL9_.",
+            "message": "File not found: 1GZG74emPj2NXv2d9jp7f0ls_eBG8idPjdDx6GGVUOhg.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1amCLdagXCIBt5W5bUXN56DsdT9E_dL9_."
+          "message": "File not found: 1GZG74emPj2NXv2d9jp7f0ls_eBG8idPjdDx6GGVUOhg."
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:04:56 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1kpB9WybD7vh6vPtsl7kuPn6whR6QIzW6MqH93__ecQ4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:04:56 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:04:56 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:04:56 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1kpB9WybD7vh6vPtsl7kuPn6whR6QIzW6MqH93__ecQ4",
-         "name": "File",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1nPjlq480aw1IsXPvjBHqHPRDJkKZLegB"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1kpB9WybD7vh6vPtsl7kuPn6whR6QIzW6MqH93__ecQ4&v=1&s=AMedNnoAAAAAW9PHyOC4kM9CqCfMfKP8HXg6WMoqeGgK&sz=s220",
-         "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:04:56 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1kpB9WybD7vh6vPtsl7kuPn6whR6QIzW6MqH93__ecQ4/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:04:56 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:04:56 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:04:56 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "kind": "drive#revision",
-         "id": "1",
-         "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:03:53.725Z"
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:04:57 GMT
-- request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1kpB9WybD7vh6vPtsl7kuPn6whR6QIzW6MqH93__ecQ4&s=AMedNnoAAAAAW9PHyOC4kM9CqCfMfKP8HXg6WMoqeGgK&sz=s350&v=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:04:57 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Expose-Headers:
-      - Content-Length
-      Etag:
-      - '"v1"'
-      Expires:
-      - Fri, 01 Jan 1990 00:00:00 GMT
-      Cache-Control:
-      - private, max-age=86400, no-transform
-      Content-Disposition:
-      - inline;filename="unnamed.png"
-      Content-Type:
-      - image/png
-      Vary:
-      - Origin
-      Access-Control-Allow-Origin:
-      - "*"
-      Timing-Allow-Origin:
-      - "*"
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Sat, 27 Oct 2018 00:04:57 GMT
-      Server:
-      - fife
-      Content-Length:
-      - '1022'
-      X-Xss-Protection:
-      - 1; mode=block
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:04:57 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1wgeIvZ9IPkri22NQGV5FceBRi23mxC-Cu__HY37YMl8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:04:57 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:04:57 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:04:57 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "notFound",
-            "message": "File not found: 1wgeIvZ9IPkri22NQGV5FceBRi23mxC-Cu__HY37YMl8.",
-            "locationType": "parameter",
-            "location": "fileId"
-           }
-          ],
-          "code": 404,
-          "message": "File not found: 1wgeIvZ9IPkri22NQGV5FceBRi23mxC-Cu__HY37YMl8."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:04:57 GMT
+  recorded_at: Mon, 29 Oct 2018 21:40:05 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_moves_file_out_of_project_folder.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_moves_file_out_of_project_folder.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Fri, 26 Oct 2018 23:59:53 GMT
+      - Mon, 29 Oct 2018 21:33:53 GMT
       Server:
       - ESF
       Cache-Control:
@@ -48,12 +48,12 @@ http_interactions:
       string: |-
         {
           "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
-          "expires_in": 3600,
+          "expires_in": 3599,
           "scope": "https://www.googleapis.com/auth/drive",
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:53 GMT
+  recorded_at: Mon, 29 Oct 2018 21:33:53 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Fri, 26 Oct 2018 23:59:53 GMT
+      - Mon, 29 Oct 2018 21:33:54 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:53 GMT
+  recorded_at: Mon, 29 Oct 2018 21:33:54 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-26
-        23:59:53 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-29
+        21:33:54 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:59:53 GMT
+      - Mon, 29 Oct 2018 21:33:54 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 26 Oct 2018 23:59:54 GMT
+      - Mon, 29 Oct 2018 21:33:55 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1BYxN0-vOTTfRVsdIC7uufVxgmP7InNBT",
-         "name": "Test @ 2018-10-26 23:59:53 UTC",
+         "id": "14r3rbuiFoN3OZbNKQ6ssU9SFzxozY-Li",
+         "name": "Test @ 2018-10-29 21:33:54 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:55 GMT
+  recorded_at: Mon, 29 Oct 2018 21:33:56 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1BYxN0-vOTTfRVsdIC7uufVxgmP7InNBT/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/14r3rbuiFoN3OZbNKQ6ssU9SFzxozY-Li/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:59:55 GMT
+      - Mon, 29 Oct 2018 21:33:56 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 26 Oct 2018 23:59:55 GMT
+      - Mon, 29 Oct 2018 21:33:57 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:55 GMT
+  recorded_at: Mon, 29 Oct 2018 21:33:57 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:59:55 GMT
+      - Mon, 29 Oct 2018 21:33:57 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Fri, 26 Oct 2018 23:59:56 GMT
+      - Mon, 29 Oct 2018 21:33:57 GMT
       Date:
-      - Fri, 26 Oct 2018 23:59:56 GMT
+      - Mon, 29 Oct 2018 21:33:57 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,17 +302,17 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "10943"
+         "startPageToken": "13182"
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:56 GMT
+  recorded_at: Mon, 29 Oct 2018 21:33:57 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.document","name":"File To
-        Move","parents":["1BYxN0-vOTTfRVsdIC7uufVxgmP7InNBT"]}'
+        Move","parents":["14r3rbuiFoN3OZbNKQ6ssU9SFzxozY-Li"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -321,7 +321,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:59:56 GMT
+      - Mon, 29 Oct 2018 21:33:57 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -338,7 +338,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 26 Oct 2018 23:59:57 GMT
+      - Mon, 29 Oct 2018 21:33:59 GMT
       Vary:
       - Origin
       - X-Origin
@@ -362,12 +362,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1R7ayZToGOl4CodHTtGcNxsZOM046w3Qbeyi96dV5tKM",
+         "id": "1zXEkvgwRdAi2YOQM1nqJvje6e6Owo45zg100lexcdVI",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1BYxN0-vOTTfRVsdIC7uufVxgmP7InNBT"
+          "14r3rbuiFoN3OZbNKQ6ssU9SFzxozY-Li"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -392,13 +392,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:57 GMT
+  recorded_at: Mon, 29 Oct 2018 21:33:59 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"2 RW6 (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"5 Heart of
+        Gold (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -407,7 +408,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:59:57 GMT
+      - Mon, 29 Oct 2018 21:33:59 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -424,7 +425,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 26 Oct 2018 23:59:57 GMT
+      - Mon, 29 Oct 2018 21:33:59 GMT
       Vary:
       - Origin
       - X-Origin
@@ -448,8 +449,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1t7g6pQ1KPAX8GqLzJNlz8CHe22qvqsuE",
-         "name": "2 RW6 (Archive)",
+         "id": "1hoAqEhwZWgBnLYaq6pL60jNhAQ7CAW6k",
+         "name": "5 Heart of Gold (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -469,10 +470,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:57 GMT
+  recorded_at: Mon, 29 Oct 2018 21:33:59 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1t7g6pQ1KPAX8GqLzJNlz8CHe22qvqsuE/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1hoAqEhwZWgBnLYaq6pL60jNhAQ7CAW6k/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -484,7 +485,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:59:57 GMT
+      - Mon, 29 Oct 2018 21:33:59 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -501,7 +502,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 26 Oct 2018 23:59:58 GMT
+      - Mon, 29 Oct 2018 21:34:00 GMT
       Vary:
       - Origin
       - X-Origin
@@ -531,10 +532,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:58 GMT
+  recorded_at: Mon, 29 Oct 2018 21:34:00 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1t7g6pQ1KPAX8GqLzJNlz8CHe22qvqsuE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/14r3rbuiFoN3OZbNKQ6ssU9SFzxozY-Li?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -546,7 +547,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:59:58 GMT
+      - Mon, 29 Oct 2018 21:34:00 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -557,9 +558,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Fri, 26 Oct 2018 23:59:58 GMT
+      - Mon, 29 Oct 2018 21:34:00 GMT
       Date:
-      - Fri, 26 Oct 2018 23:59:58 GMT
+      - Mon, 29 Oct 2018 21:34:00 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -585,159 +586,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1t7g6pQ1KPAX8GqLzJNlz8CHe22qvqsuE",
-         "name": "2 RW6 (Archive)",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:58 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1t7g6pQ1KPAX8GqLzJNlz8CHe22qvqsuE/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Fri, 26 Oct 2018 23:59:58 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Fri, 26 Oct 2018 23:59:58 GMT
-      Expires:
-      - Fri, 26 Oct 2018 23:59:58 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:58 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1BYxN0-vOTTfRVsdIC7uufVxgmP7InNBT?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Fri, 26 Oct 2018 23:59:58 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Fri, 26 Oct 2018 23:59:59 GMT
-      Date:
-      - Fri, 26 Oct 2018 23:59:59 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1BYxN0-vOTTfRVsdIC7uufVxgmP7InNBT",
-         "name": "Test @ 2018-10-26 23:59:53 UTC",
+         "id": "14r3rbuiFoN3OZbNKQ6ssU9SFzxozY-Li",
+         "name": "Test @ 2018-10-29 21:33:54 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -763,10 +613,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:59 GMT
+  recorded_at: Mon, 29 Oct 2018 21:34:00 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1BYxN0-vOTTfRVsdIC7uufVxgmP7InNBT/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/14r3rbuiFoN3OZbNKQ6ssU9SFzxozY-Li/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -778,7 +628,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:59:59 GMT
+      - Mon, 29 Oct 2018 21:34:00 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -796,9 +646,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Fri, 26 Oct 2018 23:59:59 GMT
+      - Mon, 29 Oct 2018 21:34:00 GMT
       Expires:
-      - Fri, 26 Oct 2018 23:59:59 GMT
+      - Mon, 29 Oct 2018 21:34:00 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -830,10 +680,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:59 GMT
+  recorded_at: Mon, 29 Oct 2018 21:34:00 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271BYxN0-vOTTfRVsdIC7uufVxgmP7InNBT%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files/14r3rbuiFoN3OZbNKQ6ssU9SFzxozY-Li?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -845,7 +695,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:59:59 GMT
+      - Mon, 29 Oct 2018 21:34:00 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -856,9 +706,305 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Fri, 26 Oct 2018 23:59:59 GMT
+      - Mon, 29 Oct 2018 21:34:01 GMT
       Date:
-      - Fri, 26 Oct 2018 23:59:59 GMT
+      - Mon, 29 Oct 2018 21:34:01 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "14r3rbuiFoN3OZbNKQ6ssU9SFzxozY-Li",
+         "name": "Test @ 2018-10-29 21:33:54 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:34:01 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/14r3rbuiFoN3OZbNKQ6ssU9SFzxozY-Li/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:34:01 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 29 Oct 2018 21:34:01 GMT
+      Expires:
+      - Mon, 29 Oct 2018 21:34:01 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:34:01 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/14r3rbuiFoN3OZbNKQ6ssU9SFzxozY-Li?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:34:01 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:34:01 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:34:01 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "14r3rbuiFoN3OZbNKQ6ssU9SFzxozY-Li",
+         "name": "Test @ 2018-10-29 21:33:54 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:34:01 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/14r3rbuiFoN3OZbNKQ6ssU9SFzxozY-Li/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:34:01 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 29 Oct 2018 21:34:01 GMT
+      Expires:
+      - Mon, 29 Oct 2018 21:34:01 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:34:01 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%2714r3rbuiFoN3OZbNKQ6ssU9SFzxozY-Li%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:34:01 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:34:01 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:34:01 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -886,14 +1032,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1R7ayZToGOl4CodHTtGcNxsZOM046w3Qbeyi96dV5tKM",
+           "id": "1zXEkvgwRdAi2YOQM1nqJvje6e6Owo45zg100lexcdVI",
            "name": "File To Move",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1BYxN0-vOTTfRVsdIC7uufVxgmP7InNBT"
+            "14r3rbuiFoN3OZbNKQ6ssU9SFzxozY-Li"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1R7ayZToGOl4CodHTtGcNxsZOM046w3Qbeyi96dV5tKM&v=1&s=AMedNnoAAAAAW9PGnwEJ7xp6cOU9Ev63MjkGpfXGEAUH&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1zXEkvgwRdAi2YOQM1nqJvje6e6Owo45zg100lexcdVI&v=1&s=AMedNnoAAAAAW9eY6TfJUzxmgulRZu693MBuvzqDM9sj&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -919,10 +1065,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:59 GMT
+  recorded_at: Mon, 29 Oct 2018 21:34:01 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1R7ayZToGOl4CodHTtGcNxsZOM046w3Qbeyi96dV5tKM/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1zXEkvgwRdAi2YOQM1nqJvje6e6Owo45zg100lexcdVI/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -934,7 +1080,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:59:59 GMT
+      - Mon, 29 Oct 2018 21:34:01 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -945,9 +1091,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:00:00 GMT
+      - Mon, 29 Oct 2018 21:34:02 GMT
       Date:
-      - Sat, 27 Oct 2018 00:00:00 GMT
+      - Mon, 29 Oct 2018 21:34:02 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -976,13 +1122,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-26T23:59:56.531Z"
+         "modifiedTime": "2018-10-29T21:33:57.741Z"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:00:00 GMT
+  recorded_at: Mon, 29 Oct 2018 21:34:02 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1R7ayZToGOl4CodHTtGcNxsZOM046w3Qbeyi96dV5tKM&s=AMedNnoAAAAAW9PGnwEJ7xp6cOU9Ev63MjkGpfXGEAUH&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1zXEkvgwRdAi2YOQM1nqJvje6e6Owo45zg100lexcdVI&s=AMedNnoAAAAAW9eY6TfJUzxmgulRZu693MBuvzqDM9sj&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -994,7 +1140,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:00:00 GMT
+      - Mon, 29 Oct 2018 21:34:02 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1025,7 +1171,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Sat, 27 Oct 2018 00:00:00 GMT
+      - Mon, 29 Oct 2018 21:34:02 GMT
       Server:
       - fife
       Content-Length:
@@ -1039,13 +1185,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:00:00 GMT
+  recorded_at: Mon, 29 Oct 2018 21:34:02 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1R7ayZToGOl4CodHTtGcNxsZOM046w3Qbeyi96dV5tKM/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1zXEkvgwRdAi2YOQM1nqJvje6e6Owo45zg100lexcdVI/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"File To Move","parents":["1t7g6pQ1KPAX8GqLzJNlz8CHe22qvqsuE"]}'
+      string: '{"name":"File To Move","parents":["1hoAqEhwZWgBnLYaq6pL60jNhAQ7CAW6k"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1054,7 +1200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:00:00 GMT
+      - Mon, 29 Oct 2018 21:34:02 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1071,7 +1217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:00:02 GMT
+      - Mon, 29 Oct 2018 21:34:04 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1095,12 +1241,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "19ZKDJSSjoRbf8AGi6YTNcYgMZoa5R0E3qhzFDav8_W4",
+         "id": "1GhCfZ1e8HJ-bRkXR6ZZZhwYOGx6xfmQWNpcz4TFKj7E",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1t7g6pQ1KPAX8GqLzJNlz8CHe22qvqsuE"
+          "1hoAqEhwZWgBnLYaq6pL60jNhAQ7CAW6k"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1125,7 +1271,7 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:00:02 GMT
+  recorded_at: Mon, 29 Oct 2018 21:34:04 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
@@ -1140,7 +1286,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:00:02 GMT
+      - Mon, 29 Oct 2018 21:34:04 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1157,7 +1303,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:00:02 GMT
+      - Mon, 29 Oct 2018 21:34:04 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1181,7 +1327,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "11ZTzZK6JPEY20g_CK1c2EApahNY5NGlm",
+         "id": "1NT7pospw39lLFZXGCOne5d1x-Px5A7VF",
          "name": "out-of-scope-folder",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
@@ -1202,10 +1348,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:00:02 GMT
+  recorded_at: Mon, 29 Oct 2018 21:34:04 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1R7ayZToGOl4CodHTtGcNxsZOM046w3Qbeyi96dV5tKM?addParents=11ZTzZK6JPEY20g_CK1c2EApahNY5NGlm&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1BYxN0-vOTTfRVsdIC7uufVxgmP7InNBT
+    uri: https://www.googleapis.com/drive/v3/files/1zXEkvgwRdAi2YOQM1nqJvje6e6Owo45zg100lexcdVI?addParents=1NT7pospw39lLFZXGCOne5d1x-Px5A7VF&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=14r3rbuiFoN3OZbNKQ6ssU9SFzxozY-Li
     body:
       encoding: UTF-8
       string: ''
@@ -1217,7 +1363,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:00:02 GMT
+      - Mon, 29 Oct 2018 21:34:04 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1234,7 +1380,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:00:03 GMT
+      - Mon, 29 Oct 2018 21:34:05 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1258,14 +1404,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1R7ayZToGOl4CodHTtGcNxsZOM046w3Qbeyi96dV5tKM",
+         "id": "1zXEkvgwRdAi2YOQM1nqJvje6e6Owo45zg100lexcdVI",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "11ZTzZK6JPEY20g_CK1c2EApahNY5NGlm"
+          "1NT7pospw39lLFZXGCOne5d1x-Px5A7VF"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1R7ayZToGOl4CodHTtGcNxsZOM046w3Qbeyi96dV5tKM&v=1&s=AMedNnoAAAAAW9PGo3PNyFBV6RFYntLlRIwCdcgdRmuY&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1zXEkvgwRdAi2YOQM1nqJvje6e6Owo45zg100lexcdVI&v=1&s=AMedNnoAAAAAW9eY7Yz68jy6QqrUqktV-G-Vs70XuszS&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -1280,10 +1426,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:00:03 GMT
+  recorded_at: Mon, 29 Oct 2018 21:34:05 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=10943
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId,changes/file/parents&pageSize=100&pageToken=13182
     body:
       encoding: UTF-8
       string: ''
@@ -1295,7 +1441,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:01:03 GMT
+      - Mon, 29 Oct 2018 21:35:05 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1306,9 +1452,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:01:03 GMT
+      - Mon, 29 Oct 2018 21:35:06 GMT
       Date:
-      - Sat, 27 Oct 2018 00:01:03 GMT
+      - Mon, 29 Oct 2018 21:35:06 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1334,335 +1480,37 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "10954",
+         "newStartPageToken": "13191",
          "changes": [
           {
-           "fileId": "1qwG6-bI_3BUkAOPmvYgYJtTHi2YT394qNBb6aHDkd08"
-          },
-          {
-           "fileId": "1t7g6pQ1KPAX8GqLzJNlz8CHe22qvqsuE"
-          },
-          {
-           "fileId": "19ZKDJSSjoRbf8AGi6YTNcYgMZoa5R0E3qhzFDav8_W4"
-          },
-          {
-           "fileId": "1BYxN0-vOTTfRVsdIC7uufVxgmP7InNBT"
-          },
-          {
-           "fileId": "1R7ayZToGOl4CodHTtGcNxsZOM046w3Qbeyi96dV5tKM"
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:03 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1qwG6-bI_3BUkAOPmvYgYJtTHi2YT394qNBb6aHDkd08?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:01:03 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:01:03 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:01:03 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "notFound",
-            "message": "File not found: 1qwG6-bI_3BUkAOPmvYgYJtTHi2YT394qNBb6aHDkd08.",
-            "locationType": "parameter",
-            "location": "fileId"
+           "fileId": "1hoAqEhwZWgBnLYaq6pL60jNhAQ7CAW6k",
+           "file": {
+            "parents": [
+             "0AIeK5UAEPQfeUk9PVA"
+            ]
            }
-          ],
-          "code": 404,
-          "message": "File not found: 1qwG6-bI_3BUkAOPmvYgYJtTHi2YT394qNBb6aHDkd08."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:03 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1t7g6pQ1KPAX8GqLzJNlz8CHe22qvqsuE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:01:03 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:01:04 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:01:04 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1t7g6pQ1KPAX8GqLzJNlz8CHe22qvqsuE",
-         "name": "2 RW6 (Archive)",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
           },
           {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:04 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1t7g6pQ1KPAX8GqLzJNlz8CHe22qvqsuE/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:01:04 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:01:04 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:01:04 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
+           "fileId": "1GhCfZ1e8HJ-bRkXR6ZZZhwYOGx6xfmQWNpcz4TFKj7E",
+           "file": {
+            "parents": [
+             "1hoAqEhwZWgBnLYaq6pL60jNhAQ7CAW6k"
+            ]
            }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:04 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/19ZKDJSSjoRbf8AGi6YTNcYgMZoa5R0E3qhzFDav8_W4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:01:04 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:01:04 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:01:04 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "19ZKDJSSjoRbf8AGi6YTNcYgMZoa5R0E3qhzFDav8_W4",
-         "name": "File To Move",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1t7g6pQ1KPAX8GqLzJNlz8CHe22qvqsuE"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=19ZKDJSSjoRbf8AGi6YTNcYgMZoa5R0E3qhzFDav8_W4&v=1&s=AMedNnoAAAAAW9PG4Bz4DH8cGKc72g7-qT2isTimfir_&sz=s220",
-         "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
           },
           {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
+           "fileId": "14r3rbuiFoN3OZbNKQ6ssU9SFzxozY-Li"
+          },
+          {
+           "fileId": "1zXEkvgwRdAi2YOQM1nqJvje6e6Owo45zg100lexcdVI"
           }
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:04 GMT
+  recorded_at: Mon, 29 Oct 2018 21:35:06 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/19ZKDJSSjoRbf8AGi6YTNcYgMZoa5R0E3qhzFDav8_W4/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/14r3rbuiFoN3OZbNKQ6ssU9SFzxozY-Li?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1674,7 +1522,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:01:04 GMT
+      - Mon, 29 Oct 2018 21:35:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1685,9 +1533,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:01:04 GMT
+      - Mon, 29 Oct 2018 21:35:06 GMT
       Date:
-      - Sat, 27 Oct 2018 00:01:04 GMT
+      - Mon, 29 Oct 2018 21:35:06 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1713,128 +1561,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "kind": "drive#revision",
-         "id": "1",
-         "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:00:01.292Z"
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:04 GMT
-- request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=19ZKDJSSjoRbf8AGi6YTNcYgMZoa5R0E3qhzFDav8_W4&s=AMedNnoAAAAAW9PG4Bz4DH8cGKc72g7-qT2isTimfir_&sz=s350&v=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:01:04 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Expose-Headers:
-      - Content-Length
-      Etag:
-      - '"v1"'
-      Expires:
-      - Fri, 01 Jan 1990 00:00:00 GMT
-      Cache-Control:
-      - private, max-age=86400, no-transform
-      Content-Disposition:
-      - inline;filename="unnamed.png"
-      Content-Type:
-      - image/png
-      Vary:
-      - Origin
-      Access-Control-Allow-Origin:
-      - "*"
-      Timing-Allow-Origin:
-      - "*"
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Sat, 27 Oct 2018 00:01:05 GMT
-      Server:
-      - fife
-      Content-Length:
-      - '1022'
-      X-Xss-Protection:
-      - 1; mode=block
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:05 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1BYxN0-vOTTfRVsdIC7uufVxgmP7InNBT?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:01:05 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:01:05 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:01:05 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1BYxN0-vOTTfRVsdIC7uufVxgmP7InNBT",
-         "name": "Test @ 2018-10-26 23:59:53 UTC",
+         "id": "14r3rbuiFoN3OZbNKQ6ssU9SFzxozY-Li",
+         "name": "Test @ 2018-10-29 21:33:54 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -1860,10 +1588,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:05 GMT
+  recorded_at: Mon, 29 Oct 2018 21:35:06 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1BYxN0-vOTTfRVsdIC7uufVxgmP7InNBT/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/14r3rbuiFoN3OZbNKQ6ssU9SFzxozY-Li/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1875,7 +1603,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:01:05 GMT
+      - Mon, 29 Oct 2018 21:35:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1893,9 +1621,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:01:05 GMT
+      - Mon, 29 Oct 2018 21:35:06 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:01:05 GMT
+      - Mon, 29 Oct 2018 21:35:06 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1927,10 +1655,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:05 GMT
+  recorded_at: Mon, 29 Oct 2018 21:35:06 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1R7ayZToGOl4CodHTtGcNxsZOM046w3Qbeyi96dV5tKM?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1zXEkvgwRdAi2YOQM1nqJvje6e6Owo45zg100lexcdVI?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1942,7 +1670,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:01:05 GMT
+      - Mon, 29 Oct 2018 21:35:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1960,9 +1688,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:01:05 GMT
+      - Mon, 29 Oct 2018 21:35:06 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:01:05 GMT
+      - Mon, 29 Oct 2018 21:35:06 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1986,20 +1714,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1R7ayZToGOl4CodHTtGcNxsZOM046w3Qbeyi96dV5tKM.",
+            "message": "File not found: 1zXEkvgwRdAi2YOQM1nqJvje6e6Owo45zg100lexcdVI.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1R7ayZToGOl4CodHTtGcNxsZOM046w3Qbeyi96dV5tKM."
+          "message": "File not found: 1zXEkvgwRdAi2YOQM1nqJvje6e6Owo45zg100lexcdVI."
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:05 GMT
+  recorded_at: Mon, 29 Oct 2018 21:35:06 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/11ZTzZK6JPEY20g_CK1c2EApahNY5NGlm
+    uri: https://www.googleapis.com/drive/v3/files/1NT7pospw39lLFZXGCOne5d1x-Px5A7VF
     body:
       encoding: UTF-8
       string: ''
@@ -2011,7 +1739,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:01:05 GMT
+      - Mon, 29 Oct 2018 21:35:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -2028,7 +1756,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:01:06 GMT
+      - Mon, 29 Oct 2018 21:35:07 GMT
       Vary:
       - Origin
       - X-Origin
@@ -2040,10 +1768,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:06 GMT
+  recorded_at: Mon, 29 Oct 2018 21:35:07 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1BYxN0-vOTTfRVsdIC7uufVxgmP7InNBT
+    uri: https://www.googleapis.com/drive/v3/files/14r3rbuiFoN3OZbNKQ6ssU9SFzxozY-Li
     body:
       encoding: UTF-8
       string: ''
@@ -2055,7 +1783,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:01:06 GMT
+      - Mon, 29 Oct 2018 21:35:07 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -2072,7 +1800,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:01:07 GMT
+      - Mon, 29 Oct 2018 21:35:08 GMT
       Vary:
       - Origin
       - X-Origin
@@ -2084,5 +1812,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:07 GMT
+  recorded_at: Mon, 29 Oct 2018 21:35:08 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_moves_file_to_the_root_of_their_drive.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_moves_file_to_the_root_of_their_drive.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Sat, 27 Oct 2018 00:07:27 GMT
+      - Mon, 29 Oct 2018 21:31:10 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:07:27 GMT
+  recorded_at: Mon, 29 Oct 2018 21:31:10 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Sat, 27 Oct 2018 00:07:27 GMT
+      - Mon, 29 Oct 2018 21:31:10 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:07:27 GMT
+  recorded_at: Mon, 29 Oct 2018 21:31:10 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-27
-        00:07:27 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-29
+        21:31:10 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:07:27 GMT
+      - Mon, 29 Oct 2018 21:31:10 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:07:28 GMT
+      - Mon, 29 Oct 2018 21:31:11 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1KGnJQ57d1bjciqM6dWiuXuaxVGqIbcvK",
-         "name": "Test @ 2018-10-27 00:07:27 UTC",
+         "id": "1iiN090w5xoia3ssOE7ejt99X_iWq1y4x",
+         "name": "Test @ 2018-10-29 21:31:10 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:07:28 GMT
+  recorded_at: Mon, 29 Oct 2018 21:31:11 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1KGnJQ57d1bjciqM6dWiuXuaxVGqIbcvK/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1iiN090w5xoia3ssOE7ejt99X_iWq1y4x/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:07:28 GMT
+      - Mon, 29 Oct 2018 21:31:11 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:07:29 GMT
+      - Mon, 29 Oct 2018 21:31:12 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:07:29 GMT
+  recorded_at: Mon, 29 Oct 2018 21:31:12 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:07:29 GMT
+      - Mon, 29 Oct 2018 21:31:12 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:07:29 GMT
+      - Mon, 29 Oct 2018 21:31:13 GMT
       Date:
-      - Sat, 27 Oct 2018 00:07:29 GMT
+      - Mon, 29 Oct 2018 21:31:13 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,17 +302,17 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "11032"
+         "startPageToken": "13147"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:07:29 GMT
+  recorded_at: Mon, 29 Oct 2018 21:31:13 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.document","name":"File To
-        Move","parents":["1KGnJQ57d1bjciqM6dWiuXuaxVGqIbcvK"]}'
+        Move","parents":["1iiN090w5xoia3ssOE7ejt99X_iWq1y4x"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -321,7 +321,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:07:29 GMT
+      - Mon, 29 Oct 2018 21:31:14 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -338,7 +338,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:07:30 GMT
+      - Mon, 29 Oct 2018 21:31:16 GMT
       Vary:
       - Origin
       - X-Origin
@@ -362,12 +362,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1MnJXVNtX5xIR4KbmlrY8H06BCahHN_zNE2gw7zoO124",
+         "id": "1Qh0jYyS0Pk-Lz9hh7HcvvdqLUiRWB96wmWM422KbHY4",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1KGnJQ57d1bjciqM6dWiuXuaxVGqIbcvK"
+          "1iiN090w5xoia3ssOE7ejt99X_iWq1y4x"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -392,14 +392,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:07:30 GMT
+  recorded_at: Mon, 29 Oct 2018 21:31:16 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"8 Golgafrinchan
-        Ark Fleet Ship B (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"1 Starship
+        Titanic (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -408,7 +408,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:07:30 GMT
+      - Mon, 29 Oct 2018 21:31:16 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -425,7 +425,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:07:31 GMT
+      - Mon, 29 Oct 2018 21:31:17 GMT
       Vary:
       - Origin
       - X-Origin
@@ -449,8 +449,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1zcwe9rEoEIi8bxpEsHYGi4fiT7NkrPnD",
-         "name": "8 Golgafrinchan Ark Fleet Ship B (Archive)",
+         "id": "1YO1aHjn8HAb4Jjaw1GQTXF-IN9kq9HEr",
+         "name": "1 Starship Titanic (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -470,10 +470,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:07:31 GMT
+  recorded_at: Mon, 29 Oct 2018 21:31:17 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1zcwe9rEoEIi8bxpEsHYGi4fiT7NkrPnD/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1YO1aHjn8HAb4Jjaw1GQTXF-IN9kq9HEr/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -485,7 +485,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:07:31 GMT
+      - Mon, 29 Oct 2018 21:31:17 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -502,7 +502,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:07:32 GMT
+      - Mon, 29 Oct 2018 21:31:18 GMT
       Vary:
       - Origin
       - X-Origin
@@ -532,10 +532,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:07:32 GMT
+  recorded_at: Mon, 29 Oct 2018 21:31:18 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1zcwe9rEoEIi8bxpEsHYGi4fiT7NkrPnD?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1iiN090w5xoia3ssOE7ejt99X_iWq1y4x?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -547,7 +547,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:07:32 GMT
+      - Mon, 29 Oct 2018 21:31:18 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -558,9 +558,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:07:32 GMT
+      - Mon, 29 Oct 2018 21:31:18 GMT
       Date:
-      - Sat, 27 Oct 2018 00:07:32 GMT
+      - Mon, 29 Oct 2018 21:31:18 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -586,159 +586,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1zcwe9rEoEIi8bxpEsHYGi4fiT7NkrPnD",
-         "name": "8 Golgafrinchan Ark Fleet Ship B (Archive)",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:07:32 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1zcwe9rEoEIi8bxpEsHYGi4fiT7NkrPnD/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:07:32 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:07:32 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:07:32 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:07:32 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1KGnJQ57d1bjciqM6dWiuXuaxVGqIbcvK?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:07:32 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:07:32 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:07:32 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1KGnJQ57d1bjciqM6dWiuXuaxVGqIbcvK",
-         "name": "Test @ 2018-10-27 00:07:27 UTC",
+         "id": "1iiN090w5xoia3ssOE7ejt99X_iWq1y4x",
+         "name": "Test @ 2018-10-29 21:31:10 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -764,10 +613,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:07:32 GMT
+  recorded_at: Mon, 29 Oct 2018 21:31:18 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1KGnJQ57d1bjciqM6dWiuXuaxVGqIbcvK/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1iiN090w5xoia3ssOE7ejt99X_iWq1y4x/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -779,7 +628,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:07:32 GMT
+      - Mon, 29 Oct 2018 21:31:19 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -797,9 +646,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:07:32 GMT
+      - Mon, 29 Oct 2018 21:31:19 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:07:32 GMT
+      - Mon, 29 Oct 2018 21:31:19 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -831,10 +680,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:07:33 GMT
+  recorded_at: Mon, 29 Oct 2018 21:31:19 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271KGnJQ57d1bjciqM6dWiuXuaxVGqIbcvK%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files/1iiN090w5xoia3ssOE7ejt99X_iWq1y4x?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -846,7 +695,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:07:33 GMT
+      - Mon, 29 Oct 2018 21:31:19 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -857,9 +706,305 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:07:33 GMT
+      - Mon, 29 Oct 2018 21:31:19 GMT
       Date:
-      - Sat, 27 Oct 2018 00:07:33 GMT
+      - Mon, 29 Oct 2018 21:31:19 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1iiN090w5xoia3ssOE7ejt99X_iWq1y4x",
+         "name": "Test @ 2018-10-29 21:31:10 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:31:19 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1iiN090w5xoia3ssOE7ejt99X_iWq1y4x/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:31:19 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 29 Oct 2018 21:31:19 GMT
+      Expires:
+      - Mon, 29 Oct 2018 21:31:19 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:31:19 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1iiN090w5xoia3ssOE7ejt99X_iWq1y4x?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:31:19 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:31:20 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:31:20 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1iiN090w5xoia3ssOE7ejt99X_iWq1y4x",
+         "name": "Test @ 2018-10-29 21:31:10 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:31:20 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1iiN090w5xoia3ssOE7ejt99X_iWq1y4x/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:31:20 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 29 Oct 2018 21:31:20 GMT
+      Expires:
+      - Mon, 29 Oct 2018 21:31:20 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:31:20 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271iiN090w5xoia3ssOE7ejt99X_iWq1y4x%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:31:20 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:31:20 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:31:20 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -887,14 +1032,15 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1MnJXVNtX5xIR4KbmlrY8H06BCahHN_zNE2gw7zoO124",
+           "id": "1Qh0jYyS0Pk-Lz9hh7HcvvdqLUiRWB96wmWM422KbHY4",
            "name": "File To Move",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1KGnJQ57d1bjciqM6dWiuXuaxVGqIbcvK"
+            "1iiN090w5xoia3ssOE7ejt99X_iWq1y4x"
            ],
-           "thumbnailVersion": "0",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Qh0jYyS0Pk-Lz9hh7HcvvdqLUiRWB96wmWM422KbHY4&v=1&s=AMedNnoAAAAAW9eYSD65lJ4sKv2ADy7n8Nvlqt8HTnZ0&sz=s220",
+           "thumbnailVersion": "1",
            "permissions": [
             {
              "kind": "drive#permission",
@@ -919,10 +1065,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:07:33 GMT
+  recorded_at: Mon, 29 Oct 2018 21:31:20 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1MnJXVNtX5xIR4KbmlrY8H06BCahHN_zNE2gw7zoO124/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1Qh0jYyS0Pk-Lz9hh7HcvvdqLUiRWB96wmWM422KbHY4/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -934,7 +1080,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:07:33 GMT
+      - Mon, 29 Oct 2018 21:31:20 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -945,9 +1091,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:07:33 GMT
+      - Mon, 29 Oct 2018 21:31:21 GMT
       Date:
-      - Sat, 27 Oct 2018 00:07:33 GMT
+      - Mon, 29 Oct 2018 21:31:21 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -976,16 +1122,16 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:07:29.956Z"
+         "modifiedTime": "2018-10-29T21:31:15.215Z"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:07:33 GMT
+  recorded_at: Mon, 29 Oct 2018 21:31:21 GMT
 - request:
-    method: post
-    uri: https://www.googleapis.com/drive/v3/files/1MnJXVNtX5xIR4KbmlrY8H06BCahHN_zNE2gw7zoO124/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1Qh0jYyS0Pk-Lz9hh7HcvvdqLUiRWB96wmWM422KbHY4&s=AMedNnoAAAAAW9eYSD65lJ4sKv2ADy7n8Nvlqt8HTnZ0&sz=s350&v=1
     body:
       encoding: UTF-8
-      string: '{"name":"File To Move","parents":["1zcwe9rEoEIi8bxpEsHYGi4fiT7NkrPnD"]}'
+      string: ''
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -994,7 +1140,67 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:07:33 GMT
+      - Mon, 29 Oct 2018 21:31:21 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 29 Oct 2018 21:31:21 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:31:21 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1Qh0jYyS0Pk-Lz9hh7HcvvdqLUiRWB96wmWM422KbHY4/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"File To Move","parents":["1YO1aHjn8HAb4Jjaw1GQTXF-IN9kq9HEr"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:31:21 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1011,7 +1217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:07:35 GMT
+      - Mon, 29 Oct 2018 21:31:23 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1035,12 +1241,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1rSPZTBV5_4fWPs4lbm5lwLM2XaZc8sh6_FtX5oR6q_U",
+         "id": "1Bv_toU4nbkcEM6Z91wIxxOqLEqokXz7fePpzuposmU0",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1zcwe9rEoEIi8bxpEsHYGi4fiT7NkrPnD"
+          "1YO1aHjn8HAb4Jjaw1GQTXF-IN9kq9HEr"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1065,10 +1271,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:07:35 GMT
+  recorded_at: Mon, 29 Oct 2018 21:31:23 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1MnJXVNtX5xIR4KbmlrY8H06BCahHN_zNE2gw7zoO124?addParents=root&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1KGnJQ57d1bjciqM6dWiuXuaxVGqIbcvK
+    uri: https://www.googleapis.com/drive/v3/files/1Qh0jYyS0Pk-Lz9hh7HcvvdqLUiRWB96wmWM422KbHY4?addParents=root&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1iiN090w5xoia3ssOE7ejt99X_iWq1y4x
     body:
       encoding: UTF-8
       string: ''
@@ -1080,7 +1286,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:07:35 GMT
+      - Mon, 29 Oct 2018 21:31:23 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1097,7 +1303,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:07:36 GMT
+      - Mon, 29 Oct 2018 21:31:24 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1121,14 +1327,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1MnJXVNtX5xIR4KbmlrY8H06BCahHN_zNE2gw7zoO124",
+         "id": "1Qh0jYyS0Pk-Lz9hh7HcvvdqLUiRWB96wmWM422KbHY4",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
           "0AEIi2L68pCuiUk9PVA"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1MnJXVNtX5xIR4KbmlrY8H06BCahHN_zNE2gw7zoO124&v=1&s=AMedNnoAAAAAW9PIaL3qsCq2PtopX2GV87KuukNaJKU1&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Qh0jYyS0Pk-Lz9hh7HcvvdqLUiRWB96wmWM422KbHY4&v=1&s=AMedNnoAAAAAW9eYTB7su1JoUyzKXP-Hql2OFc38C0L7&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -1143,10 +1349,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:07:36 GMT
+  recorded_at: Mon, 29 Oct 2018 21:31:24 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=11032
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId,changes/file/parents&pageSize=100&pageToken=13147
     body:
       encoding: UTF-8
       string: ''
@@ -1158,7 +1364,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:08:36 GMT
+      - Mon, 29 Oct 2018 21:32:24 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1169,9 +1375,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:08:36 GMT
+      - Mon, 29 Oct 2018 21:32:24 GMT
       Date:
-      - Sat, 27 Oct 2018 00:08:36 GMT
+      - Mon, 29 Oct 2018 21:32:24 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1197,341 +1403,61 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "11044",
+         "newStartPageToken": "13160",
          "changes": [
           {
-           "fileId": "1zcwe9rEoEIi8bxpEsHYGi4fiT7NkrPnD"
-          },
-          {
-           "fileId": "1iYi3yTGB2iCGNGl6G95zjTSBpDM5F-Eg8vs54_apkN8"
-          },
-          {
-           "fileId": "1rSPZTBV5_4fWPs4lbm5lwLM2XaZc8sh6_FtX5oR6q_U"
-          },
-          {
-           "fileId": "1hqihjTC6H38OdLpeslzL-T82msHY0XJ2jmxaxzYq1VE"
-          },
-          {
-           "fileId": "1SSBLOdlVZOghHsng5aVY7RVBZlHuID9PFcxD8yXCaz0"
-          },
-          {
-           "fileId": "1KGnJQ57d1bjciqM6dWiuXuaxVGqIbcvK"
-          },
-          {
-           "fileId": "1MnJXVNtX5xIR4KbmlrY8H06BCahHN_zNE2gw7zoO124"
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:36 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1zcwe9rEoEIi8bxpEsHYGi4fiT7NkrPnD?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:08:36 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:08:36 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:08:36 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1zcwe9rEoEIi8bxpEsHYGi4fiT7NkrPnD",
-         "name": "8 Golgafrinchan Ark Fleet Ship B (Archive)",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:36 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1zcwe9rEoEIi8bxpEsHYGi4fiT7NkrPnD/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:08:36 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:08:36 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:08:36 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
+           "fileId": "1YO1aHjn8HAb4Jjaw1GQTXF-IN9kq9HEr",
+           "file": {
+            "parents": [
+             "0AIeK5UAEPQfeUk9PVA"
+            ]
            }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:37 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1iYi3yTGB2iCGNGl6G95zjTSBpDM5F-Eg8vs54_apkN8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:08:37 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:08:37 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:08:37 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "notFound",
-            "message": "File not found: 1iYi3yTGB2iCGNGl6G95zjTSBpDM5F-Eg8vs54_apkN8.",
-            "locationType": "parameter",
-            "location": "fileId"
+          },
+          {
+           "fileId": "1Bv_toU4nbkcEM6Z91wIxxOqLEqokXz7fePpzuposmU0",
+           "file": {
+            "parents": [
+             "1YO1aHjn8HAb4Jjaw1GQTXF-IN9kq9HEr"
+            ]
            }
-          ],
-          "code": 404,
-          "message": "File not found: 1iYi3yTGB2iCGNGl6G95zjTSBpDM5F-Eg8vs54_apkN8."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:37 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1rSPZTBV5_4fWPs4lbm5lwLM2XaZc8sh6_FtX5oR6q_U?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:08:37 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:08:37 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:08:37 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1rSPZTBV5_4fWPs4lbm5lwLM2XaZc8sh6_FtX5oR6q_U",
-         "name": "File To Move",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1zcwe9rEoEIi8bxpEsHYGi4fiT7NkrPnD"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1rSPZTBV5_4fWPs4lbm5lwLM2XaZc8sh6_FtX5oR6q_U&v=1&s=AMedNnoAAAAAW9PIpZWBPj17iDCPDeTY5Zr1gU-b2i0o&sz=s220",
-         "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
           },
           {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
+           "fileId": "1Tk66KdMSu1VNAAxm3v_dgq53linEsys18_0INMZG5nw",
+           "file": {
+            "parents": [
+             "1uCIUWQaSiHTRMBEGB80-3OsZnvat6duo"
+            ]
+           }
+          },
+          {
+           "fileId": "1jSEsMIW1HfproK-WBU9LyPAg_gszu9Zqhsjrb7ZKIOc",
+           "file": {
+            "parents": [
+             "1uCIUWQaSiHTRMBEGB80-3OsZnvat6duo"
+            ]
+           }
+          },
+          {
+           "fileId": "1iiN090w5xoia3ssOE7ejt99X_iWq1y4x"
+          },
+          {
+           "fileId": "1lylL80Z2lMo56Qng5UoOpcN18M6P2DLfH1v5umbnac4",
+           "file": {
+            "parents": [
+             "1zihOYT8qtc-1vsHXKGs4ikC8Jd2CBZ8l"
+            ]
+           }
+          },
+          {
+           "fileId": "1Qh0jYyS0Pk-Lz9hh7HcvvdqLUiRWB96wmWM422KbHY4"
           }
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:37 GMT
+  recorded_at: Mon, 29 Oct 2018 21:32:25 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1rSPZTBV5_4fWPs4lbm5lwLM2XaZc8sh6_FtX5oR6q_U/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1iiN090w5xoia3ssOE7ejt99X_iWq1y4x?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1543,7 +1469,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:08:37 GMT
+      - Mon, 29 Oct 2018 21:32:25 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1554,9 +1480,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:08:37 GMT
+      - Mon, 29 Oct 2018 21:32:25 GMT
       Date:
-      - Sat, 27 Oct 2018 00:08:37 GMT
+      - Mon, 29 Oct 2018 21:32:25 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1582,538 +1508,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "kind": "drive#revision",
-         "id": "1",
-         "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:07:34.466Z"
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:37 GMT
-- request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1rSPZTBV5_4fWPs4lbm5lwLM2XaZc8sh6_FtX5oR6q_U&s=AMedNnoAAAAAW9PIpZWBPj17iDCPDeTY5Zr1gU-b2i0o&sz=s350&v=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:08:37 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Expose-Headers:
-      - Content-Length
-      Etag:
-      - '"v1"'
-      Expires:
-      - Fri, 01 Jan 1990 00:00:00 GMT
-      Cache-Control:
-      - private, max-age=86400, no-transform
-      Content-Disposition:
-      - inline;filename="unnamed.png"
-      Content-Type:
-      - image/png
-      Vary:
-      - Origin
-      Access-Control-Allow-Origin:
-      - "*"
-      Timing-Allow-Origin:
-      - "*"
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Sat, 27 Oct 2018 00:08:38 GMT
-      Server:
-      - fife
-      Content-Length:
-      - '1022'
-      X-Xss-Protection:
-      - 1; mode=block
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:38 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1hqihjTC6H38OdLpeslzL-T82msHY0XJ2jmxaxzYq1VE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:08:38 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:08:38 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:08:38 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1hqihjTC6H38OdLpeslzL-T82msHY0XJ2jmxaxzYq1VE",
-         "name": "File",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1h_RSdb_1zKB3cxLwAtprK2OYHfUNszbD"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1hqihjTC6H38OdLpeslzL-T82msHY0XJ2jmxaxzYq1VE&v=1&s=AMedNnoAAAAAW9PIpoJrzUHhnwJN-cJjZDs_OtKxoXAv&sz=s220",
-         "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:38 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1hqihjTC6H38OdLpeslzL-T82msHY0XJ2jmxaxzYq1VE/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:08:38 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:08:38 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:08:38 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "kind": "drive#revision",
-         "id": "1",
-         "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:03:42.959Z"
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:39 GMT
-- request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1hqihjTC6H38OdLpeslzL-T82msHY0XJ2jmxaxzYq1VE&s=AMedNnoAAAAAW9PIpoJrzUHhnwJN-cJjZDs_OtKxoXAv&sz=s350&v=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:08:39 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Expose-Headers:
-      - Content-Length
-      Etag:
-      - '"v1"'
-      Expires:
-      - Fri, 01 Jan 1990 00:00:00 GMT
-      Cache-Control:
-      - private, max-age=86400, no-transform
-      Content-Disposition:
-      - inline;filename="unnamed.png"
-      Content-Type:
-      - image/png
-      Vary:
-      - Origin
-      Access-Control-Allow-Origin:
-      - "*"
-      Timing-Allow-Origin:
-      - "*"
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Sat, 27 Oct 2018 00:08:39 GMT
-      Server:
-      - fife
-      Content-Length:
-      - '1533'
-      X-Xss-Protection:
-      - 1; mode=block
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAAFtUlEQVR4nO3du2pV3RqA4RnxEJSARwhRwRixEAmoSNTOi7H3LrwGewVrLb0CjYUQRRQSImKjuEBhZZnDIrv4Ybf7baL8m+fpRjEm4yteBoxmzuzv7w9AcOhvHwD+NdQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBaq/X8toNNrd3d3b2/vbB4H/4cBrmUwmP378GIZhPB5PJpPfv3/v7+9Pp9PJZDIMw/Pnz1++fLm6uvrq1avt7e3xePzfXb9+/RqG4du3b/8sR6PRZDJ59uzZMAz/fPDXr19bW1vv37//8OHDQU8BwzDMHPS/wR49erS0tLS8vPzixYujR48eP3782rVrP3/+/Pr164MHDx4/fnzx4sWtra2TJ0++fft2Z2fn4cOHhw8ffvr06cLCwmg0On/+/Hg8fvPmzZUrV5aWll6/fj0zM3PixIn5+fm1tbVhGFZWVo4cOXL37t0DnQKGP3C3LC4u3r9/f2Nj49ChQ2fPnl1eXn7y5Mm7d+9u3rw5DMO5c+fm5uZ2dnZGo9F0Op2fn9/b2xuPx/Pz8zdu3Njc3Lx3797nz58vXbp079696XR6+vTptbW1Cxcu/P79e2VlZXFx8dixY2fOnDnoKWD4A3fLp0+fzp8/P5lM1tfXp9PpysrKx48fh2G4fPny7Ozs+vr67OzseDyem5v78uXLdDq9c+fOzMzM6urq7u7u1atXV1dXb9++/f3794WFhclksrGxMT8/v7m5ef369e3t7e3t7VOnTm1ubt66detAp4DhD9QC/zf+/psY/FuoBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoFKLVCpBSq1QKUWqNQClVqgUgtUaoHqP+q3665OEUZRAAAAAElFTkSuQmCC
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:39 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1SSBLOdlVZOghHsng5aVY7RVBZlHuID9PFcxD8yXCaz0?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:08:39 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:08:39 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:08:39 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1SSBLOdlVZOghHsng5aVY7RVBZlHuID9PFcxD8yXCaz0",
-         "name": "To Delete",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1uFSHaA2LB488XOPIiLk1Qlm9owYQ-Ua8"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1SSBLOdlVZOghHsng5aVY7RVBZlHuID9PFcxD8yXCaz0&v=1&s=AMedNnoAAAAAW9PIp0G6f79YVCIU5dKro0vTh0dE2AMb&sz=s220",
-         "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:39 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1SSBLOdlVZOghHsng5aVY7RVBZlHuID9PFcxD8yXCaz0/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:08:39 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:08:39 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:08:39 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "kind": "drive#revision",
-         "id": "1",
-         "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:05:07.264Z"
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:40 GMT
-- request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1SSBLOdlVZOghHsng5aVY7RVBZlHuID9PFcxD8yXCaz0&s=AMedNnoAAAAAW9PIp0G6f79YVCIU5dKro0vTh0dE2AMb&sz=s350&v=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:08:40 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Expose-Headers:
-      - Content-Length
-      Etag:
-      - '"v1"'
-      Expires:
-      - Fri, 01 Jan 1990 00:00:00 GMT
-      Cache-Control:
-      - private, max-age=86400, no-transform
-      Content-Disposition:
-      - inline;filename="unnamed.png"
-      Content-Type:
-      - image/png
-      Vary:
-      - Origin
-      Access-Control-Allow-Origin:
-      - "*"
-      Timing-Allow-Origin:
-      - "*"
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Sat, 27 Oct 2018 00:08:40 GMT
-      Server:
-      - fife
-      Content-Length:
-      - '1022'
-      X-Xss-Protection:
-      - 1; mode=block
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:40 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1KGnJQ57d1bjciqM6dWiuXuaxVGqIbcvK?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:08:40 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:08:40 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:08:40 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1KGnJQ57d1bjciqM6dWiuXuaxVGqIbcvK",
-         "name": "Test @ 2018-10-27 00:07:27 UTC",
+         "id": "1iiN090w5xoia3ssOE7ejt99X_iWq1y4x",
+         "name": "Test @ 2018-10-29 21:31:10 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -2139,10 +1535,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:40 GMT
+  recorded_at: Mon, 29 Oct 2018 21:32:25 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1KGnJQ57d1bjciqM6dWiuXuaxVGqIbcvK/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1iiN090w5xoia3ssOE7ejt99X_iWq1y4x/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -2154,7 +1550,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:08:40 GMT
+      - Mon, 29 Oct 2018 21:32:25 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2172,9 +1568,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:08:40 GMT
+      - Mon, 29 Oct 2018 21:32:25 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:08:40 GMT
+      - Mon, 29 Oct 2018 21:32:25 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -2206,10 +1602,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:40 GMT
+  recorded_at: Mon, 29 Oct 2018 21:32:25 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1MnJXVNtX5xIR4KbmlrY8H06BCahHN_zNE2gw7zoO124?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1Qh0jYyS0Pk-Lz9hh7HcvvdqLUiRWB96wmWM422KbHY4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -2221,7 +1617,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:08:40 GMT
+      - Mon, 29 Oct 2018 21:32:25 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2239,9 +1635,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:08:40 GMT
+      - Mon, 29 Oct 2018 21:32:25 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:08:40 GMT
+      - Mon, 29 Oct 2018 21:32:25 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -2265,20 +1661,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1MnJXVNtX5xIR4KbmlrY8H06BCahHN_zNE2gw7zoO124.",
+            "message": "File not found: 1Qh0jYyS0Pk-Lz9hh7HcvvdqLUiRWB96wmWM422KbHY4.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1MnJXVNtX5xIR4KbmlrY8H06BCahHN_zNE2gw7zoO124."
+          "message": "File not found: 1Qh0jYyS0Pk-Lz9hh7HcvvdqLUiRWB96wmWM422KbHY4."
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:40 GMT
+  recorded_at: Mon, 29 Oct 2018 21:32:25 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1MnJXVNtX5xIR4KbmlrY8H06BCahHN_zNE2gw7zoO124
+    uri: https://www.googleapis.com/drive/v3/files/1Qh0jYyS0Pk-Lz9hh7HcvvdqLUiRWB96wmWM422KbHY4
     body:
       encoding: UTF-8
       string: ''
@@ -2290,7 +1686,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:08:40 GMT
+      - Mon, 29 Oct 2018 21:32:25 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -2307,7 +1703,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:08:41 GMT
+      - Mon, 29 Oct 2018 21:32:26 GMT
       Vary:
       - Origin
       - X-Origin
@@ -2319,10 +1715,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:41 GMT
+  recorded_at: Mon, 29 Oct 2018 21:32:26 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1KGnJQ57d1bjciqM6dWiuXuaxVGqIbcvK
+    uri: https://www.googleapis.com/drive/v3/files/1iiN090w5xoia3ssOE7ejt99X_iWq1y4x
     body:
       encoding: UTF-8
       string: ''
@@ -2334,7 +1730,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:08:41 GMT
+      - Mon, 29 Oct 2018 21:32:26 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -2351,7 +1747,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:08:42 GMT
+      - Mon, 29 Oct 2018 21:32:27 GMT
       Vary:
       - Origin
       - X-Origin
@@ -2363,5 +1759,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:08:42 GMT
+  recorded_at: Mon, 29 Oct 2018 21:32:27 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_moves_file_within_project_folder.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_moves_file_within_project_folder.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Sat, 27 Oct 2018 00:01:07 GMT
+      - Mon, 29 Oct 2018 21:32:27 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:07 GMT
+  recorded_at: Mon, 29 Oct 2018 21:32:27 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Sat, 27 Oct 2018 00:01:07 GMT
+      - Mon, 29 Oct 2018 21:32:27 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:07 GMT
+  recorded_at: Mon, 29 Oct 2018 21:32:27 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-27
-        00:01:07 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-29
+        21:32:27 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:01:07 GMT
+      - Mon, 29 Oct 2018 21:32:27 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:01:08 GMT
+      - Mon, 29 Oct 2018 21:32:28 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1yfeWWpZ0pS317X2xcCj6d8cvTFjZS2uo",
-         "name": "Test @ 2018-10-27 00:01:07 UTC",
+         "id": "13_BlO8dgMhpF2numBmBYO9STimKkECKN",
+         "name": "Test @ 2018-10-29 21:32:27 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:08 GMT
+  recorded_at: Mon, 29 Oct 2018 21:32:28 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1yfeWWpZ0pS317X2xcCj6d8cvTFjZS2uo/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/13_BlO8dgMhpF2numBmBYO9STimKkECKN/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:01:08 GMT
+      - Mon, 29 Oct 2018 21:32:28 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:01:09 GMT
+      - Mon, 29 Oct 2018 21:32:29 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:09 GMT
+  recorded_at: Mon, 29 Oct 2018 21:32:29 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:01:09 GMT
+      - Mon, 29 Oct 2018 21:32:29 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:01:09 GMT
+      - Mon, 29 Oct 2018 21:32:29 GMT
       Date:
-      - Sat, 27 Oct 2018 00:01:09 GMT
+      - Mon, 29 Oct 2018 21:32:29 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,16 +302,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "10954"
+         "startPageToken": "13161"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:09 GMT
+  recorded_at: Mon, 29 Oct 2018 21:32:29 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1yfeWWpZ0pS317X2xcCj6d8cvTFjZS2uo"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["13_BlO8dgMhpF2numBmBYO9STimKkECKN"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -320,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:01:09 GMT
+      - Mon, 29 Oct 2018 21:32:29 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -337,7 +337,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:01:10 GMT
+      - Mon, 29 Oct 2018 21:32:30 GMT
       Vary:
       - Origin
       - X-Origin
@@ -361,12 +361,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1ri-G3xeC4Psp6wgFwKXre6jGR8nmnxUS",
+         "id": "1tUobwdQToAs3MWmjBEugyJhXnPNBAfUG",
          "name": "Folder",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1yfeWWpZ0pS317X2xcCj6d8cvTFjZS2uo"
+          "13_BlO8dgMhpF2numBmBYO9STimKkECKN"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -391,14 +391,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:10 GMT
+  recorded_at: Mon, 29 Oct 2018 21:32:30 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.document","name":"File To
-        Move","parents":["1ri-G3xeC4Psp6wgFwKXre6jGR8nmnxUS"]}'
+        Move","parents":["1tUobwdQToAs3MWmjBEugyJhXnPNBAfUG"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -407,7 +407,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:01:10 GMT
+      - Mon, 29 Oct 2018 21:32:30 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -424,7 +424,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:01:12 GMT
+      - Mon, 29 Oct 2018 21:32:31 GMT
       Vary:
       - Origin
       - X-Origin
@@ -448,12 +448,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1uNuG3SHIhi7AaSGSMiWOVwlzup4xiy_rjq1ko6UrjJs",
+         "id": "1-gC9Dy1bGaj_HgD6MOFmTkdOVS_H-maK5hpR3EKwz20",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1ri-G3xeC4Psp6wgFwKXre6jGR8nmnxUS"
+          "1tUobwdQToAs3MWmjBEugyJhXnPNBAfUG"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -478,14 +478,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:12 GMT
+  recorded_at: Mon, 29 Oct 2018 21:32:32 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"3 Starship
-        Titanic (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"2 Krikkit
+        One (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -494,7 +494,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:01:12 GMT
+      - Mon, 29 Oct 2018 21:32:32 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -511,7 +511,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:01:12 GMT
+      - Mon, 29 Oct 2018 21:32:32 GMT
       Vary:
       - Origin
       - X-Origin
@@ -535,8 +535,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1ep-1-2ODj4AYqIx6Y6bLBTGSvH78JsEE",
-         "name": "3 Starship Titanic (Archive)",
+         "id": "1Flv74-BFXz-kz1KdrHLtw06oQf8CqHzA",
+         "name": "2 Krikkit One (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -556,10 +556,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:12 GMT
+  recorded_at: Mon, 29 Oct 2018 21:32:32 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1ep-1-2ODj4AYqIx6Y6bLBTGSvH78JsEE/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1Flv74-BFXz-kz1KdrHLtw06oQf8CqHzA/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -571,7 +571,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:01:12 GMT
+      - Mon, 29 Oct 2018 21:32:32 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -588,7 +588,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:01:13 GMT
+      - Mon, 29 Oct 2018 21:32:33 GMT
       Vary:
       - Origin
       - X-Origin
@@ -618,10 +618,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:13 GMT
+  recorded_at: Mon, 29 Oct 2018 21:32:33 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1ep-1-2ODj4AYqIx6Y6bLBTGSvH78JsEE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/13_BlO8dgMhpF2numBmBYO9STimKkECKN?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -633,7 +633,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:01:13 GMT
+      - Mon, 29 Oct 2018 21:32:33 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -644,9 +644,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:01:13 GMT
+      - Mon, 29 Oct 2018 21:32:33 GMT
       Date:
-      - Sat, 27 Oct 2018 00:01:13 GMT
+      - Mon, 29 Oct 2018 21:32:33 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -672,159 +672,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1ep-1-2ODj4AYqIx6Y6bLBTGSvH78JsEE",
-         "name": "3 Starship Titanic (Archive)",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:13 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1ep-1-2ODj4AYqIx6Y6bLBTGSvH78JsEE/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:01:13 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:01:13 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:01:13 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:13 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1yfeWWpZ0pS317X2xcCj6d8cvTFjZS2uo?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:01:13 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:01:14 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:01:14 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1yfeWWpZ0pS317X2xcCj6d8cvTFjZS2uo",
-         "name": "Test @ 2018-10-27 00:01:07 UTC",
+         "id": "13_BlO8dgMhpF2numBmBYO9STimKkECKN",
+         "name": "Test @ 2018-10-29 21:32:27 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -850,10 +699,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:14 GMT
+  recorded_at: Mon, 29 Oct 2018 21:32:33 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1yfeWWpZ0pS317X2xcCj6d8cvTFjZS2uo/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/13_BlO8dgMhpF2numBmBYO9STimKkECKN/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -865,7 +714,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:01:14 GMT
+      - Mon, 29 Oct 2018 21:32:33 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -883,9 +732,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:01:14 GMT
+      - Mon, 29 Oct 2018 21:32:33 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:01:14 GMT
+      - Mon, 29 Oct 2018 21:32:33 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -917,10 +766,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:14 GMT
+  recorded_at: Mon, 29 Oct 2018 21:32:33 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271yfeWWpZ0pS317X2xcCj6d8cvTFjZS2uo%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files/13_BlO8dgMhpF2numBmBYO9STimKkECKN?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -932,7 +781,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:01:14 GMT
+      - Mon, 29 Oct 2018 21:32:33 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -943,9 +792,305 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:01:14 GMT
+      - Mon, 29 Oct 2018 21:32:34 GMT
       Date:
-      - Sat, 27 Oct 2018 00:01:14 GMT
+      - Mon, 29 Oct 2018 21:32:34 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "13_BlO8dgMhpF2numBmBYO9STimKkECKN",
+         "name": "Test @ 2018-10-29 21:32:27 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:32:34 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/13_BlO8dgMhpF2numBmBYO9STimKkECKN/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:32:34 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 29 Oct 2018 21:32:34 GMT
+      Expires:
+      - Mon, 29 Oct 2018 21:32:34 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:32:34 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/13_BlO8dgMhpF2numBmBYO9STimKkECKN?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:32:34 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:32:34 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:32:34 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "13_BlO8dgMhpF2numBmBYO9STimKkECKN",
+         "name": "Test @ 2018-10-29 21:32:27 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:32:34 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/13_BlO8dgMhpF2numBmBYO9STimKkECKN/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:32:34 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 29 Oct 2018 21:32:35 GMT
+      Expires:
+      - Mon, 29 Oct 2018 21:32:35 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:32:35 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%2713_BlO8dgMhpF2numBmBYO9STimKkECKN%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:32:35 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:32:35 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:32:35 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -973,12 +1118,12 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1ri-G3xeC4Psp6wgFwKXre6jGR8nmnxUS",
+           "id": "1tUobwdQToAs3MWmjBEugyJhXnPNBAfUG",
            "name": "Folder",
            "mimeType": "application/vnd.google-apps.folder",
            "trashed": false,
            "parents": [
-            "1yfeWWpZ0pS317X2xcCj6d8cvTFjZS2uo"
+            "13_BlO8dgMhpF2numBmBYO9STimKkECKN"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -1005,10 +1150,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:14 GMT
+  recorded_at: Mon, 29 Oct 2018 21:32:35 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1ri-G3xeC4Psp6wgFwKXre6jGR8nmnxUS/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1tUobwdQToAs3MWmjBEugyJhXnPNBAfUG/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1020,7 +1165,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:01:14 GMT
+      - Mon, 29 Oct 2018 21:32:35 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1038,9 +1183,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:01:14 GMT
+      - Mon, 29 Oct 2018 21:32:35 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:01:14 GMT
+      - Mon, 29 Oct 2018 21:32:35 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1072,10 +1217,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:14 GMT
+  recorded_at: Mon, 29 Oct 2018 21:32:35 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271ri-G3xeC4Psp6wgFwKXre6jGR8nmnxUS%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271tUobwdQToAs3MWmjBEugyJhXnPNBAfUG%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -1087,7 +1232,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:01:14 GMT
+      - Mon, 29 Oct 2018 21:32:35 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1098,9 +1243,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:01:15 GMT
+      - Mon, 29 Oct 2018 21:32:36 GMT
       Date:
-      - Sat, 27 Oct 2018 00:01:15 GMT
+      - Mon, 29 Oct 2018 21:32:36 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1128,15 +1273,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1uNuG3SHIhi7AaSGSMiWOVwlzup4xiy_rjq1ko6UrjJs",
+           "id": "1-gC9Dy1bGaj_HgD6MOFmTkdOVS_H-maK5hpR3EKwz20",
            "name": "File To Move",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1ri-G3xeC4Psp6wgFwKXre6jGR8nmnxUS"
+            "1tUobwdQToAs3MWmjBEugyJhXnPNBAfUG"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1uNuG3SHIhi7AaSGSMiWOVwlzup4xiy_rjq1ko6UrjJs&v=1&s=AMedNnoAAAAAW9PG68KG1k6I0OTRqNORx0xenOVa--dG&sz=s220",
-           "thumbnailVersion": "1",
+           "thumbnailVersion": "0",
            "permissions": [
             {
              "kind": "drive#permission",
@@ -1161,10 +1305,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:15 GMT
+  recorded_at: Mon, 29 Oct 2018 21:32:36 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1uNuG3SHIhi7AaSGSMiWOVwlzup4xiy_rjq1ko6UrjJs/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1-gC9Dy1bGaj_HgD6MOFmTkdOVS_H-maK5hpR3EKwz20/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1176,7 +1320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:01:15 GMT
+      - Mon, 29 Oct 2018 21:32:36 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1187,9 +1331,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:01:15 GMT
+      - Mon, 29 Oct 2018 21:32:36 GMT
       Date:
-      - Sat, 27 Oct 2018 00:01:15 GMT
+      - Mon, 29 Oct 2018 21:32:36 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1218,76 +1362,16 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:01:10.823Z"
+         "modifiedTime": "2018-10-29T21:32:30.851Z"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:15 GMT
-- request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1uNuG3SHIhi7AaSGSMiWOVwlzup4xiy_rjq1ko6UrjJs&s=AMedNnoAAAAAW9PG68KG1k6I0OTRqNORx0xenOVa--dG&sz=s350&v=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:01:15 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Expose-Headers:
-      - Content-Length
-      Etag:
-      - '"v1"'
-      Expires:
-      - Fri, 01 Jan 1990 00:00:00 GMT
-      Cache-Control:
-      - private, max-age=86400, no-transform
-      Content-Disposition:
-      - inline;filename="unnamed.png"
-      Content-Type:
-      - image/png
-      Vary:
-      - Origin
-      Access-Control-Allow-Origin:
-      - "*"
-      Timing-Allow-Origin:
-      - "*"
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Sat, 27 Oct 2018 00:01:15 GMT
-      Server:
-      - fife
-      Content-Length:
-      - '1022'
-      X-Xss-Protection:
-      - 1; mode=block
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:15 GMT
+  recorded_at: Mon, 29 Oct 2018 21:32:36 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1uNuG3SHIhi7AaSGSMiWOVwlzup4xiy_rjq1ko6UrjJs/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1-gC9Dy1bGaj_HgD6MOFmTkdOVS_H-maK5hpR3EKwz20/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"File To Move","parents":["1ep-1-2ODj4AYqIx6Y6bLBTGSvH78JsEE"]}'
+      string: '{"name":"File To Move","parents":["1Flv74-BFXz-kz1KdrHLtw06oQf8CqHzA"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1296,7 +1380,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:01:15 GMT
+      - Mon, 29 Oct 2018 21:32:36 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1313,7 +1397,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:01:17 GMT
+      - Mon, 29 Oct 2018 21:32:38 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1337,12 +1421,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1Se2UjSeqo6C442ffeH_hK0gecWvX_JLJkJarCigELuM",
+         "id": "14f5r_DN_OC6vExxNKN7IBjr-Akf4qiZ-GUoVZV26YVA",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1ep-1-2ODj4AYqIx6Y6bLBTGSvH78JsEE"
+          "1Flv74-BFXz-kz1KdrHLtw06oQf8CqHzA"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1367,10 +1451,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:17 GMT
+  recorded_at: Mon, 29 Oct 2018 21:32:38 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1uNuG3SHIhi7AaSGSMiWOVwlzup4xiy_rjq1ko6UrjJs?addParents=1yfeWWpZ0pS317X2xcCj6d8cvTFjZS2uo&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1ri-G3xeC4Psp6wgFwKXre6jGR8nmnxUS
+    uri: https://www.googleapis.com/drive/v3/files/1-gC9Dy1bGaj_HgD6MOFmTkdOVS_H-maK5hpR3EKwz20?addParents=13_BlO8dgMhpF2numBmBYO9STimKkECKN&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1tUobwdQToAs3MWmjBEugyJhXnPNBAfUG
     body:
       encoding: UTF-8
       string: ''
@@ -1382,7 +1466,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:01:17 GMT
+      - Mon, 29 Oct 2018 21:32:38 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1399,7 +1483,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:01:17 GMT
+      - Mon, 29 Oct 2018 21:32:39 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1423,14 +1507,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1uNuG3SHIhi7AaSGSMiWOVwlzup4xiy_rjq1ko6UrjJs",
+         "id": "1-gC9Dy1bGaj_HgD6MOFmTkdOVS_H-maK5hpR3EKwz20",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1yfeWWpZ0pS317X2xcCj6d8cvTFjZS2uo"
+          "13_BlO8dgMhpF2numBmBYO9STimKkECKN"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1uNuG3SHIhi7AaSGSMiWOVwlzup4xiy_rjq1ko6UrjJs&v=1&s=AMedNnoAAAAAW9PG7coxByPgHjQOehAAvqn-WUJxVI8h&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1-gC9Dy1bGaj_HgD6MOFmTkdOVS_H-maK5hpR3EKwz20&v=1&s=AMedNnoAAAAAW9eYl2Jv1dVqr5n0vyBKZCQBmDMzaZEQ&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -1454,10 +1538,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:01:17 GMT
+  recorded_at: Mon, 29 Oct 2018 21:32:39 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=10954
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId,changes/file/parents&pageSize=100&pageToken=13161
     body:
       encoding: UTF-8
       string: ''
@@ -1469,7 +1553,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:02:17 GMT
+      - Mon, 29 Oct 2018 21:33:39 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1480,9 +1564,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:02:18 GMT
+      - Mon, 29 Oct 2018 21:33:39 GMT
       Date:
-      - Sat, 27 Oct 2018 00:02:18 GMT
+      - Mon, 29 Oct 2018 21:33:39 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1508,416 +1592,53 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "10971",
+         "newStartPageToken": "13174",
          "changes": [
           {
-           "fileId": "1R7ayZToGOl4CodHTtGcNxsZOM046w3Qbeyi96dV5tKM"
+           "fileId": "1iiN090w5xoia3ssOE7ejt99X_iWq1y4x"
           },
           {
-           "fileId": "1BYxN0-vOTTfRVsdIC7uufVxgmP7InNBT"
-          },
-          {
-           "fileId": "1ep-1-2ODj4AYqIx6Y6bLBTGSvH78JsEE"
-          },
-          {
-           "fileId": "1Se2UjSeqo6C442ffeH_hK0gecWvX_JLJkJarCigELuM"
-          },
-          {
-           "fileId": "19rjISlxZifvYM1MMTSwpHC6WoPdsmSuR7CEnBAvh8AA"
-          },
-          {
-           "fileId": "1TUif6mvPiFPWkQu0Bs7j_x4_Cx1nsvRTdq6oDslQQE0"
-          },
-          {
-           "fileId": "1ri-G3xeC4Psp6wgFwKXre6jGR8nmnxUS"
-          },
-          {
-           "fileId": "1uNuG3SHIhi7AaSGSMiWOVwlzup4xiy_rjq1ko6UrjJs"
-          },
-          {
-           "fileId": "1yfeWWpZ0pS317X2xcCj6d8cvTFjZS2uo"
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:18 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1R7ayZToGOl4CodHTtGcNxsZOM046w3Qbeyi96dV5tKM?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:02:18 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:02:18 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:02:18 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "notFound",
-            "message": "File not found: 1R7ayZToGOl4CodHTtGcNxsZOM046w3Qbeyi96dV5tKM.",
-            "locationType": "parameter",
-            "location": "fileId"
+           "fileId": "1Flv74-BFXz-kz1KdrHLtw06oQf8CqHzA",
+           "file": {
+            "parents": [
+             "0AIeK5UAEPQfeUk9PVA"
+            ]
            }
-          ],
-          "code": 404,
-          "message": "File not found: 1R7ayZToGOl4CodHTtGcNxsZOM046w3Qbeyi96dV5tKM."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:18 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1BYxN0-vOTTfRVsdIC7uufVxgmP7InNBT?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:02:18 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:02:18 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:02:18 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "notFound",
-            "message": "File not found: 1BYxN0-vOTTfRVsdIC7uufVxgmP7InNBT.",
-            "locationType": "parameter",
-            "location": "fileId"
+          },
+          {
+           "fileId": "14f5r_DN_OC6vExxNKN7IBjr-Akf4qiZ-GUoVZV26YVA",
+           "file": {
+            "parents": [
+             "1Flv74-BFXz-kz1KdrHLtw06oQf8CqHzA"
+            ]
            }
-          ],
-          "code": 404,
-          "message": "File not found: 1BYxN0-vOTTfRVsdIC7uufVxgmP7InNBT."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:18 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1ep-1-2ODj4AYqIx6Y6bLBTGSvH78JsEE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:02:18 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:02:18 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:02:18 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1ep-1-2ODj4AYqIx6Y6bLBTGSvH78JsEE",
-         "name": "3 Starship Titanic (Archive)",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
           },
           {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:18 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1ep-1-2ODj4AYqIx6Y6bLBTGSvH78JsEE/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:02:18 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:02:18 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:02:18 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
+           "fileId": "1tUobwdQToAs3MWmjBEugyJhXnPNBAfUG",
+           "file": {
+            "parents": [
+             "13_BlO8dgMhpF2numBmBYO9STimKkECKN"
+            ]
            }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:18 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Se2UjSeqo6C442ffeH_hK0gecWvX_JLJkJarCigELuM?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:02:18 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:02:19 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:02:19 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1Se2UjSeqo6C442ffeH_hK0gecWvX_JLJkJarCigELuM",
-         "name": "File To Move",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1ep-1-2ODj4AYqIx6Y6bLBTGSvH78JsEE"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Se2UjSeqo6C442ffeH_hK0gecWvX_JLJkJarCigELuM&v=1&s=AMedNnoAAAAAW9PHK2ym7oH_ijuh6lNPrOyM_UP1pRAA&sz=s220",
-         "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
           },
           {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
+           "fileId": "1-gC9Dy1bGaj_HgD6MOFmTkdOVS_H-maK5hpR3EKwz20",
+           "file": {
+            "parents": [
+             "13_BlO8dgMhpF2numBmBYO9STimKkECKN"
+            ]
+           }
+          },
+          {
+           "fileId": "13_BlO8dgMhpF2numBmBYO9STimKkECKN"
           }
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:19 GMT
+  recorded_at: Mon, 29 Oct 2018 21:33:39 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Se2UjSeqo6C442ffeH_hK0gecWvX_JLJkJarCigELuM/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1tUobwdQToAs3MWmjBEugyJhXnPNBAfUG?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1929,7 +1650,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:02:19 GMT
+      - Mon, 29 Oct 2018 21:33:39 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1940,9 +1661,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:02:19 GMT
+      - Mon, 29 Oct 2018 21:33:40 GMT
       Date:
-      - Sat, 27 Oct 2018 00:02:19 GMT
+      - Mon, 29 Oct 2018 21:33:40 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1968,542 +1689,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "kind": "drive#revision",
-         "id": "1",
-         "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:01:16.624Z"
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:19 GMT
-- request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1Se2UjSeqo6C442ffeH_hK0gecWvX_JLJkJarCigELuM&s=AMedNnoAAAAAW9PHK2ym7oH_ijuh6lNPrOyM_UP1pRAA&sz=s350&v=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:02:19 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Expose-Headers:
-      - Content-Length
-      Etag:
-      - '"v1"'
-      Expires:
-      - Fri, 01 Jan 1990 00:00:00 GMT
-      Cache-Control:
-      - private, max-age=86400, no-transform
-      Content-Disposition:
-      - inline;filename="unnamed.png"
-      Content-Type:
-      - image/png
-      Vary:
-      - Origin
-      Access-Control-Allow-Origin:
-      - "*"
-      Timing-Allow-Origin:
-      - "*"
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Sat, 27 Oct 2018 00:02:19 GMT
-      Server:
-      - fife
-      Content-Length:
-      - '1022'
-      X-Xss-Protection:
-      - 1; mode=block
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:19 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/19rjISlxZifvYM1MMTSwpHC6WoPdsmSuR7CEnBAvh8AA?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:02:19 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:02:19 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:02:19 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "19rjISlxZifvYM1MMTSwpHC6WoPdsmSuR7CEnBAvh8AA",
-         "name": "New File Name",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "17Yve_OpLEfrtRfTorSGR-IVCPPblfheU"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=19rjISlxZifvYM1MMTSwpHC6WoPdsmSuR7CEnBAvh8AA&v=1&s=AMedNnoAAAAAW9PHK801JNHdbFtsG1fSO58NqrzVxr-k&sz=s220",
-         "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:19 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/19rjISlxZifvYM1MMTSwpHC6WoPdsmSuR7CEnBAvh8AA/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:02:19 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:02:20 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:02:20 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "kind": "drive#revision",
-         "id": "1",
-         "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-26T23:59:50.581Z"
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:20 GMT
-- request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=19rjISlxZifvYM1MMTSwpHC6WoPdsmSuR7CEnBAvh8AA&s=AMedNnoAAAAAW9PHK801JNHdbFtsG1fSO58NqrzVxr-k&sz=s350&v=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:02:20 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Expose-Headers:
-      - Content-Length
-      Etag:
-      - '"v1"'
-      Expires:
-      - Fri, 01 Jan 1990 00:00:00 GMT
-      Cache-Control:
-      - private, max-age=86400, no-transform
-      Content-Disposition:
-      - inline;filename="unnamed.png"
-      Content-Type:
-      - image/png
-      Vary:
-      - Origin
-      Access-Control-Allow-Origin:
-      - "*"
-      Timing-Allow-Origin:
-      - "*"
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Sat, 27 Oct 2018 00:02:20 GMT
-      Server:
-      - fife
-      Content-Length:
-      - '1022'
-      X-Xss-Protection:
-      - 1; mode=block
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:20 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1TUif6mvPiFPWkQu0Bs7j_x4_Cx1nsvRTdq6oDslQQE0?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:02:21 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:02:21 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:02:21 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1TUif6mvPiFPWkQu0Bs7j_x4_Cx1nsvRTdq6oDslQQE0",
-         "name": "File",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "17Yve_OpLEfrtRfTorSGR-IVCPPblfheU"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1TUif6mvPiFPWkQu0Bs7j_x4_Cx1nsvRTdq6oDslQQE0&v=1&s=AMedNnoAAAAAW9PHLZ6FJaZjcLQMur4nykkhhRja-t5O&sz=s220",
-         "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:21 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1TUif6mvPiFPWkQu0Bs7j_x4_Cx1nsvRTdq6oDslQQE0/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:02:21 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:02:21 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:02:21 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "kind": "drive#revision",
-         "id": "1",
-         "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-26T23:58:45.192Z"
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:21 GMT
-- request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1TUif6mvPiFPWkQu0Bs7j_x4_Cx1nsvRTdq6oDslQQE0&s=AMedNnoAAAAAW9PHLZ6FJaZjcLQMur4nykkhhRja-t5O&sz=s350&v=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:02:21 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Expose-Headers:
-      - Content-Length
-      Etag:
-      - '"v1"'
-      Expires:
-      - Fri, 01 Jan 1990 00:00:00 GMT
-      Cache-Control:
-      - private, max-age=86400, no-transform
-      Content-Disposition:
-      - inline;filename="unnamed.png"
-      Content-Type:
-      - image/png
-      Vary:
-      - Origin
-      Access-Control-Allow-Origin:
-      - "*"
-      Timing-Allow-Origin:
-      - "*"
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Sat, 27 Oct 2018 00:02:21 GMT
-      Server:
-      - fife
-      Content-Length:
-      - '1022'
-      X-Xss-Protection:
-      - 1; mode=block
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:21 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1ri-G3xeC4Psp6wgFwKXre6jGR8nmnxUS?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:02:22 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:02:22 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:02:22 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1ri-G3xeC4Psp6wgFwKXre6jGR8nmnxUS",
+         "id": "1tUobwdQToAs3MWmjBEugyJhXnPNBAfUG",
          "name": "Folder",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1yfeWWpZ0pS317X2xcCj6d8cvTFjZS2uo"
+          "13_BlO8dgMhpF2numBmBYO9STimKkECKN"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -2528,10 +1719,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:22 GMT
+  recorded_at: Mon, 29 Oct 2018 21:33:40 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1ri-G3xeC4Psp6wgFwKXre6jGR8nmnxUS/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1tUobwdQToAs3MWmjBEugyJhXnPNBAfUG/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -2543,7 +1734,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:02:22 GMT
+      - Mon, 29 Oct 2018 21:33:40 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2561,9 +1752,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:02:22 GMT
+      - Mon, 29 Oct 2018 21:33:40 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:02:22 GMT
+      - Mon, 29 Oct 2018 21:33:40 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -2595,10 +1786,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:22 GMT
+  recorded_at: Mon, 29 Oct 2018 21:33:40 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1uNuG3SHIhi7AaSGSMiWOVwlzup4xiy_rjq1ko6UrjJs?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1tUobwdQToAs3MWmjBEugyJhXnPNBAfUG?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -2610,7 +1801,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:02:22 GMT
+      - Mon, 29 Oct 2018 21:33:40 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2621,9 +1812,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:02:22 GMT
+      - Mon, 29 Oct 2018 21:33:40 GMT
       Date:
-      - Sat, 27 Oct 2018 00:02:22 GMT
+      - Mon, 29 Oct 2018 21:33:40 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -2649,14 +1840,165 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1uNuG3SHIhi7AaSGSMiWOVwlzup4xiy_rjq1ko6UrjJs",
+         "id": "1tUobwdQToAs3MWmjBEugyJhXnPNBAfUG",
+         "name": "Folder",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "13_BlO8dgMhpF2numBmBYO9STimKkECKN"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:33:40 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1tUobwdQToAs3MWmjBEugyJhXnPNBAfUG/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:33:40 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 29 Oct 2018 21:33:40 GMT
+      Expires:
+      - Mon, 29 Oct 2018 21:33:40 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:33:40 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1-gC9Dy1bGaj_HgD6MOFmTkdOVS_H-maK5hpR3EKwz20?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:33:40 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:33:41 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:33:41 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1-gC9Dy1bGaj_HgD6MOFmTkdOVS_H-maK5hpR3EKwz20",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1yfeWWpZ0pS317X2xcCj6d8cvTFjZS2uo"
+          "13_BlO8dgMhpF2numBmBYO9STimKkECKN"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1uNuG3SHIhi7AaSGSMiWOVwlzup4xiy_rjq1ko6UrjJs&v=1&s=AMedNnoAAAAAW9PHLhhd0uuvqj3QAY0JCSMVk1tElgBN&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1-gC9Dy1bGaj_HgD6MOFmTkdOVS_H-maK5hpR3EKwz20&v=1&s=AMedNnoAAAAAW9eY1ZNabHQfoyABWWYIzjvJCSOzI7PV&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -2680,10 +2022,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:22 GMT
+  recorded_at: Mon, 29 Oct 2018 21:33:41 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1uNuG3SHIhi7AaSGSMiWOVwlzup4xiy_rjq1ko6UrjJs/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1-gC9Dy1bGaj_HgD6MOFmTkdOVS_H-maK5hpR3EKwz20/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -2695,7 +2037,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:02:22 GMT
+      - Mon, 29 Oct 2018 21:33:41 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2706,9 +2048,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:02:22 GMT
+      - Mon, 29 Oct 2018 21:33:41 GMT
       Date:
-      - Sat, 27 Oct 2018 00:02:22 GMT
+      - Mon, 29 Oct 2018 21:33:41 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -2737,16 +2079,16 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:01:10.823Z"
+         "modifiedTime": "2018-10-29T21:32:30.851Z"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:23 GMT
+  recorded_at: Mon, 29 Oct 2018 21:33:41 GMT
 - request:
-    method: post
-    uri: https://www.googleapis.com/drive/v3/files/1uNuG3SHIhi7AaSGSMiWOVwlzup4xiy_rjq1ko6UrjJs/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1-gC9Dy1bGaj_HgD6MOFmTkdOVS_H-maK5hpR3EKwz20&s=AMedNnoAAAAAW9eY1ZNabHQfoyABWWYIzjvJCSOzI7PV&sz=s350&v=1
     body:
       encoding: UTF-8
-      string: '{"name":"File To Move","parents":["1ep-1-2ODj4AYqIx6Y6bLBTGSvH78JsEE"]}'
+      string: ''
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -2755,7 +2097,67 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:02:23 GMT
+      - Mon, 29 Oct 2018 21:33:41 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 29 Oct 2018 21:33:42 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:33:42 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1-gC9Dy1bGaj_HgD6MOFmTkdOVS_H-maK5hpR3EKwz20/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"File To Move","parents":["1Flv74-BFXz-kz1KdrHLtw06oQf8CqHzA"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:33:42 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -2772,7 +2174,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:02:24 GMT
+      - Mon, 29 Oct 2018 21:33:43 GMT
       Vary:
       - Origin
       - X-Origin
@@ -2796,12 +2198,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "13PlUAEHfMZQCrrl9bfJJrjhQoOjMfUE6pcIGRFZlDR8",
+         "id": "1faD2rFFXDNdGvLSHMlXRyeHyvA3aQeDN3BihOU0PA04",
          "name": "File To Move",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1ep-1-2ODj4AYqIx6Y6bLBTGSvH78JsEE"
+          "1Flv74-BFXz-kz1KdrHLtw06oQf8CqHzA"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -2826,10 +2228,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:24 GMT
+  recorded_at: Mon, 29 Oct 2018 21:33:44 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1yfeWWpZ0pS317X2xcCj6d8cvTFjZS2uo?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1-gC9Dy1bGaj_HgD6MOFmTkdOVS_H-maK5hpR3EKwz20?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -2841,7 +2243,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:02:24 GMT
+      - Mon, 29 Oct 2018 21:33:44 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2852,9 +2254,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:02:24 GMT
+      - Mon, 29 Oct 2018 21:33:44 GMT
       Date:
-      - Sat, 27 Oct 2018 00:02:24 GMT
+      - Mon, 29 Oct 2018 21:33:44 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -2880,8 +2282,153 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1yfeWWpZ0pS317X2xcCj6d8cvTFjZS2uo",
-         "name": "Test @ 2018-10-27 00:01:07 UTC",
+         "id": "1-gC9Dy1bGaj_HgD6MOFmTkdOVS_H-maK5hpR3EKwz20",
+         "name": "File To Move",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "13_BlO8dgMhpF2numBmBYO9STimKkECKN"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1-gC9Dy1bGaj_HgD6MOFmTkdOVS_H-maK5hpR3EKwz20&v=1&s=AMedNnoAAAAAW9eY2LK5q_uK3UrhPUQwLQW3qUNG-u88&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:33:44 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1-gC9Dy1bGaj_HgD6MOFmTkdOVS_H-maK5hpR3EKwz20/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:33:44 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:33:44 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:33:44 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-29T21:32:30.851Z"
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:33:44 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/13_BlO8dgMhpF2numBmBYO9STimKkECKN?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:33:44 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:33:44 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:33:44 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "13_BlO8dgMhpF2numBmBYO9STimKkECKN",
+         "name": "Test @ 2018-10-29 21:32:27 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -2907,10 +2454,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:24 GMT
+  recorded_at: Mon, 29 Oct 2018 21:33:44 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1yfeWWpZ0pS317X2xcCj6d8cvTFjZS2uo/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/13_BlO8dgMhpF2numBmBYO9STimKkECKN/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -2922,7 +2469,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:02:24 GMT
+      - Mon, 29 Oct 2018 21:33:44 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2940,9 +2487,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:02:25 GMT
+      - Mon, 29 Oct 2018 21:33:45 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:02:25 GMT
+      - Mon, 29 Oct 2018 21:33:45 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -2974,10 +2521,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:25 GMT
+  recorded_at: Mon, 29 Oct 2018 21:33:45 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1yfeWWpZ0pS317X2xcCj6d8cvTFjZS2uo
+    uri: https://www.googleapis.com/drive/v3/files/13_BlO8dgMhpF2numBmBYO9STimKkECKN
     body:
       encoding: UTF-8
       string: ''
@@ -2989,7 +2536,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:02:25 GMT
+      - Mon, 29 Oct 2018 21:33:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -3006,7 +2553,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:02:26 GMT
+      - Mon, 29 Oct 2018 21:33:45 GMT
       Vary:
       - Origin
       - X-Origin
@@ -3018,5 +2565,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:26 GMT
+  recorded_at: Mon, 29 Oct 2018 21:33:45 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_renames_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_renames_file.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Fri, 26 Oct 2018 23:58:34 GMT
+      - Mon, 29 Oct 2018 21:29:36 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:58:34 GMT
+  recorded_at: Mon, 29 Oct 2018 21:29:36 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Fri, 26 Oct 2018 23:58:34 GMT
+      - Mon, 29 Oct 2018 21:29:37 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:58:34 GMT
+  recorded_at: Mon, 29 Oct 2018 21:29:37 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-26
-        23:58:34 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-29
+        21:29:37 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:58:34 GMT
+      - Mon, 29 Oct 2018 21:29:37 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 26 Oct 2018 23:58:36 GMT
+      - Mon, 29 Oct 2018 21:29:37 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1kEjU8QgRp9sSu6FL84PdqBeB_PKhgXLJ",
-         "name": "Test @ 2018-10-26 23:58:34 UTC",
+         "id": "1rMstcuwqKxYNVV84MDmLe3H5xttAiMVn",
+         "name": "Test @ 2018-10-29 21:29:37 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:58:36 GMT
+  recorded_at: Mon, 29 Oct 2018 21:29:37 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1kEjU8QgRp9sSu6FL84PdqBeB_PKhgXLJ/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1rMstcuwqKxYNVV84MDmLe3H5xttAiMVn/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:58:36 GMT
+      - Mon, 29 Oct 2018 21:29:37 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 26 Oct 2018 23:58:37 GMT
+      - Mon, 29 Oct 2018 21:29:38 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:58:37 GMT
+  recorded_at: Mon, 29 Oct 2018 21:29:38 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:58:37 GMT
+      - Mon, 29 Oct 2018 21:29:38 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Fri, 26 Oct 2018 23:58:37 GMT
+      - Mon, 29 Oct 2018 21:29:39 GMT
       Date:
-      - Fri, 26 Oct 2018 23:58:37 GMT
+      - Mon, 29 Oct 2018 21:29:39 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,16 +302,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "10927"
+         "startPageToken": "13132"
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:58:37 GMT
+  recorded_at: Mon, 29 Oct 2018 21:29:39 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1kEjU8QgRp9sSu6FL84PdqBeB_PKhgXLJ"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1rMstcuwqKxYNVV84MDmLe3H5xttAiMVn"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -320,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:58:39 GMT
+      - Mon, 29 Oct 2018 21:29:40 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -337,7 +337,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 26 Oct 2018 23:58:40 GMT
+      - Mon, 29 Oct 2018 21:29:41 GMT
       Vary:
       - Origin
       - X-Origin
@@ -361,12 +361,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1qwG6-bI_3BUkAOPmvYgYJtTHi2YT394qNBb6aHDkd08",
+         "id": "1_BMleBSktqUMCnZL-U4iWfhaYMG6xiTIoabk81ZkxBU",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1kEjU8QgRp9sSu6FL84PdqBeB_PKhgXLJ"
+          "1rMstcuwqKxYNVV84MDmLe3H5xttAiMVn"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -391,14 +391,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:58:40 GMT
+  recorded_at: Mon, 29 Oct 2018 21:29:42 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"1 Bistromath
-        (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"1 Starship
+        Titanic (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -407,7 +407,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:58:40 GMT
+      - Mon, 29 Oct 2018 21:29:42 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -424,7 +424,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 26 Oct 2018 23:58:41 GMT
+      - Mon, 29 Oct 2018 21:29:42 GMT
       Vary:
       - Origin
       - X-Origin
@@ -448,8 +448,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "17Yve_OpLEfrtRfTorSGR-IVCPPblfheU",
-         "name": "1 Bistromath (Archive)",
+         "id": "1zihOYT8qtc-1vsHXKGs4ikC8Jd2CBZ8l",
+         "name": "1 Starship Titanic (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -469,10 +469,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:58:41 GMT
+  recorded_at: Mon, 29 Oct 2018 21:29:42 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/17Yve_OpLEfrtRfTorSGR-IVCPPblfheU/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1zihOYT8qtc-1vsHXKGs4ikC8Jd2CBZ8l/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -484,7 +484,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:58:41 GMT
+      - Mon, 29 Oct 2018 21:29:42 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -501,7 +501,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 26 Oct 2018 23:58:42 GMT
+      - Mon, 29 Oct 2018 21:29:43 GMT
       Vary:
       - Origin
       - X-Origin
@@ -531,10 +531,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:58:42 GMT
+  recorded_at: Mon, 29 Oct 2018 21:29:43 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/17Yve_OpLEfrtRfTorSGR-IVCPPblfheU?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1rMstcuwqKxYNVV84MDmLe3H5xttAiMVn?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -546,7 +546,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:58:42 GMT
+      - Mon, 29 Oct 2018 21:29:43 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -557,9 +557,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Fri, 26 Oct 2018 23:58:42 GMT
+      - Mon, 29 Oct 2018 21:29:44 GMT
       Date:
-      - Fri, 26 Oct 2018 23:58:42 GMT
+      - Mon, 29 Oct 2018 21:29:44 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -585,159 +585,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "17Yve_OpLEfrtRfTorSGR-IVCPPblfheU",
-         "name": "1 Bistromath (Archive)",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:58:42 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/17Yve_OpLEfrtRfTorSGR-IVCPPblfheU/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Fri, 26 Oct 2018 23:58:42 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Fri, 26 Oct 2018 23:58:42 GMT
-      Expires:
-      - Fri, 26 Oct 2018 23:58:42 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:58:42 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1kEjU8QgRp9sSu6FL84PdqBeB_PKhgXLJ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Fri, 26 Oct 2018 23:58:42 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Fri, 26 Oct 2018 23:58:42 GMT
-      Date:
-      - Fri, 26 Oct 2018 23:58:42 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1kEjU8QgRp9sSu6FL84PdqBeB_PKhgXLJ",
-         "name": "Test @ 2018-10-26 23:58:34 UTC",
+         "id": "1rMstcuwqKxYNVV84MDmLe3H5xttAiMVn",
+         "name": "Test @ 2018-10-29 21:29:37 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -763,10 +612,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:58:42 GMT
+  recorded_at: Mon, 29 Oct 2018 21:29:44 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1kEjU8QgRp9sSu6FL84PdqBeB_PKhgXLJ/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1rMstcuwqKxYNVV84MDmLe3H5xttAiMVn/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -778,7 +627,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:58:42 GMT
+      - Mon, 29 Oct 2018 21:29:44 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -796,9 +645,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Fri, 26 Oct 2018 23:58:43 GMT
+      - Mon, 29 Oct 2018 21:29:45 GMT
       Expires:
-      - Fri, 26 Oct 2018 23:58:43 GMT
+      - Mon, 29 Oct 2018 21:29:45 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -830,10 +679,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:58:42 GMT
+  recorded_at: Mon, 29 Oct 2018 21:29:45 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271kEjU8QgRp9sSu6FL84PdqBeB_PKhgXLJ%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files/1rMstcuwqKxYNVV84MDmLe3H5xttAiMVn?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -845,7 +694,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:58:43 GMT
+      - Mon, 29 Oct 2018 21:29:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -856,9 +705,305 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Fri, 26 Oct 2018 23:58:43 GMT
+      - Mon, 29 Oct 2018 21:29:45 GMT
       Date:
-      - Fri, 26 Oct 2018 23:58:43 GMT
+      - Mon, 29 Oct 2018 21:29:45 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1rMstcuwqKxYNVV84MDmLe3H5xttAiMVn",
+         "name": "Test @ 2018-10-29 21:29:37 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:29:45 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1rMstcuwqKxYNVV84MDmLe3H5xttAiMVn/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:29:45 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 29 Oct 2018 21:29:45 GMT
+      Expires:
+      - Mon, 29 Oct 2018 21:29:45 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:29:45 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1rMstcuwqKxYNVV84MDmLe3H5xttAiMVn?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:29:45 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:29:45 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:29:45 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1rMstcuwqKxYNVV84MDmLe3H5xttAiMVn",
+         "name": "Test @ 2018-10-29 21:29:37 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:29:45 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1rMstcuwqKxYNVV84MDmLe3H5xttAiMVn/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:29:45 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 29 Oct 2018 21:29:46 GMT
+      Expires:
+      - Mon, 29 Oct 2018 21:29:46 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:29:46 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271rMstcuwqKxYNVV84MDmLe3H5xttAiMVn%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:29:46 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:29:46 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:29:46 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -886,14 +1031,15 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1qwG6-bI_3BUkAOPmvYgYJtTHi2YT394qNBb6aHDkd08",
+           "id": "1_BMleBSktqUMCnZL-U4iWfhaYMG6xiTIoabk81ZkxBU",
            "name": "File",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1kEjU8QgRp9sSu6FL84PdqBeB_PKhgXLJ"
+            "1rMstcuwqKxYNVV84MDmLe3H5xttAiMVn"
            ],
-           "thumbnailVersion": "0",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1_BMleBSktqUMCnZL-U4iWfhaYMG6xiTIoabk81ZkxBU&v=1&s=AMedNnoAAAAAW9eX6immeygGWXG_RiyAbDyS8cIvw8gr&sz=s220",
+           "thumbnailVersion": "1",
            "permissions": [
             {
              "kind": "drive#permission",
@@ -918,10 +1064,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:58:43 GMT
+  recorded_at: Mon, 29 Oct 2018 21:29:46 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1qwG6-bI_3BUkAOPmvYgYJtTHi2YT394qNBb6aHDkd08/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1_BMleBSktqUMCnZL-U4iWfhaYMG6xiTIoabk81ZkxBU/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -933,7 +1079,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:58:43 GMT
+      - Mon, 29 Oct 2018 21:29:46 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -944,9 +1090,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Fri, 26 Oct 2018 23:58:44 GMT
+      - Mon, 29 Oct 2018 21:29:46 GMT
       Date:
-      - Fri, 26 Oct 2018 23:58:44 GMT
+      - Mon, 29 Oct 2018 21:29:46 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -975,186 +1121,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-26T23:58:39.434Z"
+         "modifiedTime": "2018-10-29T21:29:40.786Z"
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:58:44 GMT
-- request:
-    method: post
-    uri: https://www.googleapis.com/drive/v3/files/1qwG6-bI_3BUkAOPmvYgYJtTHi2YT394qNBb6aHDkd08/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: '{"name":"File","parents":["17Yve_OpLEfrtRfTorSGR-IVCPPblfheU"]}'
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Fri, 26 Oct 2018 23:58:44 GMT
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Fri, 26 Oct 2018 23:58:45 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1TUif6mvPiFPWkQu0Bs7j_x4_Cx1nsvRTdq6oDslQQE0",
-         "name": "File",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "17Yve_OpLEfrtRfTorSGR-IVCPPblfheU"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:58:45 GMT
-- request:
-    method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1qwG6-bI_3BUkAOPmvYgYJtTHi2YT394qNBb6aHDkd08?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: '{"name":"New File Name"}'
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Fri, 26 Oct 2018 23:58:46 GMT
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Fri, 26 Oct 2018 23:58:46 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1qwG6-bI_3BUkAOPmvYgYJtTHi2YT394qNBb6aHDkd08",
-         "name": "New File Name",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1kEjU8QgRp9sSu6FL84PdqBeB_PKhgXLJ"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1qwG6-bI_3BUkAOPmvYgYJtTHi2YT394qNBb6aHDkd08&v=2&s=AMedNnoAAAAAW9PGVh4kTuSZP3Sgs-RJWWZmzCycR6my&sz=s220",
-         "thumbnailVersion": "2",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:58:46 GMT
+  recorded_at: Mon, 29 Oct 2018 21:29:46 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=10927
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1_BMleBSktqUMCnZL-U4iWfhaYMG6xiTIoabk81ZkxBU&s=AMedNnoAAAAAW9eX6immeygGWXG_RiyAbDyS8cIvw8gr&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1166,374 +1139,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:59:46 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Fri, 26 Oct 2018 23:59:47 GMT
-      Date:
-      - Fri, 26 Oct 2018 23:59:47 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "newStartPageToken": "10938",
-         "changes": [
-          {
-           "fileId": "17Yve_OpLEfrtRfTorSGR-IVCPPblfheU"
-          },
-          {
-           "fileId": "1TUif6mvPiFPWkQu0Bs7j_x4_Cx1nsvRTdq6oDslQQE0"
-          },
-          {
-           "fileId": "1kEjU8QgRp9sSu6FL84PdqBeB_PKhgXLJ"
-          },
-          {
-           "fileId": "1qwG6-bI_3BUkAOPmvYgYJtTHi2YT394qNBb6aHDkd08"
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:47 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/17Yve_OpLEfrtRfTorSGR-IVCPPblfheU?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Fri, 26 Oct 2018 23:59:47 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Fri, 26 Oct 2018 23:59:47 GMT
-      Date:
-      - Fri, 26 Oct 2018 23:59:47 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "17Yve_OpLEfrtRfTorSGR-IVCPPblfheU",
-         "name": "1 Bistromath (Archive)",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:47 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/17Yve_OpLEfrtRfTorSGR-IVCPPblfheU/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Fri, 26 Oct 2018 23:59:47 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Fri, 26 Oct 2018 23:59:47 GMT
-      Expires:
-      - Fri, 26 Oct 2018 23:59:47 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:47 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1TUif6mvPiFPWkQu0Bs7j_x4_Cx1nsvRTdq6oDslQQE0?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Fri, 26 Oct 2018 23:59:47 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Fri, 26 Oct 2018 23:59:47 GMT
-      Date:
-      - Fri, 26 Oct 2018 23:59:47 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1TUif6mvPiFPWkQu0Bs7j_x4_Cx1nsvRTdq6oDslQQE0",
-         "name": "File",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "17Yve_OpLEfrtRfTorSGR-IVCPPblfheU"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1TUif6mvPiFPWkQu0Bs7j_x4_Cx1nsvRTdq6oDslQQE0&v=1&s=AMedNnoAAAAAW9PGkwtmVQLW7r5_NpPi1c2WdPMPMi3O&sz=s220",
-         "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:47 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1TUif6mvPiFPWkQu0Bs7j_x4_Cx1nsvRTdq6oDslQQE0/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Fri, 26 Oct 2018 23:59:47 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Fri, 26 Oct 2018 23:59:48 GMT
-      Date:
-      - Fri, 26 Oct 2018 23:59:48 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "kind": "drive#revision",
-         "id": "1",
-         "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-26T23:58:45.192Z"
-        }
-    http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:48 GMT
-- request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1TUif6mvPiFPWkQu0Bs7j_x4_Cx1nsvRTdq6oDslQQE0&s=AMedNnoAAAAAW9PGkwtmVQLW7r5_NpPi1c2WdPMPMi3O&sz=s350&v=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Fri, 26 Oct 2018 23:59:48 GMT
+      - Mon, 29 Oct 2018 21:29:46 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1564,7 +1170,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Fri, 26 Oct 2018 23:59:48 GMT
+      - Mon, 29 Oct 2018 21:29:47 GMT
       Server:
       - fife
       Content-Length:
@@ -1578,10 +1184,183 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:48 GMT
+  recorded_at: Mon, 29 Oct 2018 21:29:47 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1_BMleBSktqUMCnZL-U4iWfhaYMG6xiTIoabk81ZkxBU/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"File","parents":["1zihOYT8qtc-1vsHXKGs4ikC8Jd2CBZ8l"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:29:47 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:29:49 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1lylL80Z2lMo56Qng5UoOpcN18M6P2DLfH1v5umbnac4",
+         "name": "File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1zihOYT8qtc-1vsHXKGs4ikC8Jd2CBZ8l"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:29:49 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/drive/v3/files/1_BMleBSktqUMCnZL-U4iWfhaYMG6xiTIoabk81ZkxBU?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"New File Name"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:29:49 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:29:49 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1_BMleBSktqUMCnZL-U4iWfhaYMG6xiTIoabk81ZkxBU",
+         "name": "New File Name",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1rMstcuwqKxYNVV84MDmLe3H5xttAiMVn"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1_BMleBSktqUMCnZL-U4iWfhaYMG6xiTIoabk81ZkxBU&v=2&s=AMedNnoAAAAAW9eX7QrFmCQwW_tHWNc3ltaUjcPbfkDR&sz=s220",
+         "thumbnailVersion": "2",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:29:50 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1kEjU8QgRp9sSu6FL84PdqBeB_PKhgXLJ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId,changes/file/parents&pageSize=100&pageToken=13132
     body:
       encoding: UTF-8
       string: ''
@@ -1593,7 +1372,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:59:48 GMT
+      - Mon, 29 Oct 2018 21:30:50 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1604,9 +1383,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Fri, 26 Oct 2018 23:59:48 GMT
+      - Mon, 29 Oct 2018 21:30:50 GMT
       Date:
-      - Fri, 26 Oct 2018 23:59:48 GMT
+      - Mon, 29 Oct 2018 21:30:50 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1632,8 +1411,94 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1kEjU8QgRp9sSu6FL84PdqBeB_PKhgXLJ",
-         "name": "Test @ 2018-10-26 23:58:34 UTC",
+         "newStartPageToken": "13141",
+         "changes": [
+          {
+           "fileId": "1zihOYT8qtc-1vsHXKGs4ikC8Jd2CBZ8l",
+           "file": {
+            "parents": [
+             "0AIeK5UAEPQfeUk9PVA"
+            ]
+           }
+          },
+          {
+           "fileId": "1lylL80Z2lMo56Qng5UoOpcN18M6P2DLfH1v5umbnac4",
+           "file": {
+            "parents": [
+             "1zihOYT8qtc-1vsHXKGs4ikC8Jd2CBZ8l"
+            ]
+           }
+          },
+          {
+           "fileId": "1rMstcuwqKxYNVV84MDmLe3H5xttAiMVn"
+          },
+          {
+           "fileId": "1_BMleBSktqUMCnZL-U4iWfhaYMG6xiTIoabk81ZkxBU",
+           "file": {
+            "parents": [
+             "1rMstcuwqKxYNVV84MDmLe3H5xttAiMVn"
+            ]
+           }
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:30:50 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1rMstcuwqKxYNVV84MDmLe3H5xttAiMVn?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:30:50 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:30:50 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:30:50 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1rMstcuwqKxYNVV84MDmLe3H5xttAiMVn",
+         "name": "Test @ 2018-10-29 21:29:37 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -1659,10 +1524,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:48 GMT
+  recorded_at: Mon, 29 Oct 2018 21:30:50 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1kEjU8QgRp9sSu6FL84PdqBeB_PKhgXLJ/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1rMstcuwqKxYNVV84MDmLe3H5xttAiMVn/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1674,7 +1539,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:59:48 GMT
+      - Mon, 29 Oct 2018 21:30:50 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1692,9 +1557,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Fri, 26 Oct 2018 23:59:48 GMT
+      - Mon, 29 Oct 2018 21:30:50 GMT
       Expires:
-      - Fri, 26 Oct 2018 23:59:48 GMT
+      - Mon, 29 Oct 2018 21:30:50 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1726,10 +1591,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:48 GMT
+  recorded_at: Mon, 29 Oct 2018 21:30:50 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1qwG6-bI_3BUkAOPmvYgYJtTHi2YT394qNBb6aHDkd08?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1_BMleBSktqUMCnZL-U4iWfhaYMG6xiTIoabk81ZkxBU?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1741,7 +1606,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:59:48 GMT
+      - Mon, 29 Oct 2018 21:30:50 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1752,9 +1617,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Fri, 26 Oct 2018 23:59:49 GMT
+      - Mon, 29 Oct 2018 21:30:51 GMT
       Date:
-      - Fri, 26 Oct 2018 23:59:49 GMT
+      - Mon, 29 Oct 2018 21:30:51 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1780,14 +1645,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1qwG6-bI_3BUkAOPmvYgYJtTHi2YT394qNBb6aHDkd08",
+         "id": "1_BMleBSktqUMCnZL-U4iWfhaYMG6xiTIoabk81ZkxBU",
          "name": "New File Name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1kEjU8QgRp9sSu6FL84PdqBeB_PKhgXLJ"
+          "1rMstcuwqKxYNVV84MDmLe3H5xttAiMVn"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1qwG6-bI_3BUkAOPmvYgYJtTHi2YT394qNBb6aHDkd08&v=2&s=AMedNnoAAAAAW9PGlZpiRVGKPQqEQ56jDDS4yxw1D5KQ&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1_BMleBSktqUMCnZL-U4iWfhaYMG6xiTIoabk81ZkxBU&v=2&s=AMedNnoAAAAAW9eYK8aK9IKuKd6UfY01ZwtKNeRgH7cY&sz=s220",
          "thumbnailVersion": "2",
          "permissions": [
           {
@@ -1811,10 +1676,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:49 GMT
+  recorded_at: Mon, 29 Oct 2018 21:30:51 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1qwG6-bI_3BUkAOPmvYgYJtTHi2YT394qNBb6aHDkd08/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1_BMleBSktqUMCnZL-U4iWfhaYMG6xiTIoabk81ZkxBU/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1826,7 +1691,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:59:49 GMT
+      - Mon, 29 Oct 2018 21:30:51 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1837,9 +1702,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Fri, 26 Oct 2018 23:59:49 GMT
+      - Mon, 29 Oct 2018 21:30:51 GMT
       Date:
-      - Fri, 26 Oct 2018 23:59:49 GMT
+      - Mon, 29 Oct 2018 21:30:51 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1868,13 +1733,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-26T23:58:39.434Z"
+         "modifiedTime": "2018-10-29T21:29:40.786Z"
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:49 GMT
+  recorded_at: Mon, 29 Oct 2018 21:30:51 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1qwG6-bI_3BUkAOPmvYgYJtTHi2YT394qNBb6aHDkd08&s=AMedNnoAAAAAW9PGlZpiRVGKPQqEQ56jDDS4yxw1D5KQ&sz=s350&v=2
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1_BMleBSktqUMCnZL-U4iWfhaYMG6xiTIoabk81ZkxBU&s=AMedNnoAAAAAW9eYK8aK9IKuKd6UfY01ZwtKNeRgH7cY&sz=s350&v=2
     body:
       encoding: UTF-8
       string: ''
@@ -1886,7 +1751,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:59:49 GMT
+      - Mon, 29 Oct 2018 21:30:51 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1917,7 +1782,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Fri, 26 Oct 2018 23:59:49 GMT
+      - Mon, 29 Oct 2018 21:30:51 GMT
       Server:
       - fife
       Content-Length:
@@ -1931,13 +1796,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:49 GMT
+  recorded_at: Mon, 29 Oct 2018 21:30:51 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1qwG6-bI_3BUkAOPmvYgYJtTHi2YT394qNBb6aHDkd08/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1_BMleBSktqUMCnZL-U4iWfhaYMG6xiTIoabk81ZkxBU/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"New File Name","parents":["17Yve_OpLEfrtRfTorSGR-IVCPPblfheU"]}'
+      string: '{"name":"New File Name","parents":["1zihOYT8qtc-1vsHXKGs4ikC8Jd2CBZ8l"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1946,7 +1811,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:59:49 GMT
+      - Mon, 29 Oct 2018 21:30:51 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1963,7 +1828,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 26 Oct 2018 23:59:51 GMT
+      - Mon, 29 Oct 2018 21:30:53 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1987,12 +1852,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "19rjISlxZifvYM1MMTSwpHC6WoPdsmSuR7CEnBAvh8AA",
+         "id": "1lPeuySl2fIkcTtk8GgZCNPvtCq9ra6lwa2g_kQ2tXUA",
          "name": "New File Name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "17Yve_OpLEfrtRfTorSGR-IVCPPblfheU"
+          "1zihOYT8qtc-1vsHXKGs4ikC8Jd2CBZ8l"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -2017,10 +1882,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:51 GMT
+  recorded_at: Mon, 29 Oct 2018 21:30:53 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/19rjISlxZifvYM1MMTSwpHC6WoPdsmSuR7CEnBAvh8AA?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1_BMleBSktqUMCnZL-U4iWfhaYMG6xiTIoabk81ZkxBU?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -2032,7 +1897,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:59:51 GMT
+      - Mon, 29 Oct 2018 21:30:53 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2043,9 +1908,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Fri, 26 Oct 2018 23:59:51 GMT
+      - Mon, 29 Oct 2018 21:30:53 GMT
       Date:
-      - Fri, 26 Oct 2018 23:59:51 GMT
+      - Mon, 29 Oct 2018 21:30:53 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -2071,40 +1936,41 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "19rjISlxZifvYM1MMTSwpHC6WoPdsmSuR7CEnBAvh8AA",
+         "id": "1_BMleBSktqUMCnZL-U4iWfhaYMG6xiTIoabk81ZkxBU",
          "name": "New File Name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "17Yve_OpLEfrtRfTorSGR-IVCPPblfheU"
+          "1rMstcuwqKxYNVV84MDmLe3H5xttAiMVn"
          ],
-         "thumbnailVersion": "0",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1_BMleBSktqUMCnZL-U4iWfhaYMG6xiTIoabk81ZkxBU&v=2&s=AMedNnoAAAAAW9eYLaVdyCmlObGsfp232XCUhLG3mQIy&sz=s220",
+         "thumbnailVersion": "2",
          "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
           {
            "kind": "drive#permission",
            "id": "11673017242486491425",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
+           "role": "writer",
            "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
            "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:51 GMT
+  recorded_at: Mon, 29 Oct 2018 21:30:53 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1TUif6mvPiFPWkQu0Bs7j_x4_Cx1nsvRTdq6oDslQQE0?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1_BMleBSktqUMCnZL-U4iWfhaYMG6xiTIoabk81ZkxBU/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -2116,7 +1982,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:59:51 GMT
+      - Mon, 29 Oct 2018 21:30:53 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2127,9 +1993,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Fri, 26 Oct 2018 23:59:51 GMT
+      - Mon, 29 Oct 2018 21:30:53 GMT
       Date:
-      - Fri, 26 Oct 2018 23:59:51 GMT
+      - Mon, 29 Oct 2018 21:30:53 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -2155,14 +2021,158 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1TUif6mvPiFPWkQu0Bs7j_x4_Cx1nsvRTdq6oDslQQE0",
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-29T21:29:40.786Z"
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:30:53 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1lPeuySl2fIkcTtk8GgZCNPvtCq9ra6lwa2g_kQ2tXUA?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:30:54 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:30:54 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:30:54 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1lPeuySl2fIkcTtk8GgZCNPvtCq9ra6lwa2g_kQ2tXUA",
+         "name": "New File Name",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1zihOYT8qtc-1vsHXKGs4ikC8Jd2CBZ8l"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:30:54 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1lylL80Z2lMo56Qng5UoOpcN18M6P2DLfH1v5umbnac4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:30:54 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:30:54 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:30:54 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1lylL80Z2lMo56Qng5UoOpcN18M6P2DLfH1v5umbnac4",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "17Yve_OpLEfrtRfTorSGR-IVCPPblfheU"
+          "1zihOYT8qtc-1vsHXKGs4ikC8Jd2CBZ8l"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1TUif6mvPiFPWkQu0Bs7j_x4_Cx1nsvRTdq6oDslQQE0&v=1&s=AMedNnoAAAAAW9PGl92AIIOZtiXs0A7TjV73miloLidG&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1lylL80Z2lMo56Qng5UoOpcN18M6P2DLfH1v5umbnac4&v=1&s=AMedNnoAAAAAW9eYLrYhAL2e7fVykSVcPYWn9dTkQ2pZ&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -2186,10 +2196,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:51 GMT
+  recorded_at: Mon, 29 Oct 2018 21:30:54 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1kEjU8QgRp9sSu6FL84PdqBeB_PKhgXLJ
+    uri: https://www.googleapis.com/drive/v3/files/1rMstcuwqKxYNVV84MDmLe3H5xttAiMVn
     body:
       encoding: UTF-8
       string: ''
@@ -2201,7 +2211,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 26 Oct 2018 23:59:51 GMT
+      - Mon, 29 Oct 2018 21:30:54 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -2218,7 +2228,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 26 Oct 2018 23:59:52 GMT
+      - Mon, 29 Oct 2018 21:30:55 GMT
       Vary:
       - Origin
       - X-Origin
@@ -2230,5 +2240,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 26 Oct 2018 23:59:52 GMT
+  recorded_at: Mon, 29 Oct 2018 21:30:55 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_stops_sharing_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_stops_sharing_file.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Sat, 27 Oct 2018 00:09:54 GMT
+      - Mon, 29 Oct 2018 21:36:21 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:09:54 GMT
+  recorded_at: Mon, 29 Oct 2018 21:36:21 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Sat, 27 Oct 2018 00:09:54 GMT
+      - Mon, 29 Oct 2018 21:36:21 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:09:54 GMT
+  recorded_at: Mon, 29 Oct 2018 21:36:21 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-27
-        00:09:54 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-29
+        21:36:21 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:09:54 GMT
+      - Mon, 29 Oct 2018 21:36:21 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:09:54 GMT
+      - Mon, 29 Oct 2018 21:36:21 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "124D3MGOml3RUGEgD3uYVWWEKrdvVZKBu",
-         "name": "Test @ 2018-10-27 00:09:54 UTC",
+         "id": "15Qj6obGHheC-oY9dKWRchi1b3r3Sk0Qb",
+         "name": "Test @ 2018-10-29 21:36:21 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:09:55 GMT
+  recorded_at: Mon, 29 Oct 2018 21:36:21 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/124D3MGOml3RUGEgD3uYVWWEKrdvVZKBu/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/15Qj6obGHheC-oY9dKWRchi1b3r3Sk0Qb/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:09:55 GMT
+      - Mon, 29 Oct 2018 21:36:21 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:09:55 GMT
+      - Mon, 29 Oct 2018 21:36:22 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:09:56 GMT
+  recorded_at: Mon, 29 Oct 2018 21:36:22 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:09:56 GMT
+      - Mon, 29 Oct 2018 21:36:22 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:09:56 GMT
+      - Mon, 29 Oct 2018 21:36:23 GMT
       Date:
-      - Sat, 27 Oct 2018 00:09:56 GMT
+      - Mon, 29 Oct 2018 21:36:23 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,16 +302,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "11059"
+         "startPageToken": "13209"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:09:56 GMT
+  recorded_at: Mon, 29 Oct 2018 21:36:23 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["124D3MGOml3RUGEgD3uYVWWEKrdvVZKBu"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["15Qj6obGHheC-oY9dKWRchi1b3r3Sk0Qb"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -320,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:09:56 GMT
+      - Mon, 29 Oct 2018 21:36:23 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -337,7 +337,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:09:57 GMT
+      - Mon, 29 Oct 2018 21:36:24 GMT
       Vary:
       - Origin
       - X-Origin
@@ -361,12 +361,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1H5L_HEKwkrrpzR4WJqhe-bzJ8_mIihO2tYbQY9LTV4I",
+         "id": "1ENzYBTMuMypwChUKJih9XDWI-Fv4bSGrZH-VNuseJe8",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "124D3MGOml3RUGEgD3uYVWWEKrdvVZKBu"
+          "15Qj6obGHheC-oY9dKWRchi1b3r3Sk0Qb"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -391,14 +391,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:09:57 GMT
+  recorded_at: Mon, 29 Oct 2018 21:36:24 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"10 Heart of
-        Gold (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"7 Krikkit
+        One (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -407,7 +407,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:09:57 GMT
+      - Mon, 29 Oct 2018 21:36:24 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -424,7 +424,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:09:57 GMT
+      - Mon, 29 Oct 2018 21:36:25 GMT
       Vary:
       - Origin
       - X-Origin
@@ -448,8 +448,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1YzqPQsLig8FeR-RWeEYF0FDEGcWh-gZD",
-         "name": "10 Heart of Gold (Archive)",
+         "id": "1VwJY7LJ8Ma-mLhBAem54kMRGya62uHfz",
+         "name": "7 Krikkit One (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -469,10 +469,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:09:57 GMT
+  recorded_at: Mon, 29 Oct 2018 21:36:25 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1YzqPQsLig8FeR-RWeEYF0FDEGcWh-gZD/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1VwJY7LJ8Ma-mLhBAem54kMRGya62uHfz/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -484,7 +484,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:09:57 GMT
+      - Mon, 29 Oct 2018 21:36:25 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -501,7 +501,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:09:58 GMT
+      - Mon, 29 Oct 2018 21:36:25 GMT
       Vary:
       - Origin
       - X-Origin
@@ -531,10 +531,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:09:58 GMT
+  recorded_at: Mon, 29 Oct 2018 21:36:26 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1YzqPQsLig8FeR-RWeEYF0FDEGcWh-gZD?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/15Qj6obGHheC-oY9dKWRchi1b3r3Sk0Qb?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -546,7 +546,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:09:58 GMT
+      - Mon, 29 Oct 2018 21:36:26 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -557,9 +557,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:09:58 GMT
+      - Mon, 29 Oct 2018 21:36:26 GMT
       Date:
-      - Sat, 27 Oct 2018 00:09:58 GMT
+      - Mon, 29 Oct 2018 21:36:26 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -585,159 +585,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1YzqPQsLig8FeR-RWeEYF0FDEGcWh-gZD",
-         "name": "10 Heart of Gold (Archive)",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:09:58 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1YzqPQsLig8FeR-RWeEYF0FDEGcWh-gZD/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:09:58 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:09:58 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:09:58 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:09:59 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/124D3MGOml3RUGEgD3uYVWWEKrdvVZKBu?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:09:59 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:09:59 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:09:59 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "124D3MGOml3RUGEgD3uYVWWEKrdvVZKBu",
-         "name": "Test @ 2018-10-27 00:09:54 UTC",
+         "id": "15Qj6obGHheC-oY9dKWRchi1b3r3Sk0Qb",
+         "name": "Test @ 2018-10-29 21:36:21 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -763,10 +612,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:09:59 GMT
+  recorded_at: Mon, 29 Oct 2018 21:36:26 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/124D3MGOml3RUGEgD3uYVWWEKrdvVZKBu/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/15Qj6obGHheC-oY9dKWRchi1b3r3Sk0Qb/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -778,7 +627,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:09:59 GMT
+      - Mon, 29 Oct 2018 21:36:26 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -796,9 +645,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:09:59 GMT
+      - Mon, 29 Oct 2018 21:36:26 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:09:59 GMT
+      - Mon, 29 Oct 2018 21:36:26 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -830,10 +679,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:09:59 GMT
+  recorded_at: Mon, 29 Oct 2018 21:36:26 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%27124D3MGOml3RUGEgD3uYVWWEKrdvVZKBu%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files/15Qj6obGHheC-oY9dKWRchi1b3r3Sk0Qb?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -845,7 +694,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:09:59 GMT
+      - Mon, 29 Oct 2018 21:36:26 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -856,9 +705,305 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:09:59 GMT
+      - Mon, 29 Oct 2018 21:36:26 GMT
       Date:
-      - Sat, 27 Oct 2018 00:09:59 GMT
+      - Mon, 29 Oct 2018 21:36:26 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "15Qj6obGHheC-oY9dKWRchi1b3r3Sk0Qb",
+         "name": "Test @ 2018-10-29 21:36:21 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:36:26 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/15Qj6obGHheC-oY9dKWRchi1b3r3Sk0Qb/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:36:26 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 29 Oct 2018 21:36:26 GMT
+      Expires:
+      - Mon, 29 Oct 2018 21:36:26 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:36:26 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/15Qj6obGHheC-oY9dKWRchi1b3r3Sk0Qb?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:36:26 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:36:27 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:36:27 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "15Qj6obGHheC-oY9dKWRchi1b3r3Sk0Qb",
+         "name": "Test @ 2018-10-29 21:36:21 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:36:27 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/15Qj6obGHheC-oY9dKWRchi1b3r3Sk0Qb/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:36:27 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 29 Oct 2018 21:36:27 GMT
+      Expires:
+      - Mon, 29 Oct 2018 21:36:27 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:36:27 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%2715Qj6obGHheC-oY9dKWRchi1b3r3Sk0Qb%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:36:27 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:36:28 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:36:28 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -886,14 +1031,15 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1H5L_HEKwkrrpzR4WJqhe-bzJ8_mIihO2tYbQY9LTV4I",
+           "id": "1ENzYBTMuMypwChUKJih9XDWI-Fv4bSGrZH-VNuseJe8",
            "name": "File",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "124D3MGOml3RUGEgD3uYVWWEKrdvVZKBu"
+            "15Qj6obGHheC-oY9dKWRchi1b3r3Sk0Qb"
            ],
-           "thumbnailVersion": "0",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1ENzYBTMuMypwChUKJih9XDWI-Fv4bSGrZH-VNuseJe8&v=1&s=AMedNnoAAAAAW9eZfLMsfqC8uefX_5RVWUkE50TVv5IL&sz=s220",
+           "thumbnailVersion": "1",
            "permissions": [
             {
              "kind": "drive#permission",
@@ -918,10 +1064,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:09:59 GMT
+  recorded_at: Mon, 29 Oct 2018 21:36:28 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1H5L_HEKwkrrpzR4WJqhe-bzJ8_mIihO2tYbQY9LTV4I/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1ENzYBTMuMypwChUKJih9XDWI-Fv4bSGrZH-VNuseJe8/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -933,7 +1079,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:09:59 GMT
+      - Mon, 29 Oct 2018 21:36:28 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -944,9 +1090,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:09:59 GMT
+      - Mon, 29 Oct 2018 21:36:28 GMT
       Date:
-      - Sat, 27 Oct 2018 00:09:59 GMT
+      - Mon, 29 Oct 2018 21:36:28 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -975,16 +1121,16 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:09:56.569Z"
+         "modifiedTime": "2018-10-29T21:36:23.427Z"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:10:00 GMT
+  recorded_at: Mon, 29 Oct 2018 21:36:28 GMT
 - request:
-    method: post
-    uri: https://www.googleapis.com/drive/v3/files/1H5L_HEKwkrrpzR4WJqhe-bzJ8_mIihO2tYbQY9LTV4I/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1ENzYBTMuMypwChUKJih9XDWI-Fv4bSGrZH-VNuseJe8&s=AMedNnoAAAAAW9eZfLMsfqC8uefX_5RVWUkE50TVv5IL&sz=s350&v=1
     body:
       encoding: UTF-8
-      string: '{"name":"File","parents":["1YzqPQsLig8FeR-RWeEYF0FDEGcWh-gZD"]}'
+      string: ''
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -993,7 +1139,67 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:10:00 GMT
+      - Mon, 29 Oct 2018 21:36:28 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 29 Oct 2018 21:36:28 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:36:28 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1ENzYBTMuMypwChUKJih9XDWI-Fv4bSGrZH-VNuseJe8/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"File","parents":["1VwJY7LJ8Ma-mLhBAem54kMRGya62uHfz"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:36:28 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1010,7 +1216,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:10:01 GMT
+      - Mon, 29 Oct 2018 21:36:30 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1034,12 +1240,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "111uuRLK_fsLgcFATQhU0doMH7vX1Y3JRgKcySUXRXyg",
+         "id": "1CyHW38bShwqy_1B6DpY9C7CQ0MKf4t6puiX3GB0qE3E",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1YzqPQsLig8FeR-RWeEYF0FDEGcWh-gZD"
+          "1VwJY7LJ8Ma-mLhBAem54kMRGya62uHfz"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1064,10 +1270,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:10:01 GMT
+  recorded_at: Mon, 29 Oct 2018 21:36:30 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1H5L_HEKwkrrpzR4WJqhe-bzJ8_mIihO2tYbQY9LTV4I/permissions?fields=permissions/id,%20permissions/emailAddress
+    uri: https://www.googleapis.com/drive/v3/files/1ENzYBTMuMypwChUKJih9XDWI-Fv4bSGrZH-VNuseJe8/permissions?fields=permissions/id,%20permissions/emailAddress
     body:
       encoding: UTF-8
       string: ''
@@ -1079,7 +1285,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:10:01 GMT
+      - Mon, 29 Oct 2018 21:36:30 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1090,9 +1296,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:10:01 GMT
+      - Mon, 29 Oct 2018 21:36:31 GMT
       Date:
-      - Sat, 27 Oct 2018 00:10:01 GMT
+      - Mon, 29 Oct 2018 21:36:31 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1130,10 +1336,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:10:01 GMT
+  recorded_at: Mon, 29 Oct 2018 21:36:31 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1H5L_HEKwkrrpzR4WJqhe-bzJ8_mIihO2tYbQY9LTV4I/permissions/11673017242486491425
+    uri: https://www.googleapis.com/drive/v3/files/1ENzYBTMuMypwChUKJih9XDWI-Fv4bSGrZH-VNuseJe8/permissions/11673017242486491425
     body:
       encoding: UTF-8
       string: ''
@@ -1145,7 +1351,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:10:01 GMT
+      - Mon, 29 Oct 2018 21:36:31 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1162,7 +1368,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:10:02 GMT
+      - Mon, 29 Oct 2018 21:36:31 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1174,10 +1380,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:10:02 GMT
+  recorded_at: Mon, 29 Oct 2018 21:36:31 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=11059
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId,changes/file/parents&pageSize=100&pageToken=13209
     body:
       encoding: UTF-8
       string: ''
@@ -1189,7 +1395,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:02 GMT
+      - Mon, 29 Oct 2018 21:37:31 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1200,9 +1406,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:11:02 GMT
+      - Mon, 29 Oct 2018 21:37:32 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:02 GMT
+      - Mon, 29 Oct 2018 21:37:32 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1228,33 +1434,37 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "11070",
+         "newStartPageToken": "13219",
          "changes": [
           {
-           "fileId": "1_NWxM97RWgFKaSr-u2OR0Mpa-WKE5QArhmrq5pK5Guk"
+           "fileId": "1VwJY7LJ8Ma-mLhBAem54kMRGya62uHfz",
+           "file": {
+            "parents": [
+             "0AIeK5UAEPQfeUk9PVA"
+            ]
+           }
           },
           {
-           "fileId": "1YzqPQsLig8FeR-RWeEYF0FDEGcWh-gZD"
+           "fileId": "1ENzYBTMuMypwChUKJih9XDWI-Fv4bSGrZH-VNuseJe8"
           },
           {
-           "fileId": "1H5L_HEKwkrrpzR4WJqhe-bzJ8_mIihO2tYbQY9LTV4I"
+           "fileId": "15Qj6obGHheC-oY9dKWRchi1b3r3Sk0Qb"
           },
           {
-           "fileId": "124D3MGOml3RUGEgD3uYVWWEKrdvVZKBu"
-          },
-          {
-           "fileId": "111uuRLK_fsLgcFATQhU0doMH7vX1Y3JRgKcySUXRXyg"
-          },
-          {
-           "fileId": "14CRpMDS-yqtBQ9tuQzGajGql9Gjt108FkNoCxKUJVP8"
+           "fileId": "1CyHW38bShwqy_1B6DpY9C7CQ0MKf4t6puiX3GB0qE3E",
+           "file": {
+            "parents": [
+             "1VwJY7LJ8Ma-mLhBAem54kMRGya62uHfz"
+            ]
+           }
           }
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:02 GMT
+  recorded_at: Mon, 29 Oct 2018 21:37:32 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1_NWxM97RWgFKaSr-u2OR0Mpa-WKE5QArhmrq5pK5Guk?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ENzYBTMuMypwChUKJih9XDWI-Fv4bSGrZH-VNuseJe8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1266,7 +1476,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:02 GMT
+      - Mon, 29 Oct 2018 21:37:32 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1284,9 +1494,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:11:02 GMT
+      - Mon, 29 Oct 2018 21:37:32 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:11:02 GMT
+      - Mon, 29 Oct 2018 21:37:32 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1310,20 +1520,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1_NWxM97RWgFKaSr-u2OR0Mpa-WKE5QArhmrq5pK5Guk.",
+            "message": "File not found: 1ENzYBTMuMypwChUKJih9XDWI-Fv4bSGrZH-VNuseJe8.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1_NWxM97RWgFKaSr-u2OR0Mpa-WKE5QArhmrq5pK5Guk."
+          "message": "File not found: 1ENzYBTMuMypwChUKJih9XDWI-Fv4bSGrZH-VNuseJe8."
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:02 GMT
+  recorded_at: Mon, 29 Oct 2018 21:37:32 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1YzqPQsLig8FeR-RWeEYF0FDEGcWh-gZD?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/15Qj6obGHheC-oY9dKWRchi1b3r3Sk0Qb?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1335,7 +1545,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:02 GMT
+      - Mon, 29 Oct 2018 21:37:32 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1346,9 +1556,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:11:02 GMT
+      - Mon, 29 Oct 2018 21:37:32 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:02 GMT
+      - Mon, 29 Oct 2018 21:37:32 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1374,228 +1584,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1YzqPQsLig8FeR-RWeEYF0FDEGcWh-gZD",
-         "name": "10 Heart of Gold (Archive)",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:02 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1YzqPQsLig8FeR-RWeEYF0FDEGcWh-gZD/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:11:02 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:11:03 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:11:03 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:03 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1H5L_HEKwkrrpzR4WJqhe-bzJ8_mIihO2tYbQY9LTV4I?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:11:03 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:11:03 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:11:03 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "notFound",
-            "message": "File not found: 1H5L_HEKwkrrpzR4WJqhe-bzJ8_mIihO2tYbQY9LTV4I.",
-            "locationType": "parameter",
-            "location": "fileId"
-           }
-          ],
-          "code": 404,
-          "message": "File not found: 1H5L_HEKwkrrpzR4WJqhe-bzJ8_mIihO2tYbQY9LTV4I."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:03 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/124D3MGOml3RUGEgD3uYVWWEKrdvVZKBu?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:11:03 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:11:03 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:11:03 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "124D3MGOml3RUGEgD3uYVWWEKrdvVZKBu",
-         "name": "Test @ 2018-10-27 00:09:54 UTC",
+         "id": "15Qj6obGHheC-oY9dKWRchi1b3r3Sk0Qb",
+         "name": "Test @ 2018-10-29 21:36:21 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -1621,10 +1611,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:03 GMT
+  recorded_at: Mon, 29 Oct 2018 21:37:32 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/124D3MGOml3RUGEgD3uYVWWEKrdvVZKBu/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/15Qj6obGHheC-oY9dKWRchi1b3r3Sk0Qb/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1636,7 +1626,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:03 GMT
+      - Mon, 29 Oct 2018 21:37:32 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1654,9 +1644,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:11:03 GMT
+      - Mon, 29 Oct 2018 21:37:32 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:11:03 GMT
+      - Mon, 29 Oct 2018 21:37:32 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1688,420 +1678,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:03 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/111uuRLK_fsLgcFATQhU0doMH7vX1Y3JRgKcySUXRXyg?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:11:03 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:11:04 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:11:04 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "111uuRLK_fsLgcFATQhU0doMH7vX1Y3JRgKcySUXRXyg",
-         "name": "File",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1YzqPQsLig8FeR-RWeEYF0FDEGcWh-gZD"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=111uuRLK_fsLgcFATQhU0doMH7vX1Y3JRgKcySUXRXyg&v=1&s=AMedNnoAAAAAW9PJOKvwvcjuKKpQhIC9ndh8fR8k-fam&sz=s220",
-         "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:04 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/111uuRLK_fsLgcFATQhU0doMH7vX1Y3JRgKcySUXRXyg/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:11:04 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:11:04 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:11:04 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "kind": "drive#revision",
-         "id": "1",
-         "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:10:00.734Z"
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:04 GMT
-- request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=111uuRLK_fsLgcFATQhU0doMH7vX1Y3JRgKcySUXRXyg&s=AMedNnoAAAAAW9PJOKvwvcjuKKpQhIC9ndh8fR8k-fam&sz=s350&v=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:11:04 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Expose-Headers:
-      - Content-Length
-      Etag:
-      - '"v1"'
-      Expires:
-      - Fri, 01 Jan 1990 00:00:00 GMT
-      Cache-Control:
-      - private, max-age=86400, no-transform
-      Content-Disposition:
-      - inline;filename="unnamed.png"
-      Content-Type:
-      - image/png
-      Vary:
-      - Origin
-      Access-Control-Allow-Origin:
-      - "*"
-      Timing-Allow-Origin:
-      - "*"
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Sat, 27 Oct 2018 00:11:04 GMT
-      Server:
-      - fife
-      Content-Length:
-      - '1022'
-      X-Xss-Protection:
-      - 1; mode=block
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:04 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/14CRpMDS-yqtBQ9tuQzGajGql9Gjt108FkNoCxKUJVP8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:11:04 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:11:04 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:11:04 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "14CRpMDS-yqtBQ9tuQzGajGql9Gjt108FkNoCxKUJVP8",
-         "name": "File To Trash",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1BAE-wh1spM8vm7EuXNCn0jZqYfVnFyNE"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=14CRpMDS-yqtBQ9tuQzGajGql9Gjt108FkNoCxKUJVP8&v=1&s=AMedNnoAAAAAW9PJOMmfq1YWAe8hZtEIveSVxm01hJ_W&sz=s220",
-         "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:04 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/14CRpMDS-yqtBQ9tuQzGajGql9Gjt108FkNoCxKUJVP8/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:11:04 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:11:05 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:11:05 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "kind": "drive#revision",
-         "id": "1",
-         "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:06:22.124Z"
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:05 GMT
-- request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=14CRpMDS-yqtBQ9tuQzGajGql9Gjt108FkNoCxKUJVP8&s=AMedNnoAAAAAW9PJOMmfq1YWAe8hZtEIveSVxm01hJ_W&sz=s350&v=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:11:05 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Expose-Headers:
-      - Content-Length
-      Etag:
-      - '"v1"'
-      Expires:
-      - Fri, 01 Jan 1990 00:00:00 GMT
-      Cache-Control:
-      - private, max-age=86400, no-transform
-      Content-Disposition:
-      - inline;filename="unnamed.png"
-      Content-Type:
-      - image/png
-      Vary:
-      - Origin
-      Access-Control-Allow-Origin:
-      - "*"
-      Timing-Allow-Origin:
-      - "*"
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Sat, 27 Oct 2018 00:11:05 GMT
-      Server:
-      - fife
-      Content-Length:
-      - '1022'
-      X-Xss-Protection:
-      - 1; mode=block
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:05 GMT
+  recorded_at: Mon, 29 Oct 2018 21:37:32 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/124D3MGOml3RUGEgD3uYVWWEKrdvVZKBu
+    uri: https://www.googleapis.com/drive/v3/files/15Qj6obGHheC-oY9dKWRchi1b3r3Sk0Qb
     body:
       encoding: UTF-8
       string: ''
@@ -2113,7 +1693,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:05 GMT
+      - Mon, 29 Oct 2018 21:37:32 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -2130,7 +1710,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:06 GMT
+      - Mon, 29 Oct 2018 21:37:33 GMT
       Vary:
       - Origin
       - X-Origin
@@ -2142,5 +1722,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:06 GMT
+  recorded_at: Mon, 29 Oct 2018 21:37:33 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_trashes_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_trashes_file.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Sat, 27 Oct 2018 00:06:15 GMT
+      - Mon, 29 Oct 2018 21:37:34 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:15 GMT
+  recorded_at: Mon, 29 Oct 2018 21:37:34 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Sat, 27 Oct 2018 00:06:16 GMT
+      - Mon, 29 Oct 2018 21:37:34 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:16 GMT
+  recorded_at: Mon, 29 Oct 2018 21:37:34 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-27
-        00:06:16 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-29
+        21:37:34 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:06:16 GMT
+      - Mon, 29 Oct 2018 21:37:34 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:06:16 GMT
+      - Mon, 29 Oct 2018 21:37:35 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "18-6bKzdH0h5E8TBphdk8BY-axdtIDcXv",
-         "name": "Test @ 2018-10-27 00:06:16 UTC",
+         "id": "1PpyG9vUFxOT48xrjM-XeLcxCdq_FDo_O",
+         "name": "Test @ 2018-10-29 21:37:34 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:16 GMT
+  recorded_at: Mon, 29 Oct 2018 21:37:35 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/18-6bKzdH0h5E8TBphdk8BY-axdtIDcXv/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1PpyG9vUFxOT48xrjM-XeLcxCdq_FDo_O/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:06:16 GMT
+      - Mon, 29 Oct 2018 21:37:35 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:06:17 GMT
+      - Mon, 29 Oct 2018 21:37:36 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:17 GMT
+  recorded_at: Mon, 29 Oct 2018 21:37:36 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:06:17 GMT
+      - Mon, 29 Oct 2018 21:37:36 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:06:17 GMT
+      - Mon, 29 Oct 2018 21:37:36 GMT
       Date:
-      - Sat, 27 Oct 2018 00:06:17 GMT
+      - Mon, 29 Oct 2018 21:37:36 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,17 +302,17 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "11020"
+         "startPageToken": "13221"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:17 GMT
+  recorded_at: Mon, 29 Oct 2018 21:37:36 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.document","name":"File To
-        Trash","parents":["18-6bKzdH0h5E8TBphdk8BY-axdtIDcXv"]}'
+        Trash","parents":["1PpyG9vUFxOT48xrjM-XeLcxCdq_FDo_O"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -321,7 +321,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:06:17 GMT
+      - Mon, 29 Oct 2018 21:37:36 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -338,7 +338,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:06:18 GMT
+      - Mon, 29 Oct 2018 21:37:37 GMT
       Vary:
       - Origin
       - X-Origin
@@ -362,12 +362,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1iYi3yTGB2iCGNGl6G95zjTSBpDM5F-Eg8vs54_apkN8",
+         "id": "1IcY8em19Oj5C11s8kGkW4OFKUUmXiHKhWlhIYCI0A14",
          "name": "File To Trash",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "18-6bKzdH0h5E8TBphdk8BY-axdtIDcXv"
+          "1PpyG9vUFxOT48xrjM-XeLcxCdq_FDo_O"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -392,14 +392,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:18 GMT
+  recorded_at: Mon, 29 Oct 2018 21:37:38 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"7 Tanngrisnir
-        (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"8 RW6 (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -408,7 +407,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:06:18 GMT
+      - Mon, 29 Oct 2018 21:37:38 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -425,7 +424,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:06:19 GMT
+      - Mon, 29 Oct 2018 21:37:38 GMT
       Vary:
       - Origin
       - X-Origin
@@ -449,8 +448,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1BAE-wh1spM8vm7EuXNCn0jZqYfVnFyNE",
-         "name": "7 Tanngrisnir (Archive)",
+         "id": "1PHEdbPrlZEXk3JtbwaRHAPMEoshc5dyv",
+         "name": "8 RW6 (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -470,10 +469,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:19 GMT
+  recorded_at: Mon, 29 Oct 2018 21:37:38 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1BAE-wh1spM8vm7EuXNCn0jZqYfVnFyNE/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1PHEdbPrlZEXk3JtbwaRHAPMEoshc5dyv/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -485,7 +484,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:06:19 GMT
+      - Mon, 29 Oct 2018 21:37:38 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -502,7 +501,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:06:20 GMT
+      - Mon, 29 Oct 2018 21:37:39 GMT
       Vary:
       - Origin
       - X-Origin
@@ -532,10 +531,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:20 GMT
+  recorded_at: Mon, 29 Oct 2018 21:37:39 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1BAE-wh1spM8vm7EuXNCn0jZqYfVnFyNE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1PpyG9vUFxOT48xrjM-XeLcxCdq_FDo_O?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -547,7 +546,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:06:20 GMT
+      - Mon, 29 Oct 2018 21:37:39 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -558,9 +557,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:06:20 GMT
+      - Mon, 29 Oct 2018 21:37:39 GMT
       Date:
-      - Sat, 27 Oct 2018 00:06:20 GMT
+      - Mon, 29 Oct 2018 21:37:39 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -586,159 +585,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1BAE-wh1spM8vm7EuXNCn0jZqYfVnFyNE",
-         "name": "7 Tanngrisnir (Archive)",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:20 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1BAE-wh1spM8vm7EuXNCn0jZqYfVnFyNE/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:06:20 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:06:20 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:06:20 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:20 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/18-6bKzdH0h5E8TBphdk8BY-axdtIDcXv?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:06:20 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:06:20 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:06:20 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "18-6bKzdH0h5E8TBphdk8BY-axdtIDcXv",
-         "name": "Test @ 2018-10-27 00:06:16 UTC",
+         "id": "1PpyG9vUFxOT48xrjM-XeLcxCdq_FDo_O",
+         "name": "Test @ 2018-10-29 21:37:34 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -764,10 +612,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:20 GMT
+  recorded_at: Mon, 29 Oct 2018 21:37:39 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/18-6bKzdH0h5E8TBphdk8BY-axdtIDcXv/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1PpyG9vUFxOT48xrjM-XeLcxCdq_FDo_O/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -779,7 +627,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:06:20 GMT
+      - Mon, 29 Oct 2018 21:37:39 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -797,9 +645,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:06:20 GMT
+      - Mon, 29 Oct 2018 21:37:40 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:06:20 GMT
+      - Mon, 29 Oct 2018 21:37:40 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -831,10 +679,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:20 GMT
+  recorded_at: Mon, 29 Oct 2018 21:37:40 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%2718-6bKzdH0h5E8TBphdk8BY-axdtIDcXv%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files/1PpyG9vUFxOT48xrjM-XeLcxCdq_FDo_O?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -846,7 +694,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:06:20 GMT
+      - Mon, 29 Oct 2018 21:37:40 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -857,9 +705,305 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:06:21 GMT
+      - Mon, 29 Oct 2018 21:37:40 GMT
       Date:
-      - Sat, 27 Oct 2018 00:06:21 GMT
+      - Mon, 29 Oct 2018 21:37:40 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1PpyG9vUFxOT48xrjM-XeLcxCdq_FDo_O",
+         "name": "Test @ 2018-10-29 21:37:34 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:37:40 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1PpyG9vUFxOT48xrjM-XeLcxCdq_FDo_O/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:37:40 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 29 Oct 2018 21:37:40 GMT
+      Expires:
+      - Mon, 29 Oct 2018 21:37:40 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:37:40 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1PpyG9vUFxOT48xrjM-XeLcxCdq_FDo_O?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:37:40 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:37:40 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:37:40 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1PpyG9vUFxOT48xrjM-XeLcxCdq_FDo_O",
+         "name": "Test @ 2018-10-29 21:37:34 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:37:40 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1PpyG9vUFxOT48xrjM-XeLcxCdq_FDo_O/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:37:40 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 29 Oct 2018 21:37:40 GMT
+      Expires:
+      - Mon, 29 Oct 2018 21:37:40 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:37:40 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271PpyG9vUFxOT48xrjM-XeLcxCdq_FDo_O%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:37:40 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:37:41 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:37:41 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -887,14 +1031,15 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1iYi3yTGB2iCGNGl6G95zjTSBpDM5F-Eg8vs54_apkN8",
+           "id": "1IcY8em19Oj5C11s8kGkW4OFKUUmXiHKhWlhIYCI0A14",
            "name": "File To Trash",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "18-6bKzdH0h5E8TBphdk8BY-axdtIDcXv"
+            "1PpyG9vUFxOT48xrjM-XeLcxCdq_FDo_O"
            ],
-           "thumbnailVersion": "0",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1IcY8em19Oj5C11s8kGkW4OFKUUmXiHKhWlhIYCI0A14&v=1&s=AMedNnoAAAAAW9eZxankCu8dNarvi_e5LpyB3IZcKo1s&sz=s220",
+           "thumbnailVersion": "1",
            "permissions": [
             {
              "kind": "drive#permission",
@@ -919,10 +1064,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:21 GMT
+  recorded_at: Mon, 29 Oct 2018 21:37:41 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1iYi3yTGB2iCGNGl6G95zjTSBpDM5F-Eg8vs54_apkN8/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1IcY8em19Oj5C11s8kGkW4OFKUUmXiHKhWlhIYCI0A14/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -934,7 +1079,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:06:21 GMT
+      - Mon, 29 Oct 2018 21:37:41 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -945,9 +1090,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:06:21 GMT
+      - Mon, 29 Oct 2018 21:37:41 GMT
       Date:
-      - Sat, 27 Oct 2018 00:06:21 GMT
+      - Mon, 29 Oct 2018 21:37:41 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -976,186 +1121,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:06:17.765Z"
+         "modifiedTime": "2018-10-29T21:37:36.991Z"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:21 GMT
-- request:
-    method: post
-    uri: https://www.googleapis.com/drive/v3/files/1iYi3yTGB2iCGNGl6G95zjTSBpDM5F-Eg8vs54_apkN8/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: '{"name":"File To Trash","parents":["1BAE-wh1spM8vm7EuXNCn0jZqYfVnFyNE"]}'
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:06:21 GMT
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:06:22 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "14CRpMDS-yqtBQ9tuQzGajGql9Gjt108FkNoCxKUJVP8",
-         "name": "File To Trash",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1BAE-wh1spM8vm7EuXNCn0jZqYfVnFyNE"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:23 GMT
-- request:
-    method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1iYi3yTGB2iCGNGl6G95zjTSBpDM5F-Eg8vs54_apkN8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: '{"trashed":"true"}'
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:06:23 GMT
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:06:23 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1iYi3yTGB2iCGNGl6G95zjTSBpDM5F-Eg8vs54_apkN8",
-         "name": "File To Trash",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": true,
-         "parents": [
-          "18-6bKzdH0h5E8TBphdk8BY-axdtIDcXv"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1iYi3yTGB2iCGNGl6G95zjTSBpDM5F-Eg8vs54_apkN8&v=1&s=AMedNnoAAAAAW9PIH-Wl102rtgTI7kQNO94v-WluWTEl&sz=s220",
-         "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:06:23 GMT
+  recorded_at: Mon, 29 Oct 2018 21:37:41 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=11020
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1IcY8em19Oj5C11s8kGkW4OFKUUmXiHKhWlhIYCI0A14&s=AMedNnoAAAAAW9eZxankCu8dNarvi_e5LpyB3IZcKo1s&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1167,374 +1139,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:07:23 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:07:23 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:07:23 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "newStartPageToken": "11030",
-         "changes": [
-          {
-           "fileId": "1BAE-wh1spM8vm7EuXNCn0jZqYfVnFyNE"
-          },
-          {
-           "fileId": "14CRpMDS-yqtBQ9tuQzGajGql9Gjt108FkNoCxKUJVP8"
-          },
-          {
-           "fileId": "18-6bKzdH0h5E8TBphdk8BY-axdtIDcXv"
-          },
-          {
-           "fileId": "1iYi3yTGB2iCGNGl6G95zjTSBpDM5F-Eg8vs54_apkN8"
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:07:23 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1BAE-wh1spM8vm7EuXNCn0jZqYfVnFyNE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:07:23 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:07:24 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:07:24 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1BAE-wh1spM8vm7EuXNCn0jZqYfVnFyNE",
-         "name": "7 Tanngrisnir (Archive)",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:07:24 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1BAE-wh1spM8vm7EuXNCn0jZqYfVnFyNE/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:07:24 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:07:24 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:07:24 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:07:24 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/14CRpMDS-yqtBQ9tuQzGajGql9Gjt108FkNoCxKUJVP8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:07:24 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:07:24 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:07:24 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "14CRpMDS-yqtBQ9tuQzGajGql9Gjt108FkNoCxKUJVP8",
-         "name": "File To Trash",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1BAE-wh1spM8vm7EuXNCn0jZqYfVnFyNE"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=14CRpMDS-yqtBQ9tuQzGajGql9Gjt108FkNoCxKUJVP8&v=1&s=AMedNnoAAAAAW9PIXKKCCjTv0qJRiF_YDqgP6c0PQ6gh&sz=s220",
-         "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:07:24 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/14CRpMDS-yqtBQ9tuQzGajGql9Gjt108FkNoCxKUJVP8/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:07:24 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:07:24 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:07:24 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "kind": "drive#revision",
-         "id": "1",
-         "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:06:22.124Z"
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:07:24 GMT
-- request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=14CRpMDS-yqtBQ9tuQzGajGql9Gjt108FkNoCxKUJVP8&s=AMedNnoAAAAAW9PIXKKCCjTv0qJRiF_YDqgP6c0PQ6gh&sz=s350&v=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:07:24 GMT
+      - Mon, 29 Oct 2018 21:37:41 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1565,7 +1170,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Sat, 27 Oct 2018 00:07:25 GMT
+      - Mon, 29 Oct 2018 21:37:41 GMT
       Server:
       - fife
       Content-Length:
@@ -1579,10 +1184,183 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:07:25 GMT
+  recorded_at: Mon, 29 Oct 2018 21:37:41 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1IcY8em19Oj5C11s8kGkW4OFKUUmXiHKhWlhIYCI0A14/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"File To Trash","parents":["1PHEdbPrlZEXk3JtbwaRHAPMEoshc5dyv"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:37:41 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:37:43 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1BuT-lek0TzGY_6bI9u9_iSN_ijq6113GbNOrMzplseI",
+         "name": "File To Trash",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1PHEdbPrlZEXk3JtbwaRHAPMEoshc5dyv"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:37:43 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/drive/v3/files/1IcY8em19Oj5C11s8kGkW4OFKUUmXiHKhWlhIYCI0A14?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"trashed":"true"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:37:43 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:37:44 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1IcY8em19Oj5C11s8kGkW4OFKUUmXiHKhWlhIYCI0A14",
+         "name": "File To Trash",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": true,
+         "parents": [
+          "1PpyG9vUFxOT48xrjM-XeLcxCdq_FDo_O"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1IcY8em19Oj5C11s8kGkW4OFKUUmXiHKhWlhIYCI0A14&v=1&s=AMedNnoAAAAAW9eZyFZ2Z97-izOYcWS5_njGQlsKpSX4&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:37:44 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/18-6bKzdH0h5E8TBphdk8BY-axdtIDcXv?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId,changes/file/parents&pageSize=100&pageToken=13221
     body:
       encoding: UTF-8
       string: ''
@@ -1594,7 +1372,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:07:25 GMT
+      - Mon, 29 Oct 2018 21:38:44 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1605,9 +1383,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:07:25 GMT
+      - Mon, 29 Oct 2018 21:38:44 GMT
       Date:
-      - Sat, 27 Oct 2018 00:07:25 GMT
+      - Mon, 29 Oct 2018 21:38:44 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1633,8 +1411,94 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "18-6bKzdH0h5E8TBphdk8BY-axdtIDcXv",
-         "name": "Test @ 2018-10-27 00:06:16 UTC",
+         "newStartPageToken": "13230",
+         "changes": [
+          {
+           "fileId": "1PHEdbPrlZEXk3JtbwaRHAPMEoshc5dyv",
+           "file": {
+            "parents": [
+             "0AIeK5UAEPQfeUk9PVA"
+            ]
+           }
+          },
+          {
+           "fileId": "1BuT-lek0TzGY_6bI9u9_iSN_ijq6113GbNOrMzplseI",
+           "file": {
+            "parents": [
+             "1PHEdbPrlZEXk3JtbwaRHAPMEoshc5dyv"
+            ]
+           }
+          },
+          {
+           "fileId": "1PpyG9vUFxOT48xrjM-XeLcxCdq_FDo_O"
+          },
+          {
+           "fileId": "1IcY8em19Oj5C11s8kGkW4OFKUUmXiHKhWlhIYCI0A14",
+           "file": {
+            "parents": [
+             "1PpyG9vUFxOT48xrjM-XeLcxCdq_FDo_O"
+            ]
+           }
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:38:44 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1PpyG9vUFxOT48xrjM-XeLcxCdq_FDo_O?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:38:44 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:38:45 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:38:45 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1PpyG9vUFxOT48xrjM-XeLcxCdq_FDo_O",
+         "name": "Test @ 2018-10-29 21:37:34 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -1660,10 +1524,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:07:25 GMT
+  recorded_at: Mon, 29 Oct 2018 21:38:45 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/18-6bKzdH0h5E8TBphdk8BY-axdtIDcXv/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1PpyG9vUFxOT48xrjM-XeLcxCdq_FDo_O/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1675,7 +1539,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:07:25 GMT
+      - Mon, 29 Oct 2018 21:38:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1693,9 +1557,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:07:25 GMT
+      - Mon, 29 Oct 2018 21:38:45 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:07:25 GMT
+      - Mon, 29 Oct 2018 21:38:45 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1727,10 +1591,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:07:25 GMT
+  recorded_at: Mon, 29 Oct 2018 21:38:45 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1iYi3yTGB2iCGNGl6G95zjTSBpDM5F-Eg8vs54_apkN8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1IcY8em19Oj5C11s8kGkW4OFKUUmXiHKhWlhIYCI0A14?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1742,7 +1606,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:07:25 GMT
+      - Mon, 29 Oct 2018 21:38:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1753,9 +1617,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:07:25 GMT
+      - Mon, 29 Oct 2018 21:38:46 GMT
       Date:
-      - Sat, 27 Oct 2018 00:07:25 GMT
+      - Mon, 29 Oct 2018 21:38:46 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1781,14 +1645,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1iYi3yTGB2iCGNGl6G95zjTSBpDM5F-Eg8vs54_apkN8",
+         "id": "1IcY8em19Oj5C11s8kGkW4OFKUUmXiHKhWlhIYCI0A14",
          "name": "File To Trash",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": true,
          "parents": [
-          "18-6bKzdH0h5E8TBphdk8BY-axdtIDcXv"
+          "1PpyG9vUFxOT48xrjM-XeLcxCdq_FDo_O"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1iYi3yTGB2iCGNGl6G95zjTSBpDM5F-Eg8vs54_apkN8&v=1&s=AMedNnoAAAAAW9PIXXG39Fr2lmkqRNiU5iEQVWwtBB2M&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1IcY8em19Oj5C11s8kGkW4OFKUUmXiHKhWlhIYCI0A14&v=1&s=AMedNnoAAAAAW9eaBZ4BW-JdvFTMi55Kfeti6ovnnuGq&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -1812,10 +1676,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:07:26 GMT
+  recorded_at: Mon, 29 Oct 2018 21:38:46 GMT
 - request:
-    method: delete
-    uri: https://www.googleapis.com/drive/v3/files/18-6bKzdH0h5E8TBphdk8BY-axdtIDcXv
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1IcY8em19Oj5C11s8kGkW4OFKUUmXiHKhWlhIYCI0A14?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1827,7 +1691,92 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:07:26 GMT
+      - Mon, 29 Oct 2018 21:38:46 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:38:46 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:38:46 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1IcY8em19Oj5C11s8kGkW4OFKUUmXiHKhWlhIYCI0A14",
+         "name": "File To Trash",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": true,
+         "parents": [
+          "1PpyG9vUFxOT48xrjM-XeLcxCdq_FDo_O"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1IcY8em19Oj5C11s8kGkW4OFKUUmXiHKhWlhIYCI0A14&v=1&s=AMedNnoAAAAAW9eaBs1NeN2uX0fTaN5V-dJtrFdDx8b5&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:38:46 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1PpyG9vUFxOT48xrjM-XeLcxCdq_FDo_O
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:38:46 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1844,7 +1793,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:07:26 GMT
+      - Mon, 29 Oct 2018 21:38:46 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1856,5 +1805,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:07:26 GMT
+  recorded_at: Mon, 29 Oct 2018 21:38:46 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_updates_file_content.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_updates_file_content.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Sat, 27 Oct 2018 00:02:26 GMT
+      - Mon, 29 Oct 2018 21:27:51 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:26 GMT
+  recorded_at: Mon, 29 Oct 2018 21:27:52 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Sat, 27 Oct 2018 00:02:26 GMT
+      - Mon, 29 Oct 2018 21:27:52 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:26 GMT
+  recorded_at: Mon, 29 Oct 2018 21:27:52 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-27
-        00:02:27 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-29
+        21:27:52 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:02:27 GMT
+      - Mon, 29 Oct 2018 21:27:52 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:02:27 GMT
+      - Mon, 29 Oct 2018 21:27:54 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1wEFuxX4HbB-f69sjWrVkHKSebSa9x4q7",
-         "name": "Test @ 2018-10-27 00:02:27 UTC",
+         "id": "1HAwWmbMpL27eR8Fu_ihTZXl3ICaJPujC",
+         "name": "Test @ 2018-10-29 21:27:52 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:27 GMT
+  recorded_at: Mon, 29 Oct 2018 21:27:54 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1wEFuxX4HbB-f69sjWrVkHKSebSa9x4q7/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1HAwWmbMpL27eR8Fu_ihTZXl3ICaJPujC/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:02:27 GMT
+      - Mon, 29 Oct 2018 21:27:54 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:02:28 GMT
+      - Mon, 29 Oct 2018 21:27:55 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:28 GMT
+  recorded_at: Mon, 29 Oct 2018 21:27:56 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:02:28 GMT
+      - Mon, 29 Oct 2018 21:27:56 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:02:28 GMT
+      - Mon, 29 Oct 2018 21:27:57 GMT
       Date:
-      - Sat, 27 Oct 2018 00:02:28 GMT
+      - Mon, 29 Oct 2018 21:27:57 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,16 +302,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "10976"
+         "startPageToken": "13114"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:28 GMT
+  recorded_at: Mon, 29 Oct 2018 21:27:57 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1wEFuxX4HbB-f69sjWrVkHKSebSa9x4q7"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1HAwWmbMpL27eR8Fu_ihTZXl3ICaJPujC"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -320,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:02:28 GMT
+      - Mon, 29 Oct 2018 21:27:58 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -337,7 +337,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:02:30 GMT
+      - Mon, 29 Oct 2018 21:28:00 GMT
       Vary:
       - Origin
       - X-Origin
@@ -361,12 +361,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1UzsfkIvPgGZzLNQjZstvePzozvRaZMXUOmaf51YOho8",
+         "id": "1PNim4B_r4BFFj8HXFTE6fIWJbx6iBVowgIgmIjH7DHI",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1wEFuxX4HbB-f69sjWrVkHKSebSa9x4q7"
+          "1HAwWmbMpL27eR8Fu_ihTZXl3ICaJPujC"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -391,13 +391,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:31 GMT
+  recorded_at: Mon, 29 Oct 2018 21:28:00 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"4 Starship
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"1 Starship
         Titanic (Archive)","parents":["root"]}'
     headers:
       User-Agent:
@@ -407,7 +407,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:02:31 GMT
+      - Mon, 29 Oct 2018 21:28:00 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -424,7 +424,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:02:31 GMT
+      - Mon, 29 Oct 2018 21:28:00 GMT
       Vary:
       - Origin
       - X-Origin
@@ -448,8 +448,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1h_RSdb_1zKB3cxLwAtprK2OYHfUNszbD",
-         "name": "4 Starship Titanic (Archive)",
+         "id": "1uCIUWQaSiHTRMBEGB80-3OsZnvat6duo",
+         "name": "1 Starship Titanic (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -469,10 +469,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:31 GMT
+  recorded_at: Mon, 29 Oct 2018 21:28:00 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1h_RSdb_1zKB3cxLwAtprK2OYHfUNszbD/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1uCIUWQaSiHTRMBEGB80-3OsZnvat6duo/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -484,7 +484,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:02:31 GMT
+      - Mon, 29 Oct 2018 21:28:00 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -501,7 +501,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:02:32 GMT
+      - Mon, 29 Oct 2018 21:28:01 GMT
       Vary:
       - Origin
       - X-Origin
@@ -531,10 +531,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:32 GMT
+  recorded_at: Mon, 29 Oct 2018 21:28:01 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1h_RSdb_1zKB3cxLwAtprK2OYHfUNszbD?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1HAwWmbMpL27eR8Fu_ihTZXl3ICaJPujC?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -546,7 +546,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:02:32 GMT
+      - Mon, 29 Oct 2018 21:28:01 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -557,9 +557,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:02:33 GMT
+      - Mon, 29 Oct 2018 21:28:02 GMT
       Date:
-      - Sat, 27 Oct 2018 00:02:33 GMT
+      - Mon, 29 Oct 2018 21:28:02 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -585,159 +585,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1h_RSdb_1zKB3cxLwAtprK2OYHfUNszbD",
-         "name": "4 Starship Titanic (Archive)",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:33 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1h_RSdb_1zKB3cxLwAtprK2OYHfUNszbD/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:02:33 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:02:33 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:02:33 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:33 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1wEFuxX4HbB-f69sjWrVkHKSebSa9x4q7?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:02:33 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:02:33 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:02:33 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1wEFuxX4HbB-f69sjWrVkHKSebSa9x4q7",
-         "name": "Test @ 2018-10-27 00:02:27 UTC",
+         "id": "1HAwWmbMpL27eR8Fu_ihTZXl3ICaJPujC",
+         "name": "Test @ 2018-10-29 21:27:52 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -763,10 +612,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:33 GMT
+  recorded_at: Mon, 29 Oct 2018 21:28:02 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1wEFuxX4HbB-f69sjWrVkHKSebSa9x4q7/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1HAwWmbMpL27eR8Fu_ihTZXl3ICaJPujC/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -778,7 +627,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:02:33 GMT
+      - Mon, 29 Oct 2018 21:28:02 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -796,9 +645,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:02:33 GMT
+      - Mon, 29 Oct 2018 21:28:02 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:02:33 GMT
+      - Mon, 29 Oct 2018 21:28:02 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -830,10 +679,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:33 GMT
+  recorded_at: Mon, 29 Oct 2018 21:28:02 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271wEFuxX4HbB-f69sjWrVkHKSebSa9x4q7%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files/1HAwWmbMpL27eR8Fu_ihTZXl3ICaJPujC?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -845,7 +694,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:02:33 GMT
+      - Mon, 29 Oct 2018 21:28:02 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -856,9 +705,305 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:02:33 GMT
+      - Mon, 29 Oct 2018 21:28:02 GMT
       Date:
-      - Sat, 27 Oct 2018 00:02:33 GMT
+      - Mon, 29 Oct 2018 21:28:02 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1HAwWmbMpL27eR8Fu_ihTZXl3ICaJPujC",
+         "name": "Test @ 2018-10-29 21:27:52 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:28:02 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1HAwWmbMpL27eR8Fu_ihTZXl3ICaJPujC/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:28:02 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 29 Oct 2018 21:28:02 GMT
+      Expires:
+      - Mon, 29 Oct 2018 21:28:02 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:28:02 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1HAwWmbMpL27eR8Fu_ihTZXl3ICaJPujC?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:28:02 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:28:02 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:28:02 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1HAwWmbMpL27eR8Fu_ihTZXl3ICaJPujC",
+         "name": "Test @ 2018-10-29 21:27:52 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:28:02 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1HAwWmbMpL27eR8Fu_ihTZXl3ICaJPujC/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:28:02 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 29 Oct 2018 21:28:03 GMT
+      Expires:
+      - Mon, 29 Oct 2018 21:28:03 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:28:03 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271HAwWmbMpL27eR8Fu_ihTZXl3ICaJPujC%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:28:03 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:28:03 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:28:03 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -886,14 +1031,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1UzsfkIvPgGZzLNQjZstvePzozvRaZMXUOmaf51YOho8",
+           "id": "1PNim4B_r4BFFj8HXFTE6fIWJbx6iBVowgIgmIjH7DHI",
            "name": "File",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1wEFuxX4HbB-f69sjWrVkHKSebSa9x4q7"
+            "1HAwWmbMpL27eR8Fu_ihTZXl3ICaJPujC"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1UzsfkIvPgGZzLNQjZstvePzozvRaZMXUOmaf51YOho8&v=1&s=AMedNnoAAAAAW9PHOViZ3wyc3xwl6rCxV6eyblhYnCKF&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1PNim4B_r4BFFj8HXFTE6fIWJbx6iBVowgIgmIjH7DHI&v=1&s=AMedNnoAAAAAW9eXg_ls99sr1z1VuVJhhaAJI30pHNIl&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -919,10 +1064,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:34 GMT
+  recorded_at: Mon, 29 Oct 2018 21:28:03 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1UzsfkIvPgGZzLNQjZstvePzozvRaZMXUOmaf51YOho8/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1PNim4B_r4BFFj8HXFTE6fIWJbx6iBVowgIgmIjH7DHI/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -934,7 +1079,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:02:34 GMT
+      - Mon, 29 Oct 2018 21:28:03 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -945,9 +1090,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:02:34 GMT
+      - Mon, 29 Oct 2018 21:28:03 GMT
       Date:
-      - Sat, 27 Oct 2018 00:02:34 GMT
+      - Mon, 29 Oct 2018 21:28:03 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -976,13 +1121,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:02:29.829Z"
+         "modifiedTime": "2018-10-29T21:27:59.117Z"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:34 GMT
+  recorded_at: Mon, 29 Oct 2018 21:28:03 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1UzsfkIvPgGZzLNQjZstvePzozvRaZMXUOmaf51YOho8&s=AMedNnoAAAAAW9PHOViZ3wyc3xwl6rCxV6eyblhYnCKF&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1PNim4B_r4BFFj8HXFTE6fIWJbx6iBVowgIgmIjH7DHI&s=AMedNnoAAAAAW9eXg_ls99sr1z1VuVJhhaAJI30pHNIl&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -994,7 +1139,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:02:34 GMT
+      - Mon, 29 Oct 2018 21:28:03 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1025,7 +1170,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Sat, 27 Oct 2018 00:02:34 GMT
+      - Mon, 29 Oct 2018 21:28:04 GMT
       Server:
       - fife
       Content-Length:
@@ -1039,13 +1184,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:34 GMT
+  recorded_at: Mon, 29 Oct 2018 21:28:04 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1UzsfkIvPgGZzLNQjZstvePzozvRaZMXUOmaf51YOho8/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1PNim4B_r4BFFj8HXFTE6fIWJbx6iBVowgIgmIjH7DHI/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"File","parents":["1h_RSdb_1zKB3cxLwAtprK2OYHfUNszbD"]}'
+      string: '{"name":"File","parents":["1uCIUWQaSiHTRMBEGB80-3OsZnvat6duo"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1054,7 +1199,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:02:34 GMT
+      - Mon, 29 Oct 2018 21:28:04 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1071,7 +1216,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:02:36 GMT
+      - Mon, 29 Oct 2018 21:28:06 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1095,12 +1240,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "18WWLEIMsREk1eOiowkJ5T1IMht1TgaPWC-KqIJAsQGQ",
+         "id": "1Tk66KdMSu1VNAAxm3v_dgq53linEsys18_0INMZG5nw",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1h_RSdb_1zKB3cxLwAtprK2OYHfUNszbD"
+          "1uCIUWQaSiHTRMBEGB80-3OsZnvat6duo"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1125,10 +1270,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:36 GMT
+  recorded_at: Mon, 29 Oct 2018 21:28:06 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/upload/drive/v3/files/1UzsfkIvPgGZzLNQjZstvePzozvRaZMXUOmaf51YOho8
+    uri: https://www.googleapis.com/upload/drive/v3/files/1PNim4B_r4BFFj8HXFTE6fIWJbx6iBVowgIgmIjH7DHI
     body:
       encoding: UTF-8
       string: ''
@@ -1140,7 +1285,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:02:36 GMT
+      - Mon, 29 Oct 2018 21:28:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       X-Goog-Upload-Protocol:
@@ -1159,22 +1304,22 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2Ur1wgwChYPDZ6vrGX4NP2-ruPws9_w25eS53GNGEgUSVHtMXfj4HEWUWsChpe2-fNeigWCJQTH-fiCMP8wxKUZ7dIiiJYYu-Piy9mHODQi6hVSnBR4
+      - AEnB2UrfU_uliWAJHnS-Utj-zUx2mEZW6A-CozEfHWQyXgx3Jopoufk0Uj8Wxj1eRYaz4ogbwq-hhY7rqr_WnaQygEjfQt58JGiX5Z0HAiM8yw5LCeZN9Vs
       X-Goog-Upload-Status:
       - active
       X-Goog-Upload-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1UzsfkIvPgGZzLNQjZstvePzozvRaZMXUOmaf51YOho8?upload_id=AEnB2Ur1wgwChYPDZ6vrGX4NP2-ruPws9_w25eS53GNGEgUSVHtMXfj4HEWUWsChpe2-fNeigWCJQTH-fiCMP8wxKUZ7dIiiJYYu-Piy9mHODQi6hVSnBR4&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1PNim4B_r4BFFj8HXFTE6fIWJbx6iBVowgIgmIjH7DHI?upload_id=AEnB2UrfU_uliWAJHnS-Utj-zUx2mEZW6A-CozEfHWQyXgx3Jopoufk0Uj8Wxj1eRYaz4ogbwq-hhY7rqr_WnaQygEjfQt58JGiX5Z0HAiM8yw5LCeZN9Vs&upload_protocol=resumable
       X-Goog-Upload-Control-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1UzsfkIvPgGZzLNQjZstvePzozvRaZMXUOmaf51YOho8?upload_id=AEnB2Ur1wgwChYPDZ6vrGX4NP2-ruPws9_w25eS53GNGEgUSVHtMXfj4HEWUWsChpe2-fNeigWCJQTH-fiCMP8wxKUZ7dIiiJYYu-Piy9mHODQi6hVSnBR4&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1PNim4B_r4BFFj8HXFTE6fIWJbx6iBVowgIgmIjH7DHI?upload_id=AEnB2UrfU_uliWAJHnS-Utj-zUx2mEZW6A-CozEfHWQyXgx3Jopoufk0Uj8Wxj1eRYaz4ogbwq-hhY7rqr_WnaQygEjfQt58JGiX5Z0HAiM8yw5LCeZN9Vs&upload_protocol=resumable
       X-Goog-Upload-Chunk-Granularity:
       - '262144'
       X-Goog-Upload-Header-Vary:
       - Origin
       - X-Origin
       X-Goog-Upload-Header-X-Google-Backends:
-      - iopd1:4153
+      - oias185:4054
       X-Goog-Upload-Header-X-Google-Session-Info:
-      - CKeBxoimHBoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x4Q0JnRmtKVnR0aTVDRHFwaTBLRDZqLWpGaFFPVlJtaHFJcnAtb3ZxY3FfaWcxNFlMSk51dF9zRHN2MW1pYTJvSFFwZHZDOTRmbmw4QU0xc2lDcEViOHB1UUZvYUxvODRNVG9KME1LaEJTRWRKUHkxOVFVdFB4dU1lVFhBMAQ6DTEvSWFuUWZrd3Q0TX4
+      - CKeBxoimHBoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x4RkJrZlEtNm05ZDRwaDM3UFl1RGJTWngtU2VxOU1LMlpieS1SWTJkcHZDMXhuMERjLTVXaFp5MGd1MW13dy16bGFDRzZvb2RabUlFemNUWWVXZlEtWVBWU01zSnFjOFJYRjB3RjNDTkgtdUh0Y2oxYTFHZjR5WXFOdFBnMAQ6DTEvSWFuUWZrd3Q0TX4
       X-Goog-Upload-Header-Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       X-Goog-Upload-Header-Pragma:
@@ -1182,11 +1327,11 @@ http_interactions:
       X-Goog-Upload-Header-Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       X-Goog-Upload-Header-Date:
-      - Sat, 27 Oct 2018 00:02:36 GMT
+      - Mon, 29 Oct 2018 21:28:06 GMT
       Content-Length:
       - '0'
       Date:
-      - Sat, 27 Oct 2018 00:02:36 GMT
+      - Mon, 29 Oct 2018 21:28:06 GMT
       Server:
       - UploadServer
       Content-Type:
@@ -1197,10 +1342,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:36 GMT
+  recorded_at: Mon, 29 Oct 2018 21:28:06 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/upload/drive/v3/files/1UzsfkIvPgGZzLNQjZstvePzozvRaZMXUOmaf51YOho8?upload_id=AEnB2Ur1wgwChYPDZ6vrGX4NP2-ruPws9_w25eS53GNGEgUSVHtMXfj4HEWUWsChpe2-fNeigWCJQTH-fiCMP8wxKUZ7dIiiJYYu-Piy9mHODQi6hVSnBR4&upload_protocol=resumable
+    uri: https://www.googleapis.com/upload/drive/v3/files/1PNim4B_r4BFFj8HXFTE6fIWJbx6iBVowgIgmIjH7DHI?upload_id=AEnB2UrfU_uliWAJHnS-Utj-zUx2mEZW6A-CozEfHWQyXgx3Jopoufk0Uj8Wxj1eRYaz4ogbwq-hhY7rqr_WnaQygEjfQt58JGiX5Z0HAiM8yw5LCeZN9Vs&upload_protocol=resumable
     body:
       encoding: UTF-8
       string: new file content
@@ -1212,7 +1357,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:02:36 GMT
+      - Mon, 29 Oct 2018 21:28:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       X-Goog-Upload-Command:
@@ -1227,7 +1372,7 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2Ur1wgwChYPDZ6vrGX4NP2-ruPws9_w25eS53GNGEgUSVHtMXfj4HEWUWsChpe2-fNeigWCJQTH-fiCMP8wxKUZ7dIiiJYYu-Piy9mHODQi6hVSnBR4
+      - AEnB2UrfU_uliWAJHnS-Utj-zUx2mEZW6A-CozEfHWQyXgx3Jopoufk0Uj8Wxj1eRYaz4ogbwq-hhY7rqr_WnaQygEjfQt58JGiX5Z0HAiM8yw5LCeZN9Vs
       X-Goog-Upload-Status:
       - final
       Vary:
@@ -1242,7 +1387,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:02:38 GMT
+      - Mon, 29 Oct 2018 21:28:07 GMT
       Content-Length:
       - '151'
       Server:
@@ -1254,15 +1399,15 @@ http_interactions:
       string: |
         {
          "kind": "drive#file",
-         "id": "1UzsfkIvPgGZzLNQjZstvePzozvRaZMXUOmaf51YOho8",
+         "id": "1PNim4B_r4BFFj8HXFTE6fIWJbx6iBVowgIgmIjH7DHI",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:02:38 GMT
+  recorded_at: Mon, 29 Oct 2018 21:28:07 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId&pageSize=100&pageToken=10976
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId,changes/file/parents&pageSize=100&pageToken=13114
     body:
       encoding: UTF-8
       string: ''
@@ -1274,7 +1419,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:03:38 GMT
+      - Mon, 29 Oct 2018 21:29:07 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1285,9 +1430,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:03:38 GMT
+      - Mon, 29 Oct 2018 21:29:10 GMT
       Date:
-      - Sat, 27 Oct 2018 00:03:38 GMT
+      - Mon, 29 Oct 2018 21:29:10 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1313,36 +1458,42 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "10989",
+         "newStartPageToken": "13123",
          "changes": [
           {
-           "fileId": "1ri-G3xeC4Psp6wgFwKXre6jGR8nmnxUS"
+           "fileId": "1uCIUWQaSiHTRMBEGB80-3OsZnvat6duo",
+           "file": {
+            "parents": [
+             "0AIeK5UAEPQfeUk9PVA"
+            ]
+           }
           },
           {
-           "fileId": "1uNuG3SHIhi7AaSGSMiWOVwlzup4xiy_rjq1ko6UrjJs"
+           "fileId": "1Tk66KdMSu1VNAAxm3v_dgq53linEsys18_0INMZG5nw",
+           "file": {
+            "parents": [
+             "1uCIUWQaSiHTRMBEGB80-3OsZnvat6duo"
+            ]
+           }
           },
           {
-           "fileId": "1h_RSdb_1zKB3cxLwAtprK2OYHfUNszbD"
+           "fileId": "1HAwWmbMpL27eR8Fu_ihTZXl3ICaJPujC"
           },
           {
-           "fileId": "18WWLEIMsREk1eOiowkJ5T1IMht1TgaPWC-KqIJAsQGQ"
-          },
-          {
-           "fileId": "19ZKDJSSjoRbf8AGi6YTNcYgMZoa5R0E3qhzFDav8_W4"
-          },
-          {
-           "fileId": "1wEFuxX4HbB-f69sjWrVkHKSebSa9x4q7"
-          },
-          {
-           "fileId": "1UzsfkIvPgGZzLNQjZstvePzozvRaZMXUOmaf51YOho8"
+           "fileId": "1PNim4B_r4BFFj8HXFTE6fIWJbx6iBVowgIgmIjH7DHI",
+           "file": {
+            "parents": [
+             "1HAwWmbMpL27eR8Fu_ihTZXl3ICaJPujC"
+            ]
+           }
           }
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:38 GMT
+  recorded_at: Mon, 29 Oct 2018 21:29:10 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1ri-G3xeC4Psp6wgFwKXre6jGR8nmnxUS?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1HAwWmbMpL27eR8Fu_ihTZXl3ICaJPujC?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1354,145 +1505,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:03:38 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:03:38 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:03:38 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "notFound",
-            "message": "File not found: 1ri-G3xeC4Psp6wgFwKXre6jGR8nmnxUS.",
-            "locationType": "parameter",
-            "location": "fileId"
-           }
-          ],
-          "code": 404,
-          "message": "File not found: 1ri-G3xeC4Psp6wgFwKXre6jGR8nmnxUS."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:38 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1uNuG3SHIhi7AaSGSMiWOVwlzup4xiy_rjq1ko6UrjJs?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:03:38 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:03:39 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:03:39 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "notFound",
-            "message": "File not found: 1uNuG3SHIhi7AaSGSMiWOVwlzup4xiy_rjq1ko6UrjJs.",
-            "locationType": "parameter",
-            "location": "fileId"
-           }
-          ],
-          "code": 404,
-          "message": "File not found: 1uNuG3SHIhi7AaSGSMiWOVwlzup4xiy_rjq1ko6UrjJs."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:39 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1h_RSdb_1zKB3cxLwAtprK2OYHfUNszbD?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:03:39 GMT
+      - Mon, 29 Oct 2018 21:29:10 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1503,9 +1516,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:03:39 GMT
+      - Mon, 29 Oct 2018 21:29:11 GMT
       Date:
-      - Sat, 27 Oct 2018 00:03:39 GMT
+      - Mon, 29 Oct 2018 21:29:11 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1531,40 +1544,37 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1h_RSdb_1zKB3cxLwAtprK2OYHfUNszbD",
-         "name": "4 Starship Titanic (Archive)",
+         "id": "1HAwWmbMpL27eR8Fu_ihTZXl3ICaJPujC",
+         "name": "Test @ 2018-10-29 21:27:52 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
          "thumbnailVersion": "0",
          "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
           {
            "kind": "drive#permission",
            "id": "11673017242486491425",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
+           "role": "writer",
            "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
            "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:39 GMT
+  recorded_at: Mon, 29 Oct 2018 21:29:11 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1h_RSdb_1zKB3cxLwAtprK2OYHfUNszbD/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1HAwWmbMpL27eR8Fu_ihTZXl3ICaJPujC/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1576,7 +1586,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:03:39 GMT
+      - Mon, 29 Oct 2018 21:29:11 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1594,9 +1604,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:03:39 GMT
+      - Mon, 29 Oct 2018 21:29:11 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:03:39 GMT
+      - Mon, 29 Oct 2018 21:29:11 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1628,10 +1638,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:39 GMT
+  recorded_at: Mon, 29 Oct 2018 21:29:11 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/18WWLEIMsREk1eOiowkJ5T1IMht1TgaPWC-KqIJAsQGQ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1PNim4B_r4BFFj8HXFTE6fIWJbx6iBVowgIgmIjH7DHI?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1643,7 +1653,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:03:39 GMT
+      - Mon, 29 Oct 2018 21:29:11 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1654,9 +1664,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:03:39 GMT
+      - Mon, 29 Oct 2018 21:29:11 GMT
       Date:
-      - Sat, 27 Oct 2018 00:03:39 GMT
+      - Mon, 29 Oct 2018 21:29:11 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1682,572 +1692,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "18WWLEIMsREk1eOiowkJ5T1IMht1TgaPWC-KqIJAsQGQ",
+         "id": "1PNim4B_r4BFFj8HXFTE6fIWJbx6iBVowgIgmIjH7DHI",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1h_RSdb_1zKB3cxLwAtprK2OYHfUNszbD"
+          "1HAwWmbMpL27eR8Fu_ihTZXl3ICaJPujC"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=18WWLEIMsREk1eOiowkJ5T1IMht1TgaPWC-KqIJAsQGQ&v=1&s=AMedNnoAAAAAW9PHe1SJD0b7xhGWP1VNbhY1b7xCbNwQ&sz=s220",
-         "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:39 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/18WWLEIMsREk1eOiowkJ5T1IMht1TgaPWC-KqIJAsQGQ/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:03:39 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:03:39 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:03:39 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "kind": "drive#revision",
-         "id": "1",
-         "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:02:35.456Z"
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:39 GMT
-- request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=18WWLEIMsREk1eOiowkJ5T1IMht1TgaPWC-KqIJAsQGQ&s=AMedNnoAAAAAW9PHe1SJD0b7xhGWP1VNbhY1b7xCbNwQ&sz=s350&v=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:03:39 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Expose-Headers:
-      - Content-Length
-      Etag:
-      - '"v1"'
-      Expires:
-      - Fri, 01 Jan 1990 00:00:00 GMT
-      Cache-Control:
-      - private, max-age=86400, no-transform
-      Content-Disposition:
-      - inline;filename="unnamed.png"
-      Content-Type:
-      - image/png
-      Vary:
-      - Origin
-      Access-Control-Allow-Origin:
-      - "*"
-      Timing-Allow-Origin:
-      - "*"
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Sat, 27 Oct 2018 00:03:40 GMT
-      Server:
-      - fife
-      Content-Length:
-      - '1022'
-      X-Xss-Protection:
-      - 1; mode=block
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:40 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/19ZKDJSSjoRbf8AGi6YTNcYgMZoa5R0E3qhzFDav8_W4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:03:40 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:03:40 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:03:40 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "19ZKDJSSjoRbf8AGi6YTNcYgMZoa5R0E3qhzFDav8_W4",
-         "name": "File To Move",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1t7g6pQ1KPAX8GqLzJNlz8CHe22qvqsuE"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=19ZKDJSSjoRbf8AGi6YTNcYgMZoa5R0E3qhzFDav8_W4&v=1&s=AMedNnoAAAAAW9PHfHlMA1C1nbmkNaKRjGHD_IW2upYO&sz=s220",
-         "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:40 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/19ZKDJSSjoRbf8AGi6YTNcYgMZoa5R0E3qhzFDav8_W4/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:03:40 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:03:40 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:03:40 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "kind": "drive#revision",
-         "id": "1",
-         "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:00:01.292Z"
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:40 GMT
-- request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=19ZKDJSSjoRbf8AGi6YTNcYgMZoa5R0E3qhzFDav8_W4&s=AMedNnoAAAAAW9PHfHlMA1C1nbmkNaKRjGHD_IW2upYO&sz=s350&v=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:03:40 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Expose-Headers:
-      - Content-Length
-      Etag:
-      - '"v1"'
-      Expires:
-      - Fri, 01 Jan 1990 00:00:00 GMT
-      Cache-Control:
-      - private, max-age=86400, no-transform
-      Content-Disposition:
-      - inline;filename="unnamed.png"
-      Content-Type:
-      - image/png
-      Vary:
-      - Origin
-      Access-Control-Allow-Origin:
-      - "*"
-      Timing-Allow-Origin:
-      - "*"
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Sat, 27 Oct 2018 00:03:40 GMT
-      Server:
-      - fife
-      Content-Length:
-      - '1022'
-      X-Xss-Protection:
-      - 1; mode=block
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:40 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1wEFuxX4HbB-f69sjWrVkHKSebSa9x4q7?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:03:41 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:03:41 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:03:41 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1wEFuxX4HbB-f69sjWrVkHKSebSa9x4q7",
-         "name": "Test @ 2018-10-27 00:02:27 UTC",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:41 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1wEFuxX4HbB-f69sjWrVkHKSebSa9x4q7/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:03:41 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:03:41 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:03:41 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:41 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1UzsfkIvPgGZzLNQjZstvePzozvRaZMXUOmaf51YOho8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:03:41 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:03:41 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:03:41 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1UzsfkIvPgGZzLNQjZstvePzozvRaZMXUOmaf51YOho8",
-         "name": "File",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1wEFuxX4HbB-f69sjWrVkHKSebSa9x4q7"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1UzsfkIvPgGZzLNQjZstvePzozvRaZMXUOmaf51YOho8&v=1&s=AMedNnoAAAAAW9PHfVU91FwRQbhgnZvnFeSXg9nkX388&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1PNim4B_r4BFFj8HXFTE6fIWJbx6iBVowgIgmIjH7DHI&v=1&s=AMedNnoAAAAAW9eXx1D8_U8vuGZIKXtuaPF9AMsJ3VCi&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -2271,10 +1723,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:41 GMT
+  recorded_at: Mon, 29 Oct 2018 21:29:11 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1UzsfkIvPgGZzLNQjZstvePzozvRaZMXUOmaf51YOho8/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1PNim4B_r4BFFj8HXFTE6fIWJbx6iBVowgIgmIjH7DHI/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -2286,7 +1738,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:03:41 GMT
+      - Mon, 29 Oct 2018 21:29:11 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2297,9 +1749,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:03:42 GMT
+      - Mon, 29 Oct 2018 21:29:11 GMT
       Date:
-      - Sat, 27 Oct 2018 00:03:42 GMT
+      - Mon, 29 Oct 2018 21:29:11 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -2328,16 +1780,16 @@ http_interactions:
          "kind": "drive#revision",
          "id": "3",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:02:37.686Z"
+         "modifiedTime": "2018-10-29T21:28:07.297Z"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:42 GMT
+  recorded_at: Mon, 29 Oct 2018 21:29:11 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1UzsfkIvPgGZzLNQjZstvePzozvRaZMXUOmaf51YOho8/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1PNim4B_r4BFFj8HXFTE6fIWJbx6iBVowgIgmIjH7DHI/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"File","parents":["1h_RSdb_1zKB3cxLwAtprK2OYHfUNszbD"]}'
+      string: '{"name":"File","parents":["1uCIUWQaSiHTRMBEGB80-3OsZnvat6duo"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -2346,7 +1798,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:03:42 GMT
+      - Mon, 29 Oct 2018 21:29:11 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -2363,7 +1815,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:03:43 GMT
+      - Mon, 29 Oct 2018 21:29:13 GMT
       Vary:
       - Origin
       - X-Origin
@@ -2387,12 +1839,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1hqihjTC6H38OdLpeslzL-T82msHY0XJ2jmxaxzYq1VE",
+         "id": "1jSEsMIW1HfproK-WBU9LyPAg_gszu9Zqhsjrb7ZKIOc",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1h_RSdb_1zKB3cxLwAtprK2OYHfUNszbD"
+          "1uCIUWQaSiHTRMBEGB80-3OsZnvat6duo"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -2417,10 +1869,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:43 GMT
+  recorded_at: Mon, 29 Oct 2018 21:29:13 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1hqihjTC6H38OdLpeslzL-T82msHY0XJ2jmxaxzYq1VE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1PNim4B_r4BFFj8HXFTE6fIWJbx6iBVowgIgmIjH7DHI?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -2432,7 +1884,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:03:43 GMT
+      - Mon, 29 Oct 2018 21:29:13 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2443,9 +1895,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:03:44 GMT
+      - Mon, 29 Oct 2018 21:29:14 GMT
       Date:
-      - Sat, 27 Oct 2018 00:03:44 GMT
+      - Mon, 29 Oct 2018 21:29:14 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -2471,40 +1923,41 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1hqihjTC6H38OdLpeslzL-T82msHY0XJ2jmxaxzYq1VE",
+         "id": "1PNim4B_r4BFFj8HXFTE6fIWJbx6iBVowgIgmIjH7DHI",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1h_RSdb_1zKB3cxLwAtprK2OYHfUNszbD"
+          "1HAwWmbMpL27eR8Fu_ihTZXl3ICaJPujC"
          ],
-         "thumbnailVersion": "0",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1PNim4B_r4BFFj8HXFTE6fIWJbx6iBVowgIgmIjH7DHI&v=1&s=AMedNnoAAAAAW9eXys0NnNDK-QCJ17aJXEPEZPsZL1so&sz=s220",
+         "thumbnailVersion": "1",
          "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
           {
            "kind": "drive#permission",
            "id": "11673017242486491425",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
+           "role": "writer",
            "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
            "deleted": false
           }
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:44 GMT
+  recorded_at: Mon, 29 Oct 2018 21:29:14 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/18WWLEIMsREk1eOiowkJ5T1IMht1TgaPWC-KqIJAsQGQ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1PNim4B_r4BFFj8HXFTE6fIWJbx6iBVowgIgmIjH7DHI/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -2516,7 +1969,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:03:44 GMT
+      - Mon, 29 Oct 2018 21:29:14 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2527,9 +1980,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:03:44 GMT
+      - Mon, 29 Oct 2018 21:29:14 GMT
       Date:
-      - Sat, 27 Oct 2018 00:03:44 GMT
+      - Mon, 29 Oct 2018 21:29:14 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -2555,14 +2008,158 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "18WWLEIMsREk1eOiowkJ5T1IMht1TgaPWC-KqIJAsQGQ",
+         "kind": "drive#revision",
+         "id": "3",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-29T21:28:07.297Z"
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:29:14 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1jSEsMIW1HfproK-WBU9LyPAg_gszu9Zqhsjrb7ZKIOc?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:29:14 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:29:14 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:29:14 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1jSEsMIW1HfproK-WBU9LyPAg_gszu9Zqhsjrb7ZKIOc",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1h_RSdb_1zKB3cxLwAtprK2OYHfUNszbD"
+          "1uCIUWQaSiHTRMBEGB80-3OsZnvat6duo"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=18WWLEIMsREk1eOiowkJ5T1IMht1TgaPWC-KqIJAsQGQ&v=1&s=AMedNnoAAAAAW9PHgO2vbmC2XV3Ozp4ZPMa7yd-NCohk&sz=s220",
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 21:29:14 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1Tk66KdMSu1VNAAxm3v_dgq53linEsys18_0INMZG5nw?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 21:29:14 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 21:29:15 GMT
+      Date:
+      - Mon, 29 Oct 2018 21:29:15 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1Tk66KdMSu1VNAAxm3v_dgq53linEsys18_0INMZG5nw",
+         "name": "File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1uCIUWQaSiHTRMBEGB80-3OsZnvat6duo"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Tk66KdMSu1VNAAxm3v_dgq53linEsys18_0INMZG5nw&v=1&s=AMedNnoAAAAAW9eXy9OBXP7g1uKHjSjPVqwTgl_cKQVA&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -2586,10 +2183,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:44 GMT
+  recorded_at: Mon, 29 Oct 2018 21:29:15 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1wEFuxX4HbB-f69sjWrVkHKSebSa9x4q7
+    uri: https://www.googleapis.com/drive/v3/files/1HAwWmbMpL27eR8Fu_ihTZXl3ICaJPujC
     body:
       encoding: UTF-8
       string: ''
@@ -2601,7 +2198,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:03:44 GMT
+      - Mon, 29 Oct 2018 21:29:15 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -2618,7 +2215,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:03:45 GMT
+      - Mon, 29 Oct 2018 21:29:16 GMT
       Vary:
       - Origin
       - X-Origin
@@ -2630,5 +2227,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:03:45 GMT
+  recorded_at: Mon, 29 Oct 2018 21:29:16 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Folder_Import/Files_are_imported.yml
+++ b/spec/support/fixtures/vcr_cassettes/Folder_Import/Files_are_imported.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Sat, 27 Oct 2018 00:11:09 GMT
+      - Mon, 29 Oct 2018 19:30:50 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:09 GMT
+  recorded_at: Mon, 29 Oct 2018 19:30:50 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Sat, 27 Oct 2018 00:11:10 GMT
+      - Mon, 29 Oct 2018 19:30:50 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:10 GMT
+  recorded_at: Mon, 29 Oct 2018 19:30:50 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-27
-        00:11:10 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-29
+        19:30:50 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:10 GMT
+      - Mon, 29 Oct 2018 19:30:50 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:11 GMT
+      - Mon, 29 Oct 2018 19:30:51 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1kADpvZKBZid1qh3lA8E4StUs2XbGSndh",
-         "name": "Test @ 2018-10-27 00:11:10 UTC",
+         "id": "1DotKPIGLlwpEnWySEczhN3E4z3vDNoaf",
+         "name": "Test @ 2018-10-29 19:30:50 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,7 +185,7 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:11 GMT
+  recorded_at: Mon, 29 Oct 2018 19:30:51 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
@@ -201,7 +201,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:11 GMT
+      - Mon, 29 Oct 2018 19:30:52 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -218,7 +218,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:11 GMT
+      - Mon, 29 Oct 2018 19:30:53 GMT
       Vary:
       - Origin
       - X-Origin
@@ -242,7 +242,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1eulWwkmOUSeG9IVDwHCgndPYdnAjJH79",
+         "id": "1C8A2PG9giDmkkALMz8voLs8wQNRWIsb1",
          "name": "My Awesome New Project! (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
@@ -263,10 +263,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:11 GMT
+  recorded_at: Mon, 29 Oct 2018 19:30:53 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1eulWwkmOUSeG9IVDwHCgndPYdnAjJH79/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1C8A2PG9giDmkkALMz8voLs8wQNRWIsb1/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -278,7 +278,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:11 GMT
+      - Mon, 29 Oct 2018 19:30:53 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -295,7 +295,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:12 GMT
+      - Mon, 29 Oct 2018 19:30:54 GMT
       Vary:
       - Origin
       - X-Origin
@@ -325,164 +325,13 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:12 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1eulWwkmOUSeG9IVDwHCgndPYdnAjJH79?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:11:12 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:11:12 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:11:12 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1eulWwkmOUSeG9IVDwHCgndPYdnAjJH79",
-         "name": "My Awesome New Project! (Archive)",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:12 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1eulWwkmOUSeG9IVDwHCgndPYdnAjJH79/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:11:12 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:11:12 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:11:12 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:12 GMT
+  recorded_at: Mon, 29 Oct 2018 19:30:54 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"soluta.js","parents":["1kADpvZKBZid1qh3lA8E4StUs2XbGSndh"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"libero.doc","parents":["1DotKPIGLlwpEnWySEczhN3E4z3vDNoaf"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -491,7 +340,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:12 GMT
+      - Mon, 29 Oct 2018 19:30:54 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -508,7 +357,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:13 GMT
+      - Mon, 29 Oct 2018 19:30:56 GMT
       Vary:
       - Origin
       - X-Origin
@@ -532,12 +381,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1RLLgM87nrwMaGiges5fEgJ5oJrVdJ3EB9QsbzFWzfb8",
-         "name": "soluta.js",
+         "id": "1xMKEZZ2IQTTD8JEktFhcrx5TcGcJkKkn_A-ilp0O8uo",
+         "name": "libero.doc",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1kADpvZKBZid1qh3lA8E4StUs2XbGSndh"
+          "1DotKPIGLlwpEnWySEczhN3E4z3vDNoaf"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -553,13 +402,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:14 GMT
+  recorded_at: Mon, 29 Oct 2018 19:30:56 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"fugit.webm","parents":["1kADpvZKBZid1qh3lA8E4StUs2XbGSndh"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"voluptatibus.pages","parents":["1DotKPIGLlwpEnWySEczhN3E4z3vDNoaf"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -568,7 +417,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:14 GMT
+      - Mon, 29 Oct 2018 19:30:56 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -585,7 +434,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:15 GMT
+      - Mon, 29 Oct 2018 19:30:57 GMT
       Vary:
       - Origin
       - X-Origin
@@ -609,12 +458,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1NZ0vE7CGmrfyKZgv2YPZJCLWM8K4pS7TN1ye8pPjLNU",
-         "name": "fugit.webm",
+         "id": "1MB84gLQ7atzP6swJwuAMf21GFRTYNgtpf4KBBZETwfw",
+         "name": "voluptatibus.pages",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1kADpvZKBZid1qh3lA8E4StUs2XbGSndh"
+          "1DotKPIGLlwpEnWySEczhN3E4z3vDNoaf"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -630,13 +479,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:15 GMT
+  recorded_at: Mon, 29 Oct 2018 19:30:57 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"et.mov","parents":["1kADpvZKBZid1qh3lA8E4StUs2XbGSndh"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"odio.ods","parents":["1DotKPIGLlwpEnWySEczhN3E4z3vDNoaf"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -645,7 +494,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:15 GMT
+      - Mon, 29 Oct 2018 19:30:57 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -662,7 +511,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:16 GMT
+      - Mon, 29 Oct 2018 19:30:59 GMT
       Vary:
       - Origin
       - X-Origin
@@ -686,12 +535,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1EqUzS9ls8ZaU8wo8g4Qg0W15FGzdtpQCceprNRoo1FE",
-         "name": "et.mov",
+         "id": "10AhauevZC4k-yWN2pCQZM-4T9EwvVrN1tvy3DAJ-2aE",
+         "name": "odio.ods",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1kADpvZKBZid1qh3lA8E4StUs2XbGSndh"
+          "1DotKPIGLlwpEnWySEczhN3E4z3vDNoaf"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -707,10 +556,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:16 GMT
+  recorded_at: Mon, 29 Oct 2018 19:30:59 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1kADpvZKBZid1qh3lA8E4StUs2XbGSndh/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1DotKPIGLlwpEnWySEczhN3E4z3vDNoaf/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"reader","type":"user"}'
@@ -722,7 +571,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:16 GMT
+      - Mon, 29 Oct 2018 19:30:59 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -739,7 +588,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:17 GMT
+      - Mon, 29 Oct 2018 19:31:00 GMT
       Vary:
       - Origin
       - X-Origin
@@ -769,10 +618,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:17 GMT
+  recorded_at: Mon, 29 Oct 2018 19:31:00 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1kADpvZKBZid1qh3lA8E4StUs2XbGSndh?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1DotKPIGLlwpEnWySEczhN3E4z3vDNoaf?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -784,7 +633,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:22 GMT
+      - Mon, 29 Oct 2018 19:31:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -795,9 +644,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:11:22 GMT
+      - Mon, 29 Oct 2018 19:31:06 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:22 GMT
+      - Mon, 29 Oct 2018 19:31:06 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -823,17 +672,17 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1kADpvZKBZid1qh3lA8E4StUs2XbGSndh",
-         "name": "Test @ 2018-10-27 00:11:10 UTC",
+         "id": "1DotKPIGLlwpEnWySEczhN3E4z3vDNoaf",
+         "name": "Test @ 2018-10-29 19:30:50 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:22 GMT
+  recorded_at: Mon, 29 Oct 2018 19:31:06 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1kADpvZKBZid1qh3lA8E4StUs2XbGSndh/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1DotKPIGLlwpEnWySEczhN3E4z3vDNoaf/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -845,7 +694,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:22 GMT
+      - Mon, 29 Oct 2018 19:31:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -863,9 +712,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:11:22 GMT
+      - Mon, 29 Oct 2018 19:31:06 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:11:22 GMT
+      - Mon, 29 Oct 2018 19:31:06 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -897,10 +746,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:22 GMT
+  recorded_at: Mon, 29 Oct 2018 19:31:06 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271kADpvZKBZid1qh3lA8E4StUs2XbGSndh%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files/1DotKPIGLlwpEnWySEczhN3E4z3vDNoaf?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -912,7 +761,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:22 GMT
+      - Mon, 29 Oct 2018 19:31:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -923,9 +772,265 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:11:23 GMT
+      - Mon, 29 Oct 2018 19:31:07 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:23 GMT
+      - Mon, 29 Oct 2018 19:31:07 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1DotKPIGLlwpEnWySEczhN3E4z3vDNoaf",
+         "name": "Test @ 2018-10-29 19:30:50 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0"
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 19:31:07 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1DotKPIGLlwpEnWySEczhN3E4z3vDNoaf/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 19:31:07 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 29 Oct 2018 19:31:07 GMT
+      Expires:
+      - Mon, 29 Oct 2018 19:31:07 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 19:31:07 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1DotKPIGLlwpEnWySEczhN3E4z3vDNoaf?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 19:31:07 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 19:31:07 GMT
+      Date:
+      - Mon, 29 Oct 2018 19:31:07 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1DotKPIGLlwpEnWySEczhN3E4z3vDNoaf",
+         "name": "Test @ 2018-10-29 19:30:50 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0"
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 19:31:07 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1DotKPIGLlwpEnWySEczhN3E4z3vDNoaf/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 19:31:07 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 29 Oct 2018 19:31:07 GMT
+      Expires:
+      - Mon, 29 Oct 2018 19:31:07 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 19:31:07 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271DotKPIGLlwpEnWySEczhN3E4z3vDNoaf%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 19:31:07 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 19:31:07 GMT
+      Date:
+      - Mon, 29 Oct 2018 19:31:07 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -953,45 +1058,45 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1EqUzS9ls8ZaU8wo8g4Qg0W15FGzdtpQCceprNRoo1FE",
-           "name": "et.mov",
+           "id": "10AhauevZC4k-yWN2pCQZM-4T9EwvVrN1tvy3DAJ-2aE",
+           "name": "odio.ods",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1kADpvZKBZid1qh3lA8E4StUs2XbGSndh"
+            "1DotKPIGLlwpEnWySEczhN3E4z3vDNoaf"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1EqUzS9ls8ZaU8wo8g4Qg0W15FGzdtpQCceprNRoo1FE&v=1&s=AMedNnoAAAAAW9PJS1N84fGGs3Wt0K5LjxFCHfyQMS0-&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=10AhauevZC4k-yWN2pCQZM-4T9EwvVrN1tvy3DAJ-2aE&v=1&s=AMedNnoAAAAAW9d8G4Gx7ZqK7aQvA4GBwkY7UxbeRzGD&sz=s220",
            "thumbnailVersion": "1"
           },
           {
-           "id": "1NZ0vE7CGmrfyKZgv2YPZJCLWM8K4pS7TN1ye8pPjLNU",
-           "name": "fugit.webm",
+           "id": "1MB84gLQ7atzP6swJwuAMf21GFRTYNgtpf4KBBZETwfw",
+           "name": "voluptatibus.pages",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1kADpvZKBZid1qh3lA8E4StUs2XbGSndh"
+            "1DotKPIGLlwpEnWySEczhN3E4z3vDNoaf"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1NZ0vE7CGmrfyKZgv2YPZJCLWM8K4pS7TN1ye8pPjLNU&v=1&s=AMedNnoAAAAAW9PJSzxPiBFdvcCaOuZ3wmY_lziAIFxn&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1MB84gLQ7atzP6swJwuAMf21GFRTYNgtpf4KBBZETwfw&v=1&s=AMedNnoAAAAAW9d8GwaeeZ-HHubC30D9PuRzBAycPH0O&sz=s220",
            "thumbnailVersion": "1"
           },
           {
-           "id": "1RLLgM87nrwMaGiges5fEgJ5oJrVdJ3EB9QsbzFWzfb8",
-           "name": "soluta.js",
+           "id": "1xMKEZZ2IQTTD8JEktFhcrx5TcGcJkKkn_A-ilp0O8uo",
+           "name": "libero.doc",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1kADpvZKBZid1qh3lA8E4StUs2XbGSndh"
+            "1DotKPIGLlwpEnWySEczhN3E4z3vDNoaf"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1RLLgM87nrwMaGiges5fEgJ5oJrVdJ3EB9QsbzFWzfb8&v=1&s=AMedNnoAAAAAW9PJS2VwYxLKMu-_LBmOZKUkqBbdXtlD&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1xMKEZZ2IQTTD8JEktFhcrx5TcGcJkKkn_A-ilp0O8uo&v=1&s=AMedNnoAAAAAW9d8GwacRNdV9i4OJLrnehaSTbfjxQpg&sz=s220",
            "thumbnailVersion": "1"
           }
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:23 GMT
+  recorded_at: Mon, 29 Oct 2018 19:31:07 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1EqUzS9ls8ZaU8wo8g4Qg0W15FGzdtpQCceprNRoo1FE/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/10AhauevZC4k-yWN2pCQZM-4T9EwvVrN1tvy3DAJ-2aE/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1003,7 +1108,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:23 GMT
+      - Mon, 29 Oct 2018 19:31:07 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1021,9 +1126,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:11:23 GMT
+      - Mon, 29 Oct 2018 19:31:08 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:11:23 GMT
+      - Mon, 29 Oct 2018 19:31:08 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1047,20 +1152,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "insufficientFilePermissions",
-            "message": "The user does not have sufficient permissions for file 1EqUzS9ls8ZaU8wo8g4Qg0W15FGzdtpQCceprNRoo1FE.",
+            "message": "The user does not have sufficient permissions for file 10AhauevZC4k-yWN2pCQZM-4T9EwvVrN1tvy3DAJ-2aE.",
             "locationType": "header",
             "location": "Authorization"
            }
           ],
           "code": 403,
-          "message": "The user does not have sufficient permissions for file 1EqUzS9ls8ZaU8wo8g4Qg0W15FGzdtpQCceprNRoo1FE."
+          "message": "The user does not have sufficient permissions for file 10AhauevZC4k-yWN2pCQZM-4T9EwvVrN1tvy3DAJ-2aE."
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:23 GMT
+  recorded_at: Mon, 29 Oct 2018 19:31:08 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1EqUzS9ls8ZaU8wo8g4Qg0W15FGzdtpQCceprNRoo1FE&s=AMedNnoAAAAAW9PJS1N84fGGs3Wt0K5LjxFCHfyQMS0-&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=10AhauevZC4k-yWN2pCQZM-4T9EwvVrN1tvy3DAJ-2aE&s=AMedNnoAAAAAW9d8G4Gx7ZqK7aQvA4GBwkY7UxbeRzGD&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1072,7 +1177,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:23 GMT
+      - Mon, 29 Oct 2018 19:31:08 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1103,7 +1208,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Sat, 27 Oct 2018 00:11:23 GMT
+      - Mon, 29 Oct 2018 19:31:08 GMT
       Server:
       - fife
       Content-Length:
@@ -1117,13 +1222,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:23 GMT
+  recorded_at: Mon, 29 Oct 2018 19:31:08 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1EqUzS9ls8ZaU8wo8g4Qg0W15FGzdtpQCceprNRoo1FE/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/10AhauevZC4k-yWN2pCQZM-4T9EwvVrN1tvy3DAJ-2aE/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"et.mov","parents":["1eulWwkmOUSeG9IVDwHCgndPYdnAjJH79"]}'
+      string: '{"name":"odio.ods","parents":["1C8A2PG9giDmkkALMz8voLs8wQNRWIsb1"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1132,7 +1237,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:23 GMT
+      - Mon, 29 Oct 2018 19:31:09 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1149,7 +1254,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:27 GMT
+      - Mon, 29 Oct 2018 19:31:10 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1173,12 +1278,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1l1bdNvVFBA9kIlhHG3kVSRypxqUsi4STVXFLMKXJpDw",
-         "name": "et.mov",
+         "id": "16YWkvn1L_FbXUtoS4OMS9J4buNIXxjy2VHEdBbpinUo",
+         "name": "odio.ods",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1eulWwkmOUSeG9IVDwHCgndPYdnAjJH79"
+          "1C8A2PG9giDmkkALMz8voLs8wQNRWIsb1"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1203,10 +1308,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:27 GMT
+  recorded_at: Mon, 29 Oct 2018 19:31:11 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1NZ0vE7CGmrfyKZgv2YPZJCLWM8K4pS7TN1ye8pPjLNU/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1MB84gLQ7atzP6swJwuAMf21GFRTYNgtpf4KBBZETwfw/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1218,7 +1323,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:27 GMT
+      - Mon, 29 Oct 2018 19:31:11 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1236,9 +1341,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:11:27 GMT
+      - Mon, 29 Oct 2018 19:31:11 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:11:27 GMT
+      - Mon, 29 Oct 2018 19:31:11 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1262,20 +1367,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "insufficientFilePermissions",
-            "message": "The user does not have sufficient permissions for file 1NZ0vE7CGmrfyKZgv2YPZJCLWM8K4pS7TN1ye8pPjLNU.",
+            "message": "The user does not have sufficient permissions for file 1MB84gLQ7atzP6swJwuAMf21GFRTYNgtpf4KBBZETwfw.",
             "locationType": "header",
             "location": "Authorization"
            }
           ],
           "code": 403,
-          "message": "The user does not have sufficient permissions for file 1NZ0vE7CGmrfyKZgv2YPZJCLWM8K4pS7TN1ye8pPjLNU."
+          "message": "The user does not have sufficient permissions for file 1MB84gLQ7atzP6swJwuAMf21GFRTYNgtpf4KBBZETwfw."
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:27 GMT
+  recorded_at: Mon, 29 Oct 2018 19:31:11 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1NZ0vE7CGmrfyKZgv2YPZJCLWM8K4pS7TN1ye8pPjLNU&s=AMedNnoAAAAAW9PJSzxPiBFdvcCaOuZ3wmY_lziAIFxn&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1MB84gLQ7atzP6swJwuAMf21GFRTYNgtpf4KBBZETwfw&s=AMedNnoAAAAAW9d8GwaeeZ-HHubC30D9PuRzBAycPH0O&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1287,7 +1392,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:27 GMT
+      - Mon, 29 Oct 2018 19:31:11 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1318,7 +1423,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Sat, 27 Oct 2018 00:11:28 GMT
+      - Mon, 29 Oct 2018 19:31:11 GMT
       Server:
       - fife
       Content-Length:
@@ -1332,13 +1437,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:28 GMT
+  recorded_at: Mon, 29 Oct 2018 19:31:11 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1NZ0vE7CGmrfyKZgv2YPZJCLWM8K4pS7TN1ye8pPjLNU/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1MB84gLQ7atzP6swJwuAMf21GFRTYNgtpf4KBBZETwfw/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"fugit.webm","parents":["1eulWwkmOUSeG9IVDwHCgndPYdnAjJH79"]}'
+      string: '{"name":"voluptatibus.pages","parents":["1C8A2PG9giDmkkALMz8voLs8wQNRWIsb1"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1347,7 +1452,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:28 GMT
+      - Mon, 29 Oct 2018 19:31:12 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1364,7 +1469,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:29 GMT
+      - Mon, 29 Oct 2018 19:31:13 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1388,12 +1493,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1KYakInfYaU7f0akVW-kELZ8Gb0tJb9Ln_vxnpO7XwHA",
-         "name": "fugit.webm",
+         "id": "1sGMw2dUOyXNQLnpEiOeZeeZf9ePjGrOoHtL5KgiTTf0",
+         "name": "voluptatibus.pages",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1eulWwkmOUSeG9IVDwHCgndPYdnAjJH79"
+          "1C8A2PG9giDmkkALMz8voLs8wQNRWIsb1"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1418,10 +1523,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:29 GMT
+  recorded_at: Mon, 29 Oct 2018 19:31:14 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1RLLgM87nrwMaGiges5fEgJ5oJrVdJ3EB9QsbzFWzfb8/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1xMKEZZ2IQTTD8JEktFhcrx5TcGcJkKkn_A-ilp0O8uo/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1433,7 +1538,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:29 GMT
+      - Mon, 29 Oct 2018 19:31:14 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1451,9 +1556,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:11:30 GMT
+      - Mon, 29 Oct 2018 19:31:14 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:11:30 GMT
+      - Mon, 29 Oct 2018 19:31:14 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1477,20 +1582,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "insufficientFilePermissions",
-            "message": "The user does not have sufficient permissions for file 1RLLgM87nrwMaGiges5fEgJ5oJrVdJ3EB9QsbzFWzfb8.",
+            "message": "The user does not have sufficient permissions for file 1xMKEZZ2IQTTD8JEktFhcrx5TcGcJkKkn_A-ilp0O8uo.",
             "locationType": "header",
             "location": "Authorization"
            }
           ],
           "code": 403,
-          "message": "The user does not have sufficient permissions for file 1RLLgM87nrwMaGiges5fEgJ5oJrVdJ3EB9QsbzFWzfb8."
+          "message": "The user does not have sufficient permissions for file 1xMKEZZ2IQTTD8JEktFhcrx5TcGcJkKkn_A-ilp0O8uo."
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:30 GMT
+  recorded_at: Mon, 29 Oct 2018 19:31:14 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1RLLgM87nrwMaGiges5fEgJ5oJrVdJ3EB9QsbzFWzfb8&s=AMedNnoAAAAAW9PJS2VwYxLKMu-_LBmOZKUkqBbdXtlD&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1xMKEZZ2IQTTD8JEktFhcrx5TcGcJkKkn_A-ilp0O8uo&s=AMedNnoAAAAAW9d8GwacRNdV9i4OJLrnehaSTbfjxQpg&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1502,7 +1607,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:30 GMT
+      - Mon, 29 Oct 2018 19:31:14 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1533,7 +1638,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Sat, 27 Oct 2018 00:11:30 GMT
+      - Mon, 29 Oct 2018 19:31:14 GMT
       Server:
       - fife
       Content-Length:
@@ -1547,13 +1652,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:30 GMT
+  recorded_at: Mon, 29 Oct 2018 19:31:14 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1RLLgM87nrwMaGiges5fEgJ5oJrVdJ3EB9QsbzFWzfb8/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1xMKEZZ2IQTTD8JEktFhcrx5TcGcJkKkn_A-ilp0O8uo/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"soluta.js","parents":["1eulWwkmOUSeG9IVDwHCgndPYdnAjJH79"]}'
+      string: '{"name":"libero.doc","parents":["1C8A2PG9giDmkkALMz8voLs8wQNRWIsb1"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1562,7 +1667,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:30 GMT
+      - Mon, 29 Oct 2018 19:31:14 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1579,7 +1684,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:32 GMT
+      - Mon, 29 Oct 2018 19:31:16 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1603,12 +1708,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1WteLU926qtqQjdlua_yE5wIDoeqQNTRWQbHkJc7W5_A",
-         "name": "soluta.js",
+         "id": "1L6e_BUDGJkJHGI5MVxaQQHEar0bery3bU8uIUsvh2W0",
+         "name": "libero.doc",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1eulWwkmOUSeG9IVDwHCgndPYdnAjJH79"
+          "1C8A2PG9giDmkkALMz8voLs8wQNRWIsb1"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1633,10 +1738,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:32 GMT
+  recorded_at: Mon, 29 Oct 2018 19:31:16 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271eulWwkmOUSeG9IVDwHCgndPYdnAjJH79%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271C8A2PG9giDmkkALMz8voLs8wQNRWIsb1%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -1648,7 +1753,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:32 GMT
+      - Mon, 29 Oct 2018 19:31:17 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1659,9 +1764,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:11:32 GMT
+      - Mon, 29 Oct 2018 19:31:17 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:32 GMT
+      - Mon, 29 Oct 2018 19:31:17 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1689,12 +1794,12 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1WteLU926qtqQjdlua_yE5wIDoeqQNTRWQbHkJc7W5_A",
-           "name": "soluta.js",
+           "id": "1L6e_BUDGJkJHGI5MVxaQQHEar0bery3bU8uIUsvh2W0",
+           "name": "libero.doc",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1eulWwkmOUSeG9IVDwHCgndPYdnAjJH79"
+            "1C8A2PG9giDmkkALMz8voLs8wQNRWIsb1"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -1719,14 +1824,14 @@ http_interactions:
            ]
           },
           {
-           "id": "1KYakInfYaU7f0akVW-kELZ8Gb0tJb9Ln_vxnpO7XwHA",
-           "name": "fugit.webm",
+           "id": "1sGMw2dUOyXNQLnpEiOeZeeZf9ePjGrOoHtL5KgiTTf0",
+           "name": "voluptatibus.pages",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1eulWwkmOUSeG9IVDwHCgndPYdnAjJH79"
+            "1C8A2PG9giDmkkALMz8voLs8wQNRWIsb1"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1KYakInfYaU7f0akVW-kELZ8Gb0tJb9Ln_vxnpO7XwHA&v=1&s=AMedNnoAAAAAW9PJVMX7ynusqxCWrZTK1XH3LgRHtFdj&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1sGMw2dUOyXNQLnpEiOeZeeZf9ePjGrOoHtL5KgiTTf0&v=1&s=AMedNnoAAAAAW9d8JW5t_7qbps7N_amsrlXOi_vVmRfg&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -1750,14 +1855,14 @@ http_interactions:
            ]
           },
           {
-           "id": "1l1bdNvVFBA9kIlhHG3kVSRypxqUsi4STVXFLMKXJpDw",
-           "name": "et.mov",
+           "id": "16YWkvn1L_FbXUtoS4OMS9J4buNIXxjy2VHEdBbpinUo",
+           "name": "odio.ods",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1eulWwkmOUSeG9IVDwHCgndPYdnAjJH79"
+            "1C8A2PG9giDmkkALMz8voLs8wQNRWIsb1"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1l1bdNvVFBA9kIlhHG3kVSRypxqUsi4STVXFLMKXJpDw&v=1&s=AMedNnoAAAAAW9PJVLGnF4BPU1dx_WoeDRXZUXM4-X1h&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=16YWkvn1L_FbXUtoS4OMS9J4buNIXxjy2VHEdBbpinUo&v=1&s=AMedNnoAAAAAW9d8JZgPvqdwkI7_mO5XX7ELYnJWRnXB&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -1783,10 +1888,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:33 GMT
+  recorded_at: Mon, 29 Oct 2018 19:31:18 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1kADpvZKBZid1qh3lA8E4StUs2XbGSndh
+    uri: https://www.googleapis.com/drive/v3/files/1DotKPIGLlwpEnWySEczhN3E4z3vDNoaf
     body:
       encoding: UTF-8
       string: ''
@@ -1798,7 +1903,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:33 GMT
+      - Mon, 29 Oct 2018 19:31:18 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1815,7 +1920,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:33 GMT
+      - Mon, 29 Oct 2018 19:31:18 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1827,5 +1932,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:33 GMT
+  recorded_at: Mon, 29 Oct 2018 19:31:19 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Force_Sync/User_can_force_sync_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/Force_Sync/User_can_force_sync_file.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Sat, 27 Oct 2018 00:11:45 GMT
+      - Tue, 30 Oct 2018 04:27:38 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:45 GMT
+  recorded_at: Tue, 30 Oct 2018 04:27:38 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Sat, 27 Oct 2018 00:11:45 GMT
+      - Tue, 30 Oct 2018 04:27:38 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:45 GMT
+  recorded_at: Tue, 30 Oct 2018 04:27:38 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-27
-        00:11:45 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-30
+        04:27:38 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:45 GMT
+      - Tue, 30 Oct 2018 04:27:38 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:46 GMT
+      - Tue, 30 Oct 2018 04:27:39 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1_NYqFD0OK8Flqr5CxwbajWXUz4YvBHcz",
-         "name": "Test @ 2018-10-27 00:11:45 UTC",
+         "id": "1xNVsaRILkoptAu7_z1f0veAzGsY-RIBS",
+         "name": "Test @ 2018-10-30 04:27:38 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:46 GMT
+  recorded_at: Tue, 30 Oct 2018 04:27:39 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1_NYqFD0OK8Flqr5CxwbajWXUz4YvBHcz/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1xNVsaRILkoptAu7_z1f0veAzGsY-RIBS/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:46 GMT
+      - Tue, 30 Oct 2018 04:27:39 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:47 GMT
+      - Tue, 30 Oct 2018 04:27:40 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,13 +247,13 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:47 GMT
+  recorded_at: Tue, 30 Oct 2018 04:27:40 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1_NYqFD0OK8Flqr5CxwbajWXUz4YvBHcz"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1xNVsaRILkoptAu7_z1f0veAzGsY-RIBS"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:47 GMT
+      - Tue, 30 Oct 2018 04:27:42 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -279,7 +279,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:48 GMT
+      - Tue, 30 Oct 2018 04:27:43 GMT
       Vary:
       - Origin
       - X-Origin
@@ -303,12 +303,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "18erZaDlhd0u3YqwqDp7za0lprvs6HIWk",
+         "id": "1oybl7hOTZNDmiSjNN9FcUTEuMKD_SBZs",
          "name": "Folder",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1_NYqFD0OK8Flqr5CxwbajWXUz4YvBHcz"
+          "1xNVsaRILkoptAu7_z1f0veAzGsY-RIBS"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -333,13 +333,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:48 GMT
+  recorded_at: Tue, 30 Oct 2018 04:27:43 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"Doc XYZ","parents":["1_NYqFD0OK8Flqr5CxwbajWXUz4YvBHcz"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Doc XYZ","parents":["1xNVsaRILkoptAu7_z1f0veAzGsY-RIBS"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -348,7 +348,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:48 GMT
+      - Tue, 30 Oct 2018 04:27:43 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -365,7 +365,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:49 GMT
+      - Tue, 30 Oct 2018 04:27:44 GMT
       Vary:
       - Origin
       - X-Origin
@@ -389,12 +389,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1S0rVTehEHJOyh5VfFaNpRHWJJzYmuh6yfsjYRubJdVY",
+         "id": "1to01JvVqV8ZJio4cWq1nEmt5YfHRd3bguXnlkCEHMQ0",
          "name": "Doc XYZ",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1_NYqFD0OK8Flqr5CxwbajWXUz4YvBHcz"
+          "1xNVsaRILkoptAu7_z1f0veAzGsY-RIBS"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -419,13 +419,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:49 GMT
+  recorded_at: Tue, 30 Oct 2018 04:27:44 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"45 RW6 (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"1 RW6 (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -434,7 +434,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:49 GMT
+      - Tue, 30 Oct 2018 04:27:44 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -451,7 +451,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:49 GMT
+      - Tue, 30 Oct 2018 04:27:45 GMT
       Vary:
       - Origin
       - X-Origin
@@ -475,8 +475,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1YPqXCXdagR_JMHj1q1-T94ogO1b3mR-V",
-         "name": "45 RW6 (Archive)",
+         "id": "1CVzGdPaEaKza6C1j_txLtOVAoWkrUxeo",
+         "name": "1 RW6 (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -496,10 +496,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:49 GMT
+  recorded_at: Tue, 30 Oct 2018 04:27:46 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1YPqXCXdagR_JMHj1q1-T94ogO1b3mR-V/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1CVzGdPaEaKza6C1j_txLtOVAoWkrUxeo/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -511,7 +511,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:49 GMT
+      - Tue, 30 Oct 2018 04:27:46 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -528,7 +528,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:50 GMT
+      - Tue, 30 Oct 2018 04:27:47 GMT
       Vary:
       - Origin
       - X-Origin
@@ -558,10 +558,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:50 GMT
+  recorded_at: Tue, 30 Oct 2018 04:27:47 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1YPqXCXdagR_JMHj1q1-T94ogO1b3mR-V?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1xNVsaRILkoptAu7_z1f0veAzGsY-RIBS?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -573,7 +573,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:50 GMT
+      - Tue, 30 Oct 2018 04:27:47 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -584,9 +584,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:11:50 GMT
+      - Tue, 30 Oct 2018 04:27:47 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:50 GMT
+      - Tue, 30 Oct 2018 04:27:47 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -612,159 +612,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1YPqXCXdagR_JMHj1q1-T94ogO1b3mR-V",
-         "name": "45 RW6 (Archive)",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:50 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1YPqXCXdagR_JMHj1q1-T94ogO1b3mR-V/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:11:50 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 27 Oct 2018 00:11:51 GMT
-      Expires:
-      - Sat, 27 Oct 2018 00:11:51 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:51 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1_NYqFD0OK8Flqr5CxwbajWXUz4YvBHcz?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 27 Oct 2018 00:11:51 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Sat, 27 Oct 2018 00:11:51 GMT
-      Date:
-      - Sat, 27 Oct 2018 00:11:51 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1_NYqFD0OK8Flqr5CxwbajWXUz4YvBHcz",
-         "name": "Test @ 2018-10-27 00:11:45 UTC",
+         "id": "1xNVsaRILkoptAu7_z1f0veAzGsY-RIBS",
+         "name": "Test @ 2018-10-30 04:27:38 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -790,10 +639,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:51 GMT
+  recorded_at: Tue, 30 Oct 2018 04:27:47 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1_NYqFD0OK8Flqr5CxwbajWXUz4YvBHcz/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1xNVsaRILkoptAu7_z1f0veAzGsY-RIBS/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -805,7 +654,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:51 GMT
+      - Tue, 30 Oct 2018 04:27:47 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -823,9 +672,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:11:51 GMT
+      - Tue, 30 Oct 2018 04:27:48 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:11:51 GMT
+      - Tue, 30 Oct 2018 04:27:48 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -857,10 +706,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:51 GMT
+  recorded_at: Tue, 30 Oct 2018 04:27:48 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271_NYqFD0OK8Flqr5CxwbajWXUz4YvBHcz%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files/1xNVsaRILkoptAu7_z1f0veAzGsY-RIBS?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -872,7 +721,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:51 GMT
+      - Tue, 30 Oct 2018 04:27:48 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -883,9 +732,305 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:11:51 GMT
+      - Tue, 30 Oct 2018 04:27:48 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:51 GMT
+      - Tue, 30 Oct 2018 04:27:48 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1xNVsaRILkoptAu7_z1f0veAzGsY-RIBS",
+         "name": "Test @ 2018-10-30 04:27:38 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Tue, 30 Oct 2018 04:27:48 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1xNVsaRILkoptAu7_z1f0veAzGsY-RIBS/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Tue, 30 Oct 2018 04:27:48 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Tue, 30 Oct 2018 04:27:48 GMT
+      Expires:
+      - Tue, 30 Oct 2018 04:27:48 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Tue, 30 Oct 2018 04:27:48 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1xNVsaRILkoptAu7_z1f0veAzGsY-RIBS?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Tue, 30 Oct 2018 04:27:48 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Tue, 30 Oct 2018 04:27:48 GMT
+      Date:
+      - Tue, 30 Oct 2018 04:27:48 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1xNVsaRILkoptAu7_z1f0veAzGsY-RIBS",
+         "name": "Test @ 2018-10-30 04:27:38 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Tue, 30 Oct 2018 04:27:48 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1xNVsaRILkoptAu7_z1f0veAzGsY-RIBS/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Tue, 30 Oct 2018 04:27:48 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Tue, 30 Oct 2018 04:27:48 GMT
+      Expires:
+      - Tue, 30 Oct 2018 04:27:48 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Tue, 30 Oct 2018 04:27:48 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271xNVsaRILkoptAu7_z1f0veAzGsY-RIBS%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Tue, 30 Oct 2018 04:27:48 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Tue, 30 Oct 2018 04:27:49 GMT
+      Date:
+      - Tue, 30 Oct 2018 04:27:49 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -913,14 +1058,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1S0rVTehEHJOyh5VfFaNpRHWJJzYmuh6yfsjYRubJdVY",
+           "id": "1to01JvVqV8ZJio4cWq1nEmt5YfHRd3bguXnlkCEHMQ0",
            "name": "Doc XYZ",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1_NYqFD0OK8Flqr5CxwbajWXUz4YvBHcz"
+            "1xNVsaRILkoptAu7_z1f0veAzGsY-RIBS"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1S0rVTehEHJOyh5VfFaNpRHWJJzYmuh6yfsjYRubJdVY&v=1&s=AMedNnoAAAAAW9PJZ-M21dxYRbAYq2diKsRbqN2wPHqC&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1to01JvVqV8ZJio4cWq1nEmt5YfHRd3bguXnlkCEHMQ0&v=1&s=AMedNnoAAAAAW9f55a_g4khzVbtbLh5TcghsrG5p1RgG&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -944,12 +1089,12 @@ http_interactions:
            ]
           },
           {
-           "id": "18erZaDlhd0u3YqwqDp7za0lprvs6HIWk",
+           "id": "1oybl7hOTZNDmiSjNN9FcUTEuMKD_SBZs",
            "name": "Folder",
            "mimeType": "application/vnd.google-apps.folder",
            "trashed": false,
            "parents": [
-            "1_NYqFD0OK8Flqr5CxwbajWXUz4YvBHcz"
+            "1xNVsaRILkoptAu7_z1f0veAzGsY-RIBS"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -976,10 +1121,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:51 GMT
+  recorded_at: Tue, 30 Oct 2018 04:27:49 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1S0rVTehEHJOyh5VfFaNpRHWJJzYmuh6yfsjYRubJdVY/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1to01JvVqV8ZJio4cWq1nEmt5YfHRd3bguXnlkCEHMQ0/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -991,7 +1136,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:51 GMT
+      - Tue, 30 Oct 2018 04:27:49 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1002,9 +1147,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:11:52 GMT
+      - Tue, 30 Oct 2018 04:27:49 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:52 GMT
+      - Tue, 30 Oct 2018 04:27:49 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1033,13 +1178,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:11:48.538Z"
+         "modifiedTime": "2018-10-30T04:27:43.296Z"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:52 GMT
+  recorded_at: Tue, 30 Oct 2018 04:27:49 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1S0rVTehEHJOyh5VfFaNpRHWJJzYmuh6yfsjYRubJdVY&s=AMedNnoAAAAAW9PJZ-M21dxYRbAYq2diKsRbqN2wPHqC&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1to01JvVqV8ZJio4cWq1nEmt5YfHRd3bguXnlkCEHMQ0&s=AMedNnoAAAAAW9f55a_g4khzVbtbLh5TcghsrG5p1RgG&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1051,7 +1196,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:52 GMT
+      - Tue, 30 Oct 2018 04:27:49 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1082,7 +1227,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Sat, 27 Oct 2018 00:11:52 GMT
+      - Tue, 30 Oct 2018 04:27:49 GMT
       Server:
       - fife
       Content-Length:
@@ -1096,13 +1241,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:53 GMT
+  recorded_at: Tue, 30 Oct 2018 04:27:49 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1S0rVTehEHJOyh5VfFaNpRHWJJzYmuh6yfsjYRubJdVY/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1to01JvVqV8ZJio4cWq1nEmt5YfHRd3bguXnlkCEHMQ0/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"Doc XYZ","parents":["1YPqXCXdagR_JMHj1q1-T94ogO1b3mR-V"]}'
+      string: '{"name":"Doc XYZ","parents":["1CVzGdPaEaKza6C1j_txLtOVAoWkrUxeo"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1111,7 +1256,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:53 GMT
+      - Tue, 30 Oct 2018 04:27:49 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1128,7 +1273,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:54 GMT
+      - Tue, 30 Oct 2018 04:27:51 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1152,12 +1297,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "150vgCj79av2a5HzdcxE370sSAEGDUjYrgJsKAsUnB7U",
+         "id": "1nQ6zoNxNdtshpI2ZG0g6s2yFrGT4ZaOskL5N6Ca0fys",
          "name": "Doc XYZ",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1YPqXCXdagR_JMHj1q1-T94ogO1b3mR-V"
+          "1CVzGdPaEaKza6C1j_txLtOVAoWkrUxeo"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1182,10 +1327,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:55 GMT
+  recorded_at: Tue, 30 Oct 2018 04:27:51 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/18erZaDlhd0u3YqwqDp7za0lprvs6HIWk/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1oybl7hOTZNDmiSjNN9FcUTEuMKD_SBZs/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1197,7 +1342,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:55 GMT
+      - Tue, 30 Oct 2018 04:27:51 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1215,9 +1360,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 27 Oct 2018 00:11:55 GMT
+      - Tue, 30 Oct 2018 04:27:51 GMT
       Expires:
-      - Sat, 27 Oct 2018 00:11:55 GMT
+      - Tue, 30 Oct 2018 04:27:51 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1249,10 +1394,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:55 GMT
+  recorded_at: Tue, 30 Oct 2018 04:27:51 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%2718erZaDlhd0u3YqwqDp7za0lprvs6HIWk%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271oybl7hOTZNDmiSjNN9FcUTEuMKD_SBZs%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -1264,7 +1409,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:55 GMT
+      - Tue, 30 Oct 2018 04:27:51 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1275,9 +1420,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:11:55 GMT
+      - Tue, 30 Oct 2018 04:27:51 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:55 GMT
+      - Tue, 30 Oct 2018 04:27:51 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1306,10 +1451,10 @@ http_interactions:
          "files": []
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:55 GMT
+  recorded_at: Tue, 30 Oct 2018 04:27:51 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1S0rVTehEHJOyh5VfFaNpRHWJJzYmuh6yfsjYRubJdVY?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1to01JvVqV8ZJio4cWq1nEmt5YfHRd3bguXnlkCEHMQ0?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"name":"Doc ABC"}'
@@ -1321,7 +1466,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:55 GMT
+      - Tue, 30 Oct 2018 04:27:51 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1338,7 +1483,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:56 GMT
+      - Tue, 30 Oct 2018 04:27:52 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1362,14 +1507,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1S0rVTehEHJOyh5VfFaNpRHWJJzYmuh6yfsjYRubJdVY",
+         "id": "1to01JvVqV8ZJio4cWq1nEmt5YfHRd3bguXnlkCEHMQ0",
          "name": "Doc ABC",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1_NYqFD0OK8Flqr5CxwbajWXUz4YvBHcz"
+          "1xNVsaRILkoptAu7_z1f0veAzGsY-RIBS"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1S0rVTehEHJOyh5VfFaNpRHWJJzYmuh6yfsjYRubJdVY&v=2&s=AMedNnoAAAAAW9PJbB7dozmdsTRmPhVmh54LmdS8zJyQ&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1to01JvVqV8ZJio4cWq1nEmt5YfHRd3bguXnlkCEHMQ0&v=2&s=AMedNnoAAAAAW9f56AYpNQnoHeTZupp1v4fuBWdSC1e8&sz=s220",
          "thumbnailVersion": "2",
          "permissions": [
           {
@@ -1393,10 +1538,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:56 GMT
+  recorded_at: Tue, 30 Oct 2018 04:27:52 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1S0rVTehEHJOyh5VfFaNpRHWJJzYmuh6yfsjYRubJdVY?addParents=18erZaDlhd0u3YqwqDp7za0lprvs6HIWk&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1_NYqFD0OK8Flqr5CxwbajWXUz4YvBHcz
+    uri: https://www.googleapis.com/drive/v3/files/1to01JvVqV8ZJio4cWq1nEmt5YfHRd3bguXnlkCEHMQ0?addParents=1oybl7hOTZNDmiSjNN9FcUTEuMKD_SBZs&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1xNVsaRILkoptAu7_z1f0veAzGsY-RIBS
     body:
       encoding: UTF-8
       string: ''
@@ -1408,7 +1553,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:56 GMT
+      - Tue, 30 Oct 2018 04:27:52 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1425,7 +1570,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:57 GMT
+      - Tue, 30 Oct 2018 04:27:53 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1449,14 +1594,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1S0rVTehEHJOyh5VfFaNpRHWJJzYmuh6yfsjYRubJdVY",
+         "id": "1to01JvVqV8ZJio4cWq1nEmt5YfHRd3bguXnlkCEHMQ0",
          "name": "Doc ABC",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "18erZaDlhd0u3YqwqDp7za0lprvs6HIWk"
+          "1oybl7hOTZNDmiSjNN9FcUTEuMKD_SBZs"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1S0rVTehEHJOyh5VfFaNpRHWJJzYmuh6yfsjYRubJdVY&v=2&s=AMedNnoAAAAAW9PJbW5SaoHtpmW97-WAi-zL9c_r2SuO&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1to01JvVqV8ZJio4cWq1nEmt5YfHRd3bguXnlkCEHMQ0&v=2&s=AMedNnoAAAAAW9f56fVDibgJ_AGrco2a7rGtFRjZgs2-&sz=s220",
          "thumbnailVersion": "2",
          "permissions": [
           {
@@ -1480,10 +1625,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:57 GMT
+  recorded_at: Tue, 30 Oct 2018 04:27:53 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/upload/drive/v3/files/1S0rVTehEHJOyh5VfFaNpRHWJJzYmuh6yfsjYRubJdVY
+    uri: https://www.googleapis.com/upload/drive/v3/files/1to01JvVqV8ZJio4cWq1nEmt5YfHRd3bguXnlkCEHMQ0
     body:
       encoding: UTF-8
       string: ''
@@ -1495,7 +1640,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:57 GMT
+      - Tue, 30 Oct 2018 04:27:53 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       X-Goog-Upload-Protocol:
@@ -1514,22 +1659,22 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2Uo1IxrVxhhLjt4WEcMK4FY6f_FM9FCtipDc8E38JyDbkE6QYAUKOddYh34hC_cR9-dFs9eeUgq9g7ClDpxvcVAmtYl8xvGSVxsawXj-PHcleHXSX4k
+      - AEnB2UoiFoFHXXywD0bj87lKmw_kOggnYSnM2OyKKHlJPB_0E_nI9GXb6BUJmrW5T9dyhVrGxDDj-R0Q_SRMS3KD37zwdOZ9fsWYn53z7tXP6QhW7eGRzfc
       X-Goog-Upload-Status:
       - active
       X-Goog-Upload-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1S0rVTehEHJOyh5VfFaNpRHWJJzYmuh6yfsjYRubJdVY?upload_id=AEnB2Uo1IxrVxhhLjt4WEcMK4FY6f_FM9FCtipDc8E38JyDbkE6QYAUKOddYh34hC_cR9-dFs9eeUgq9g7ClDpxvcVAmtYl8xvGSVxsawXj-PHcleHXSX4k&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1to01JvVqV8ZJio4cWq1nEmt5YfHRd3bguXnlkCEHMQ0?upload_id=AEnB2UoiFoFHXXywD0bj87lKmw_kOggnYSnM2OyKKHlJPB_0E_nI9GXb6BUJmrW5T9dyhVrGxDDj-R0Q_SRMS3KD37zwdOZ9fsWYn53z7tXP6QhW7eGRzfc&upload_protocol=resumable
       X-Goog-Upload-Control-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1S0rVTehEHJOyh5VfFaNpRHWJJzYmuh6yfsjYRubJdVY?upload_id=AEnB2Uo1IxrVxhhLjt4WEcMK4FY6f_FM9FCtipDc8E38JyDbkE6QYAUKOddYh34hC_cR9-dFs9eeUgq9g7ClDpxvcVAmtYl8xvGSVxsawXj-PHcleHXSX4k&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1to01JvVqV8ZJio4cWq1nEmt5YfHRd3bguXnlkCEHMQ0?upload_id=AEnB2UoiFoFHXXywD0bj87lKmw_kOggnYSnM2OyKKHlJPB_0E_nI9GXb6BUJmrW5T9dyhVrGxDDj-R0Q_SRMS3KD37zwdOZ9fsWYn53z7tXP6QhW7eGRzfc&upload_protocol=resumable
       X-Goog-Upload-Chunk-Granularity:
       - '262144'
       X-Goog-Upload-Header-Vary:
       - Origin
       - X-Origin
       X-Goog-Upload-Header-X-Google-Backends:
-      - iobo21:4046
+      - ioaf127:4155
       X-Goog-Upload-Header-X-Google-Session-Info:
-      - CKeBxoimHBoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x4REJnUFlPVjl6R3I2TXJnVDhCV3NidmhjX3ZmTE03U0NjR0VlU2RxaDhFVjVnSTQ2R01KeFBMQVFLSnZJZlhEdkhpS0NsUld5VC1HOHFjcHJoc0k5QUJtRGJfUHMxMl8tSU5xWGxwWlY4WnFOSEIxbXJOZkplNkJ6RzZ3MAQ6DTEvSWFuUWZrd3Q0TX4
+      - CKeBxoimHBoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x4R0JpVGo2QTFJcnFFNmEzT2o1NksyV095MVAwRExTRF9yMEd4cGN1aW1PdnZkMWpBOVpvTGJJSWtCSnRPMkw3eENHUWlfS3ZSeTI4RDZFVmJXb0swT0p4ZFRGU1FKRklWTktOZVoyNnY4U1d1TzlHZk0yR045ZTN5ZFVRMAQ6DTEvSWFuUWZrd3Q0TX4
       X-Goog-Upload-Header-Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       X-Goog-Upload-Header-Pragma:
@@ -1537,11 +1682,11 @@ http_interactions:
       X-Goog-Upload-Header-Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       X-Goog-Upload-Header-Date:
-      - Sat, 27 Oct 2018 00:11:57 GMT
+      - Tue, 30 Oct 2018 04:27:53 GMT
       Content-Length:
       - '0'
       Date:
-      - Sat, 27 Oct 2018 00:11:58 GMT
+      - Tue, 30 Oct 2018 04:27:53 GMT
       Server:
       - UploadServer
       Content-Type:
@@ -1552,10 +1697,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:58 GMT
+  recorded_at: Tue, 30 Oct 2018 04:27:53 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/upload/drive/v3/files/1S0rVTehEHJOyh5VfFaNpRHWJJzYmuh6yfsjYRubJdVY?upload_id=AEnB2Uo1IxrVxhhLjt4WEcMK4FY6f_FM9FCtipDc8E38JyDbkE6QYAUKOddYh34hC_cR9-dFs9eeUgq9g7ClDpxvcVAmtYl8xvGSVxsawXj-PHcleHXSX4k&upload_protocol=resumable
+    uri: https://www.googleapis.com/upload/drive/v3/files/1to01JvVqV8ZJio4cWq1nEmt5YfHRd3bguXnlkCEHMQ0?upload_id=AEnB2UoiFoFHXXywD0bj87lKmw_kOggnYSnM2OyKKHlJPB_0E_nI9GXb6BUJmrW5T9dyhVrGxDDj-R0Q_SRMS3KD37zwdOZ9fsWYn53z7tXP6QhW7eGRzfc&upload_protocol=resumable
     body:
       encoding: UTF-8
       string: new file content
@@ -1567,7 +1712,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:58 GMT
+      - Tue, 30 Oct 2018 04:27:53 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       X-Goog-Upload-Command:
@@ -1582,7 +1727,7 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2Uo1IxrVxhhLjt4WEcMK4FY6f_FM9FCtipDc8E38JyDbkE6QYAUKOddYh34hC_cR9-dFs9eeUgq9g7ClDpxvcVAmtYl8xvGSVxsawXj-PHcleHXSX4k
+      - AEnB2UoiFoFHXXywD0bj87lKmw_kOggnYSnM2OyKKHlJPB_0E_nI9GXb6BUJmrW5T9dyhVrGxDDj-R0Q_SRMS3KD37zwdOZ9fsWYn53z7tXP6QhW7eGRzfc
       X-Goog-Upload-Status:
       - final
       Vary:
@@ -1597,7 +1742,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:59 GMT
+      - Tue, 30 Oct 2018 04:27:54 GMT
       Content-Length:
       - '154'
       Server:
@@ -1609,15 +1754,15 @@ http_interactions:
       string: |
         {
          "kind": "drive#file",
-         "id": "1S0rVTehEHJOyh5VfFaNpRHWJJzYmuh6yfsjYRubJdVY",
+         "id": "1to01JvVqV8ZJio4cWq1nEmt5YfHRd3bguXnlkCEHMQ0",
          "name": "Doc ABC",
          "mimeType": "application/vnd.google-apps.document"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:59 GMT
+  recorded_at: Tue, 30 Oct 2018 04:27:54 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1S0rVTehEHJOyh5VfFaNpRHWJJzYmuh6yfsjYRubJdVY?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1to01JvVqV8ZJio4cWq1nEmt5YfHRd3bguXnlkCEHMQ0?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1629,7 +1774,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:59 GMT
+      - Tue, 30 Oct 2018 04:27:54 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1640,9 +1785,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:11:59 GMT
+      - Tue, 30 Oct 2018 04:27:54 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:59 GMT
+      - Tue, 30 Oct 2018 04:27:54 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1668,14 +1813,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1S0rVTehEHJOyh5VfFaNpRHWJJzYmuh6yfsjYRubJdVY",
+         "id": "1to01JvVqV8ZJio4cWq1nEmt5YfHRd3bguXnlkCEHMQ0",
          "name": "Doc ABC",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "18erZaDlhd0u3YqwqDp7za0lprvs6HIWk"
+          "1oybl7hOTZNDmiSjNN9FcUTEuMKD_SBZs"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1S0rVTehEHJOyh5VfFaNpRHWJJzYmuh6yfsjYRubJdVY&v=2&s=AMedNnoAAAAAW9PJb_GvMnOWbZJoThCStq5954NS-5ro&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1to01JvVqV8ZJio4cWq1nEmt5YfHRd3bguXnlkCEHMQ0&v=2&s=AMedNnoAAAAAW9f56rZPsDJith0nwbLtb6pAMRwWfkcm&sz=s220",
          "thumbnailVersion": "2",
          "permissions": [
           {
@@ -1699,10 +1844,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:11:59 GMT
+  recorded_at: Tue, 30 Oct 2018 04:27:54 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1S0rVTehEHJOyh5VfFaNpRHWJJzYmuh6yfsjYRubJdVY/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1to01JvVqV8ZJio4cWq1nEmt5YfHRd3bguXnlkCEHMQ0/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1714,7 +1859,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:11:59 GMT
+      - Tue, 30 Oct 2018 04:27:54 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1725,9 +1870,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:11:59 GMT
+      - Tue, 30 Oct 2018 04:27:55 GMT
       Date:
-      - Sat, 27 Oct 2018 00:11:59 GMT
+      - Tue, 30 Oct 2018 04:27:55 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1756,13 +1901,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "3",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-27T00:11:58.824Z"
+         "modifiedTime": "2018-10-30T04:27:54.007Z"
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:12:00 GMT
+  recorded_at: Tue, 30 Oct 2018 04:27:55 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1S0rVTehEHJOyh5VfFaNpRHWJJzYmuh6yfsjYRubJdVY&s=AMedNnoAAAAAW9PJb_GvMnOWbZJoThCStq5954NS-5ro&sz=s350&v=2
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1to01JvVqV8ZJio4cWq1nEmt5YfHRd3bguXnlkCEHMQ0&s=AMedNnoAAAAAW9f56rZPsDJith0nwbLtb6pAMRwWfkcm&sz=s350&v=2
     body:
       encoding: UTF-8
       string: ''
@@ -1774,7 +1919,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:12:00 GMT
+      - Tue, 30 Oct 2018 04:27:55 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1805,7 +1950,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Sat, 27 Oct 2018 00:12:00 GMT
+      - Tue, 30 Oct 2018 04:27:55 GMT
       Server:
       - fife
       Content-Length:
@@ -1819,13 +1964,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:12:00 GMT
+  recorded_at: Tue, 30 Oct 2018 04:27:55 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1S0rVTehEHJOyh5VfFaNpRHWJJzYmuh6yfsjYRubJdVY/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1to01JvVqV8ZJio4cWq1nEmt5YfHRd3bguXnlkCEHMQ0/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"Doc ABC","parents":["1YPqXCXdagR_JMHj1q1-T94ogO1b3mR-V"]}'
+      string: '{"name":"Doc ABC","parents":["1CVzGdPaEaKza6C1j_txLtOVAoWkrUxeo"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1834,7 +1979,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:12:00 GMT
+      - Tue, 30 Oct 2018 04:27:55 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1851,7 +1996,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:12:01 GMT
+      - Tue, 30 Oct 2018 04:27:56 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1875,12 +2020,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "11SCcIpXTpLqS44hzkWCT2nrdzzTY4kUrlN8KN9anXvw",
+         "id": "1ci_A0zI0YUCgUk1aB4EZUw9rHXU4b2bIVXfH4Lunnbk",
          "name": "Doc ABC",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1YPqXCXdagR_JMHj1q1-T94ogO1b3mR-V"
+          "1CVzGdPaEaKza6C1j_txLtOVAoWkrUxeo"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1905,10 +2050,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:12:01 GMT
+  recorded_at: Tue, 30 Oct 2018 04:27:56 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/11SCcIpXTpLqS44hzkWCT2nrdzzTY4kUrlN8KN9anXvw?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ci_A0zI0YUCgUk1aB4EZUw9rHXU4b2bIVXfH4Lunnbk?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1920,7 +2065,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:12:01 GMT
+      - Tue, 30 Oct 2018 04:27:57 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1931,9 +2076,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 27 Oct 2018 00:12:02 GMT
+      - Tue, 30 Oct 2018 04:27:57 GMT
       Date:
-      - Sat, 27 Oct 2018 00:12:02 GMT
+      - Tue, 30 Oct 2018 04:27:57 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1959,12 +2104,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "11SCcIpXTpLqS44hzkWCT2nrdzzTY4kUrlN8KN9anXvw",
+         "id": "1ci_A0zI0YUCgUk1aB4EZUw9rHXU4b2bIVXfH4Lunnbk",
          "name": "Doc ABC",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1YPqXCXdagR_JMHj1q1-T94ogO1b3mR-V"
+          "1CVzGdPaEaKza6C1j_txLtOVAoWkrUxeo"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1989,10 +2134,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:12:02 GMT
+  recorded_at: Tue, 30 Oct 2018 04:27:57 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1_NYqFD0OK8Flqr5CxwbajWXUz4YvBHcz
+    uri: https://www.googleapis.com/drive/v3/files/1xNVsaRILkoptAu7_z1f0veAzGsY-RIBS
     body:
       encoding: UTF-8
       string: ''
@@ -2004,7 +2149,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 27 Oct 2018 00:12:02 GMT
+      - Tue, 30 Oct 2018 04:27:57 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -2021,7 +2166,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 27 Oct 2018 00:12:02 GMT
+      - Tue, 30 Oct 2018 04:27:57 GMT
       Vary:
       - Origin
       - X-Origin
@@ -2033,5 +2178,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sat, 27 Oct 2018 00:12:02 GMT
+  recorded_at: Tue, 30 Oct 2018 04:27:57 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/VCS_Archive/_setup/creates_a_folder_in_Google_Drive.yml
+++ b/spec/support/fixtures/vcr_cassettes/VCS_Archive/_setup/creates_a_folder_in_Google_Drive.yml
@@ -1,0 +1,518 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://oauth2.googleapis.com/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR TRACKING ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Mon, 29 Oct 2018 18:51:56 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 18:51:56 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-29
+        18:51:56 UTC","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 18:51:56 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 18:51:57 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1ZF5CjO6IHhsudgUxjGkMAzAaw-m4Aysw",
+         "name": "Test @ 2018-10-29 18:51:56 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 18:51:57 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"DEMO (Archive)","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 18:51:57 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 18:51:57 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1wuVsdtdfaU53ULBtWDPfItGA8ZYCl-88",
+         "name": "DEMO (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 18:51:57 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1wuVsdtdfaU53ULBtWDPfItGA8ZYCl-88/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 18:51:57 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 18:51:58 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "13193959451567607887",
+         "type": "user",
+         "role": "reader"
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 18:51:58 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/root?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 18:51:58 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 18:51:58 GMT
+      Date:
+      - Mon, 29 Oct 2018 18:51:58 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "0AIeK5UAEPQfeUk9PVA",
+         "name": "My Drive",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 18:51:58 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1wuVsdtdfaU53ULBtWDPfItGA8ZYCl-88?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 18:51:58 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 18:51:58 GMT
+      Date:
+      - Mon, 29 Oct 2018 18:51:58 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1wuVsdtdfaU53ULBtWDPfItGA8ZYCl-88",
+         "name": "DEMO (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 18:51:58 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1wuVsdtdfaU53ULBtWDPfItGA8ZYCl-88
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 18:51:58 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 18:51:58 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 18:51:58 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1ZF5CjO6IHhsudgUxjGkMAzAaw-m4Aysw
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 18:51:58 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 18:51:59 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 18:51:59 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/VCS_Archive/_setup/shares_view_access_to_the_archive_with_the_repository_owner.yml
+++ b/spec/support/fixtures/vcr_cassettes/VCS_Archive/_setup/shares_view_access_to_the_archive_with_the_repository_owner.yml
@@ -1,0 +1,446 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://oauth2.googleapis.com/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR TRACKING ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Mon, 29 Oct 2018 18:44:23 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 18:44:23 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-29
+        18:44:23 UTC","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 18:44:23 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 18:44:24 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1VAFLHllUkAT6xazz7Jyw1HZ9Z_dEkrp6",
+         "name": "Test @ 2018-10-29 18:44:23 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 18:44:24 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"DEMO (Archive)","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 18:44:24 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 18:44:24 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "109sq29UpqYWzFYxZj-48Ti1dfjv3XeRz",
+         "name": "DEMO (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 18:44:24 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/109sq29UpqYWzFYxZj-48Ti1dfjv3XeRz/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 18:44:24 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 18:44:25 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "13193959451567607887",
+         "type": "user",
+         "role": "reader"
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 18:44:25 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/109sq29UpqYWzFYxZj-48Ti1dfjv3XeRz?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 18:44:25 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 18:44:25 GMT
+      Date:
+      - Mon, 29 Oct 2018 18:44:25 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "109sq29UpqYWzFYxZj-48Ti1dfjv3XeRz",
+         "name": "DEMO (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 18:44:25 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/109sq29UpqYWzFYxZj-48Ti1dfjv3XeRz
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 18:44:25 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 18:44:26 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 18:44:26 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1VAFLHllUkAT6xazz7Jyw1HZ9Z_dEkrp6
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 18:44:26 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 18:44:26 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 18:44:26 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/VCS_FileBackup/_capture/inherits_access_permissions_from_archive_folder.yml
+++ b/spec/support/fixtures/vcr_cassettes/VCS_FileBackup/_capture/inherits_access_permissions_from_archive_folder.yml
@@ -1,0 +1,830 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://oauth2.googleapis.com/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR TRACKING ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Wed, 31 Oct 2018 00:36:27 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:36:27 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-31
+        00:36:27 UTC","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:36:27 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:36:28 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1Bd6WYFG2AzdSku-VxTAn3iArZo8aOXdL",
+         "name": "Test @ 2018-10-31 00:36:27 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:36:28 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"1 Billion
+        Year Bunker (Archive)","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:36:29 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:36:30 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "17GIF7Rntu7jRZPDYi1VKdKkB8kLCUSHq",
+         "name": "1 Billion Year Bunker (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:36:30 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/17GIF7Rntu7jRZPDYi1VKdKkB8kLCUSHq/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:36:30 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:36:31 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "13193959451567607887",
+         "type": "user",
+         "role": "reader"
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:36:31 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"An Awesome
+        File","parents":["1Bd6WYFG2AzdSku-VxTAn3iArZo8aOXdL"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:36:31 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:36:32 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1x-N3y4z1Zoz159lVrOTsZAyTJ50SxXmvSWtNSvEUG-o",
+         "name": "An Awesome File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1Bd6WYFG2AzdSku-VxTAn3iArZo8aOXdL"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:36:32 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1x-N3y4z1Zoz159lVrOTsZAyTJ50SxXmvSWtNSvEUG-o?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:36:32 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Wed, 31 Oct 2018 00:36:32 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:36:32 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1x-N3y4z1Zoz159lVrOTsZAyTJ50SxXmvSWtNSvEUG-o",
+         "name": "An Awesome File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1Bd6WYFG2AzdSku-VxTAn3iArZo8aOXdL"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:36:32 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1x-N3y4z1Zoz159lVrOTsZAyTJ50SxXmvSWtNSvEUG-o/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:36:32 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Wed, 31 Oct 2018 00:36:33 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:36:33 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-31T00:36:31.565Z"
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:36:33 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1x-N3y4z1Zoz159lVrOTsZAyTJ50SxXmvSWtNSvEUG-o/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"An Awesome File","parents":["17GIF7Rntu7jRZPDYi1VKdKkB8kLCUSHq"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:36:33 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:36:35 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1LVj0wpeeyCfhwKgFmrQUIaES3Q6IUADKygGtRoRBVTg",
+         "name": "An Awesome File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "17GIF7Rntu7jRZPDYi1VKdKkB8kLCUSHq"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:36:35 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/17GIF7Rntu7jRZPDYi1VKdKkB8kLCUSHq?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:36:35 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Wed, 31 Oct 2018 00:36:35 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:36:35 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "17GIF7Rntu7jRZPDYi1VKdKkB8kLCUSHq",
+         "name": "1 Billion Year Bunker (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:36:35 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1LVj0wpeeyCfhwKgFmrQUIaES3Q6IUADKygGtRoRBVTg?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:36:35 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Wed, 31 Oct 2018 00:36:35 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:36:35 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1LVj0wpeeyCfhwKgFmrQUIaES3Q6IUADKygGtRoRBVTg",
+         "name": "An Awesome File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "17GIF7Rntu7jRZPDYi1VKdKkB8kLCUSHq"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:36:35 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/17GIF7Rntu7jRZPDYi1VKdKkB8kLCUSHq
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:36:35 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:36:36 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:36:36 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1Bd6WYFG2AzdSku-VxTAn3iArZo8aOXdL
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:36:36 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:36:36 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:36:36 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/VCS_FileBackup/_capture/stores_a_copy_of_the_file_snapshot_in_archive.yml
+++ b/spec/support/fixtures/vcr_cassettes/VCS_FileBackup/_capture/stores_a_copy_of_the_file_snapshot_in_archive.yml
@@ -1,0 +1,746 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://oauth2.googleapis.com/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR TRACKING ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Wed, 31 Oct 2018 00:36:37 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:36:37 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-31
+        00:36:37 UTC","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:36:37 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:36:37 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1AFMc4utnNLuiXjGTDwwnFTgmq5kj98Zb",
+         "name": "Test @ 2018-10-31 00:36:37 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:36:37 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"2 Billion
+        Year Bunker (Archive)","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:36:37 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:36:38 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1fATrlDRsT9WL8xI0Gtf3eftykmfVsfrA",
+         "name": "2 Billion Year Bunker (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:36:38 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1fATrlDRsT9WL8xI0Gtf3eftykmfVsfrA/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:36:38 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:36:39 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "13193959451567607887",
+         "type": "user",
+         "role": "reader"
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:36:39 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"An Awesome
+        File","parents":["1AFMc4utnNLuiXjGTDwwnFTgmq5kj98Zb"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:36:39 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:36:40 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1Ddpsy6A6UTCdPslmZC9e6UgH76toEtR9a-zVh7owRzQ",
+         "name": "An Awesome File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1AFMc4utnNLuiXjGTDwwnFTgmq5kj98Zb"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:36:41 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1Ddpsy6A6UTCdPslmZC9e6UgH76toEtR9a-zVh7owRzQ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:36:41 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Wed, 31 Oct 2018 00:36:41 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:36:41 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1Ddpsy6A6UTCdPslmZC9e6UgH76toEtR9a-zVh7owRzQ",
+         "name": "An Awesome File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1AFMc4utnNLuiXjGTDwwnFTgmq5kj98Zb"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:36:41 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1Ddpsy6A6UTCdPslmZC9e6UgH76toEtR9a-zVh7owRzQ/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:36:41 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Wed, 31 Oct 2018 00:36:41 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:36:41 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-31T00:36:39.629Z"
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:36:41 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1Ddpsy6A6UTCdPslmZC9e6UgH76toEtR9a-zVh7owRzQ/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"An Awesome File","parents":["1fATrlDRsT9WL8xI0Gtf3eftykmfVsfrA"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:36:41 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:36:43 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1lPkrv9vFuYPtNYDXAjaTuUA9fqdMMoWb-8RRxEUtmCc",
+         "name": "An Awesome File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1fATrlDRsT9WL8xI0Gtf3eftykmfVsfrA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:36:43 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1lPkrv9vFuYPtNYDXAjaTuUA9fqdMMoWb-8RRxEUtmCc?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:36:43 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Wed, 31 Oct 2018 00:36:43 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:36:43 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1lPkrv9vFuYPtNYDXAjaTuUA9fqdMMoWb-8RRxEUtmCc",
+         "name": "An Awesome File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1fATrlDRsT9WL8xI0Gtf3eftykmfVsfrA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:36:43 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1fATrlDRsT9WL8xI0Gtf3eftykmfVsfrA
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:36:43 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:36:44 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:36:44 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1AFMc4utnNLuiXjGTDwwnFTgmq5kj98Zb
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:36:44 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:36:44 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:36:44 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/VCS_StagedFile/it_should_behave_like_vcs_including_syncable_integration/_fetch/sets_correct_attributes.yml
+++ b/spec/support/fixtures/vcr_cassettes/VCS_StagedFile/it_should_behave_like_vcs_including_syncable_integration/_fetch/sets_correct_attributes.yml
@@ -1,0 +1,586 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://oauth2.googleapis.com/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR TRACKING ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Mon, 29 Oct 2018 16:07:49 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:49 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-29
+        16:07:49 UTC","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:07:49 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:07:50 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1xHiTCjyQRBK5qssLazPNO7jhndqvaXLZ",
+         "name": "Test @ 2018-10-29 16:07:49 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:50 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1xHiTCjyQRBK5qssLazPNO7jhndqvaXLZ"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:07:50 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:07:51 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1NLF5i9WKI1wj4F3iVy_LFv_tneLwrZiF91cXR9KF3xI",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1xHiTCjyQRBK5qssLazPNO7jhndqvaXLZ"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:52 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/upload/drive/v3/files/1NLF5i9WKI1wj4F3iVy_LFv_tneLwrZiF91cXR9KF3xI
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:07:52 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      X-Goog-Upload-Protocol:
+      - resumable
+      X-Goog-Upload-Command:
+      - start
+      X-Goog-Upload-Header-Content-Length:
+      - '16'
+      X-Goog-Upload-Header-Content-Type:
+      - application/octet-stream
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Guploader-Uploadid:
+      - AEnB2UrlX9EL8f2o54oW96p_EaPkYwoAKQ6eKyP31AUbffoCyNf2hbuhr9qfbhW8EF-yg-rl5NXIvna0Tlx8TjFet1OVxp-cLLHOqcHMwu5cG-WoI_2xR9A
+      X-Goog-Upload-Status:
+      - active
+      X-Goog-Upload-Url:
+      - https://www.googleapis.com/upload/drive/v3/files/1NLF5i9WKI1wj4F3iVy_LFv_tneLwrZiF91cXR9KF3xI?upload_id=AEnB2UrlX9EL8f2o54oW96p_EaPkYwoAKQ6eKyP31AUbffoCyNf2hbuhr9qfbhW8EF-yg-rl5NXIvna0Tlx8TjFet1OVxp-cLLHOqcHMwu5cG-WoI_2xR9A&upload_protocol=resumable
+      X-Goog-Upload-Control-Url:
+      - https://www.googleapis.com/upload/drive/v3/files/1NLF5i9WKI1wj4F3iVy_LFv_tneLwrZiF91cXR9KF3xI?upload_id=AEnB2UrlX9EL8f2o54oW96p_EaPkYwoAKQ6eKyP31AUbffoCyNf2hbuhr9qfbhW8EF-yg-rl5NXIvna0Tlx8TjFet1OVxp-cLLHOqcHMwu5cG-WoI_2xR9A&upload_protocol=resumable
+      X-Goog-Upload-Chunk-Granularity:
+      - '262144'
+      X-Goog-Upload-Header-Vary:
+      - Origin
+      - X-Origin
+      X-Goog-Upload-Header-X-Google-Backends:
+      - oifr66:4284
+      X-Goog-Upload-Header-X-Google-Session-Info:
+      - CLrLzJuGFRoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x4RkJweURZSUxjTE5rOVVMVDQ0OThFME03MGt4WXQtVE9EaWpSTUJBMnRaRDB1Z2k5YWNMVlo0RWxRZ1BVRGI1NEF0cVdxVWROQnRHT1VhR05Bd1NNdlhWOUhNN2ZENE5SUFh4a045cXBicHpJUzltc1NEZHNvWGwtekZnMAQ6DTEvMk0zUkd3d1ZsWn4
+      X-Goog-Upload-Header-Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      X-Goog-Upload-Header-Pragma:
+      - no-cache
+      X-Goog-Upload-Header-Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      X-Goog-Upload-Header-Date:
+      - Mon, 29 Oct 2018 16:07:52 GMT
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 29 Oct 2018 16:07:52 GMT
+      Server:
+      - UploadServer
+      Content-Type:
+      - text/html; charset=UTF-8
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:53 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/upload/drive/v3/files/1NLF5i9WKI1wj4F3iVy_LFv_tneLwrZiF91cXR9KF3xI?upload_id=AEnB2UrlX9EL8f2o54oW96p_EaPkYwoAKQ6eKyP31AUbffoCyNf2hbuhr9qfbhW8EF-yg-rl5NXIvna0Tlx8TjFet1OVxp-cLLHOqcHMwu5cG-WoI_2xR9A&upload_protocol=resumable
+    body:
+      encoding: UTF-8
+      string: new file content
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:07:53 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      X-Goog-Upload-Command:
+      - upload, finalize
+      X-Goog-Upload-Offset:
+      - '0'
+      Content-Type:
+      - application/octet-stream
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Guploader-Uploadid:
+      - AEnB2UrlX9EL8f2o54oW96p_EaPkYwoAKQ6eKyP31AUbffoCyNf2hbuhr9qfbhW8EF-yg-rl5NXIvna0Tlx8TjFet1OVxp-cLLHOqcHMwu5cG-WoI_2xR9A
+      X-Goog-Upload-Status:
+      - final
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:07:54 GMT
+      Content-Length:
+      - '156'
+      Server:
+      - UploadServer
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#file",
+         "id": "1NLF5i9WKI1wj4F3iVy_LFv_tneLwrZiF91cXR9KF3xI",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document"
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:55 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1NLF5i9WKI1wj4F3iVy_LFv_tneLwrZiF91cXR9KF3xI?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:08:00 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 16:08:01 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:08:01 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1NLF5i9WKI1wj4F3iVy_LFv_tneLwrZiF91cXR9KF3xI",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1xHiTCjyQRBK5qssLazPNO7jhndqvaXLZ"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1NLF5i9WKI1wj4F3iVy_LFv_tneLwrZiF91cXR9KF3xI&v=1&s=AMedNnoAAAAAW9dMgdbxjoGX4LnH-QQtun7npM6816Pc&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:08:01 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1NLF5i9WKI1wj4F3iVy_LFv_tneLwrZiF91cXR9KF3xI/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:08:01 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 16:08:02 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:08:02 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "3",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-29T16:07:54.367Z"
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:08:02 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1NLF5i9WKI1wj4F3iVy_LFv_tneLwrZiF91cXR9KF3xI&s=AMedNnoAAAAAW9dMgdbxjoGX4LnH-QQtun7npM6816Pc&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:08:02 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 29 Oct 2018 16:08:03 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:08:03 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1xHiTCjyQRBK5qssLazPNO7jhndqvaXLZ
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:08:03 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:08:04 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:08:04 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/VCS_StagedFile/it_should_behave_like_vcs_including_syncable_integration/_fetch/when_file_is_removed/1_2_1_3_1.yml
+++ b/spec/support/fixtures/vcr_cassettes/VCS_StagedFile/it_should_behave_like_vcs_including_syncable_integration/_fetch/when_file_is_removed/1_2_1_3_1.yml
@@ -1,0 +1,503 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://oauth2.googleapis.com/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR TRACKING ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Mon, 29 Oct 2018 16:08:16 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:08:16 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-29
+        16:08:16 UTC","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:08:16 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:08:16 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1nIKtoEUDX1mEEeYynVl84VaZoJM5b-CU",
+         "name": "Test @ 2018-10-29 16:08:16 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:08:17 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1nIKtoEUDX1mEEeYynVl84VaZoJM5b-CU"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:08:17 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:08:18 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "17aomiFrbyZlzURqKuWHcZF0ksItPIQmJBrpmoH5luOk",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1nIKtoEUDX1mEEeYynVl84VaZoJM5b-CU"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:08:18 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/upload/drive/v3/files/17aomiFrbyZlzURqKuWHcZF0ksItPIQmJBrpmoH5luOk
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:08:18 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      X-Goog-Upload-Protocol:
+      - resumable
+      X-Goog-Upload-Command:
+      - start
+      X-Goog-Upload-Header-Content-Length:
+      - '16'
+      X-Goog-Upload-Header-Content-Type:
+      - application/octet-stream
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Guploader-Uploadid:
+      - AEnB2Up4FzS1cfvImK-1MYZMop7mYtWm3N8-44joR12UDDNmWQXHZhy4zmTqKlrqRYesE_Bo3fdo1yQLC5t4ZMpE11ggCA-LJdAE1cd3YMrW1d6cTAzrBos
+      X-Goog-Upload-Status:
+      - active
+      X-Goog-Upload-Url:
+      - https://www.googleapis.com/upload/drive/v3/files/17aomiFrbyZlzURqKuWHcZF0ksItPIQmJBrpmoH5luOk?upload_id=AEnB2Up4FzS1cfvImK-1MYZMop7mYtWm3N8-44joR12UDDNmWQXHZhy4zmTqKlrqRYesE_Bo3fdo1yQLC5t4ZMpE11ggCA-LJdAE1cd3YMrW1d6cTAzrBos&upload_protocol=resumable
+      X-Goog-Upload-Control-Url:
+      - https://www.googleapis.com/upload/drive/v3/files/17aomiFrbyZlzURqKuWHcZF0ksItPIQmJBrpmoH5luOk?upload_id=AEnB2Up4FzS1cfvImK-1MYZMop7mYtWm3N8-44joR12UDDNmWQXHZhy4zmTqKlrqRYesE_Bo3fdo1yQLC5t4ZMpE11ggCA-LJdAE1cd3YMrW1d6cTAzrBos&upload_protocol=resumable
+      X-Goog-Upload-Chunk-Granularity:
+      - '262144'
+      X-Goog-Upload-Header-Vary:
+      - Origin
+      - X-Origin
+      X-Goog-Upload-Header-X-Google-Backends:
+      - oiad81:4404
+      X-Goog-Upload-Header-X-Google-Session-Info:
+      - CLrLzJuGFRoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x4RkJyY3Z4MzdxZEJhTlN6NE1Ga1RSNmxNMDlmTi1DeTNLYV9VY0p5R2xZNnp3RmVncUtYY3dFSUwtWmx4TTVIc1Y4MEU0X05LNkJ2MWNFUXFZWHVsX3NHdXRMV2RBcThSb2dHNnNGNGhIcHpQNVMyc1hWU2FMYldTaDh3MAQ6DTEvMk0zUkd3d1ZsWn4
+      X-Goog-Upload-Header-Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      X-Goog-Upload-Header-Pragma:
+      - no-cache
+      X-Goog-Upload-Header-Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      X-Goog-Upload-Header-Date:
+      - Mon, 29 Oct 2018 16:08:18 GMT
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 29 Oct 2018 16:08:18 GMT
+      Server:
+      - UploadServer
+      Content-Type:
+      - text/html; charset=UTF-8
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:08:18 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/upload/drive/v3/files/17aomiFrbyZlzURqKuWHcZF0ksItPIQmJBrpmoH5luOk?upload_id=AEnB2Up4FzS1cfvImK-1MYZMop7mYtWm3N8-44joR12UDDNmWQXHZhy4zmTqKlrqRYesE_Bo3fdo1yQLC5t4ZMpE11ggCA-LJdAE1cd3YMrW1d6cTAzrBos&upload_protocol=resumable
+    body:
+      encoding: UTF-8
+      string: new file content
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:08:18 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      X-Goog-Upload-Command:
+      - upload, finalize
+      X-Goog-Upload-Offset:
+      - '0'
+      Content-Type:
+      - application/octet-stream
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Guploader-Uploadid:
+      - AEnB2Up4FzS1cfvImK-1MYZMop7mYtWm3N8-44joR12UDDNmWQXHZhy4zmTqKlrqRYesE_Bo3fdo1yQLC5t4ZMpE11ggCA-LJdAE1cd3YMrW1d6cTAzrBos
+      X-Goog-Upload-Status:
+      - final
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:08:20 GMT
+      Content-Length:
+      - '156'
+      Server:
+      - UploadServer
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#file",
+         "id": "17aomiFrbyZlzURqKuWHcZF0ksItPIQmJBrpmoH5luOk",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document"
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:08:21 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/17aomiFrbyZlzURqKuWHcZF0ksItPIQmJBrpmoH5luOk
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:08:26 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:08:26 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:08:26 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/17aomiFrbyZlzURqKuWHcZF0ksItPIQmJBrpmoH5luOk?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:08:26 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 29 Oct 2018 16:08:26 GMT
+      Expires:
+      - Mon, 29 Oct 2018 16:08:26 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "notFound",
+            "message": "File not found: 17aomiFrbyZlzURqKuWHcZF0ksItPIQmJBrpmoH5luOk.",
+            "locationType": "parameter",
+            "location": "fileId"
+           }
+          ],
+          "code": 404,
+          "message": "File not found: 17aomiFrbyZlzURqKuWHcZF0ksItPIQmJBrpmoH5luOk."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:08:26 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1nIKtoEUDX1mEEeYynVl84VaZoJM5b-CU
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:08:26 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:08:27 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:08:27 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/VCS_StagedFile/it_should_behave_like_vcs_including_syncable_integration/_fetch/when_file_is_trashed/1_2_1_2_1.yml
+++ b/spec/support/fixtures/vcr_cassettes/VCS_StagedFile/it_should_behave_like_vcs_including_syncable_integration/_fetch/when_file_is_trashed/1_2_1_2_1.yml
@@ -1,0 +1,544 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://oauth2.googleapis.com/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR TRACKING ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Mon, 29 Oct 2018 16:08:04 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:08:04 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-29
+        16:08:04 UTC","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:08:04 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:08:05 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1igaJNe91zvzr9OzgZ7nWEWF8PSjFX6x8",
+         "name": "Test @ 2018-10-29 16:08:04 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:08:05 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1igaJNe91zvzr9OzgZ7nWEWF8PSjFX6x8"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:08:05 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:08:06 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1Ig_QW1y4C58KdbGJtOOCX2CwcRrPx1c5wH5mnHQkHVc",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1igaJNe91zvzr9OzgZ7nWEWF8PSjFX6x8"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:08:06 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/upload/drive/v3/files/1Ig_QW1y4C58KdbGJtOOCX2CwcRrPx1c5wH5mnHQkHVc
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:08:06 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      X-Goog-Upload-Protocol:
+      - resumable
+      X-Goog-Upload-Command:
+      - start
+      X-Goog-Upload-Header-Content-Length:
+      - '16'
+      X-Goog-Upload-Header-Content-Type:
+      - application/octet-stream
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Guploader-Uploadid:
+      - AEnB2UrgNAywrGA5BEy3ZTyEv_CwLjsjR4Hs1LzQg6bAOFnvj6wvfezAd-s-UqUU2y62SA4yw1UPjFHe4bsHwui8qt0podpeBtaa0j_SjvXlijD9unjzif4
+      X-Goog-Upload-Status:
+      - active
+      X-Goog-Upload-Url:
+      - https://www.googleapis.com/upload/drive/v3/files/1Ig_QW1y4C58KdbGJtOOCX2CwcRrPx1c5wH5mnHQkHVc?upload_id=AEnB2UrgNAywrGA5BEy3ZTyEv_CwLjsjR4Hs1LzQg6bAOFnvj6wvfezAd-s-UqUU2y62SA4yw1UPjFHe4bsHwui8qt0podpeBtaa0j_SjvXlijD9unjzif4&upload_protocol=resumable
+      X-Goog-Upload-Control-Url:
+      - https://www.googleapis.com/upload/drive/v3/files/1Ig_QW1y4C58KdbGJtOOCX2CwcRrPx1c5wH5mnHQkHVc?upload_id=AEnB2UrgNAywrGA5BEy3ZTyEv_CwLjsjR4Hs1LzQg6bAOFnvj6wvfezAd-s-UqUU2y62SA4yw1UPjFHe4bsHwui8qt0podpeBtaa0j_SjvXlijD9unjzif4&upload_protocol=resumable
+      X-Goog-Upload-Chunk-Granularity:
+      - '262144'
+      X-Goog-Upload-Header-Vary:
+      - Origin
+      - X-Origin
+      X-Goog-Upload-Header-X-Google-Backends:
+      - oibn82:4203
+      X-Goog-Upload-Header-X-Google-Session-Info:
+      - CLrLzJuGFRoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x4RkJqS1pBWkNxVkMzdHUwWjdQV1lUNjExU1VQc2ozejFxNjNEMlpDcERKVVZQYWUxdFBHay1mNzRLUERLNTFVM1U3NHZqTUtyNHd4WFBBSzdyNnZMMWNLM19KMWJOc21NaTllSHlhYlFsaFNsNkI5cGZ0Y2x1ZEhOWkJnMAQ6DTEvMk0zUkd3d1ZsWn4
+      X-Goog-Upload-Header-Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      X-Goog-Upload-Header-Pragma:
+      - no-cache
+      X-Goog-Upload-Header-Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      X-Goog-Upload-Header-Date:
+      - Mon, 29 Oct 2018 16:08:07 GMT
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 29 Oct 2018 16:08:07 GMT
+      Server:
+      - UploadServer
+      Content-Type:
+      - text/html; charset=UTF-8
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:08:07 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/upload/drive/v3/files/1Ig_QW1y4C58KdbGJtOOCX2CwcRrPx1c5wH5mnHQkHVc?upload_id=AEnB2UrgNAywrGA5BEy3ZTyEv_CwLjsjR4Hs1LzQg6bAOFnvj6wvfezAd-s-UqUU2y62SA4yw1UPjFHe4bsHwui8qt0podpeBtaa0j_SjvXlijD9unjzif4&upload_protocol=resumable
+    body:
+      encoding: UTF-8
+      string: new file content
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:08:07 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      X-Goog-Upload-Command:
+      - upload, finalize
+      X-Goog-Upload-Offset:
+      - '0'
+      Content-Type:
+      - application/octet-stream
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Guploader-Uploadid:
+      - AEnB2UrgNAywrGA5BEy3ZTyEv_CwLjsjR4Hs1LzQg6bAOFnvj6wvfezAd-s-UqUU2y62SA4yw1UPjFHe4bsHwui8qt0podpeBtaa0j_SjvXlijD9unjzif4
+      X-Goog-Upload-Status:
+      - final
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:08:08 GMT
+      Content-Length:
+      - '156'
+      Server:
+      - UploadServer
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#file",
+         "id": "1Ig_QW1y4C58KdbGJtOOCX2CwcRrPx1c5wH5mnHQkHVc",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document"
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:08:08 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/drive/v3/files/1Ig_QW1y4C58KdbGJtOOCX2CwcRrPx1c5wH5mnHQkHVc?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"trashed":"true"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:08:13 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:08:13 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1Ig_QW1y4C58KdbGJtOOCX2CwcRrPx1c5wH5mnHQkHVc",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": true,
+         "parents": [
+          "1igaJNe91zvzr9OzgZ7nWEWF8PSjFX6x8"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Ig_QW1y4C58KdbGJtOOCX2CwcRrPx1c5wH5mnHQkHVc&v=1&s=AMedNnoAAAAAW9dMjfYoXfmsLjfMv5oqZbz9MqOG_hwJ&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:08:14 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1Ig_QW1y4C58KdbGJtOOCX2CwcRrPx1c5wH5mnHQkHVc?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:08:14 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 16:08:15 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:08:15 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1Ig_QW1y4C58KdbGJtOOCX2CwcRrPx1c5wH5mnHQkHVc",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": true,
+         "parents": [
+          "1igaJNe91zvzr9OzgZ7nWEWF8PSjFX6x8"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Ig_QW1y4C58KdbGJtOOCX2CwcRrPx1c5wH5mnHQkHVc&v=1&s=AMedNnoAAAAAW9dMjyaDG2vkR7S9zYMa2yNhOpw4lS_P&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:08:15 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1igaJNe91zvzr9OzgZ7nWEWF8PSjFX6x8
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:08:15 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:08:16 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:08:16 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/VCS_StagedFile/it_should_behave_like_vcs_including_syncable_integration/_pull/sets_correct_attributes.yml
+++ b/spec/support/fixtures/vcr_cassettes/VCS_StagedFile/it_should_behave_like_vcs_including_syncable_integration/_pull/sets_correct_attributes.yml
@@ -1,0 +1,586 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://oauth2.googleapis.com/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR TRACKING ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Mon, 29 Oct 2018 16:06:57 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:06:57 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-29
+        16:06:57 UTC","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:06:57 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:06:59 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1byTszweq-n_K1oavBbQ3XrIXLTy3x2bU",
+         "name": "Test @ 2018-10-29 16:06:57 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:06:59 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1byTszweq-n_K1oavBbQ3XrIXLTy3x2bU"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:07:00 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:07:01 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1t41jgWEZAxfWj55PJyio9txMlensy6SU3J_EhzPCdsg",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1byTszweq-n_K1oavBbQ3XrIXLTy3x2bU"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:01 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/upload/drive/v3/files/1t41jgWEZAxfWj55PJyio9txMlensy6SU3J_EhzPCdsg
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:07:01 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      X-Goog-Upload-Protocol:
+      - resumable
+      X-Goog-Upload-Command:
+      - start
+      X-Goog-Upload-Header-Content-Length:
+      - '16'
+      X-Goog-Upload-Header-Content-Type:
+      - application/octet-stream
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Guploader-Uploadid:
+      - AEnB2UoBeYFCvYDspPqr9lujDU6wtP0NbNmOm25HgvRB-CrM2NgBgim1DR4qiUnkIYrp8-0CB5CNokq-E7mS9_YKn84BB6J6AQ
+      X-Goog-Upload-Status:
+      - active
+      X-Goog-Upload-Url:
+      - https://www.googleapis.com/upload/drive/v3/files/1t41jgWEZAxfWj55PJyio9txMlensy6SU3J_EhzPCdsg?upload_id=AEnB2UoBeYFCvYDspPqr9lujDU6wtP0NbNmOm25HgvRB-CrM2NgBgim1DR4qiUnkIYrp8-0CB5CNokq-E7mS9_YKn84BB6J6AQ&upload_protocol=resumable
+      X-Goog-Upload-Control-Url:
+      - https://www.googleapis.com/upload/drive/v3/files/1t41jgWEZAxfWj55PJyio9txMlensy6SU3J_EhzPCdsg?upload_id=AEnB2UoBeYFCvYDspPqr9lujDU6wtP0NbNmOm25HgvRB-CrM2NgBgim1DR4qiUnkIYrp8-0CB5CNokq-E7mS9_YKn84BB6J6AQ&upload_protocol=resumable
+      X-Goog-Upload-Chunk-Granularity:
+      - '262144'
+      X-Goog-Upload-Header-Vary:
+      - Origin
+      - X-Origin
+      X-Goog-Upload-Header-X-Google-Backends:
+      - oiha128:4061
+      X-Goog-Upload-Header-X-Google-Session-Info:
+      - CLrLzJuGFRoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x4RkJtcUdLcnJFNXVMcFFkTWdYVFFablVWdHlyZHBIY1R4NUplLWQycUJnRHU3TG9mb2ZSTlFvbm1PMEd6cFBpc3ZMZXZ1c1lvQ3phWEV1NkdQZmVocjNobHFDSnFVQU5zWkI2eE56bFV1OTZObXMxQzN4YzlWNm5RbDVBMAQ6DTEvMk0zUkd3d1ZsWn4
+      X-Goog-Upload-Header-Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      X-Goog-Upload-Header-Pragma:
+      - no-cache
+      X-Goog-Upload-Header-Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      X-Goog-Upload-Header-Date:
+      - Mon, 29 Oct 2018 16:07:02 GMT
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 29 Oct 2018 16:07:02 GMT
+      Server:
+      - UploadServer
+      Content-Type:
+      - text/html; charset=UTF-8
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:02 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/upload/drive/v3/files/1t41jgWEZAxfWj55PJyio9txMlensy6SU3J_EhzPCdsg?upload_id=AEnB2UoBeYFCvYDspPqr9lujDU6wtP0NbNmOm25HgvRB-CrM2NgBgim1DR4qiUnkIYrp8-0CB5CNokq-E7mS9_YKn84BB6J6AQ&upload_protocol=resumable
+    body:
+      encoding: UTF-8
+      string: new file content
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:07:02 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      X-Goog-Upload-Command:
+      - upload, finalize
+      X-Goog-Upload-Offset:
+      - '0'
+      Content-Type:
+      - application/octet-stream
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Guploader-Uploadid:
+      - AEnB2UoBeYFCvYDspPqr9lujDU6wtP0NbNmOm25HgvRB-CrM2NgBgim1DR4qiUnkIYrp8-0CB5CNokq-E7mS9_YKn84BB6J6AQ
+      X-Goog-Upload-Status:
+      - final
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:07:03 GMT
+      Content-Length:
+      - '156'
+      Server:
+      - UploadServer
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#file",
+         "id": "1t41jgWEZAxfWj55PJyio9txMlensy6SU3J_EhzPCdsg",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document"
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:03 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1t41jgWEZAxfWj55PJyio9txMlensy6SU3J_EhzPCdsg?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:07:08 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 16:07:08 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:07:08 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1t41jgWEZAxfWj55PJyio9txMlensy6SU3J_EhzPCdsg",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1byTszweq-n_K1oavBbQ3XrIXLTy3x2bU"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1t41jgWEZAxfWj55PJyio9txMlensy6SU3J_EhzPCdsg&v=1&s=AMedNnoAAAAAW9dMTOaNd3LqYQ3wXeDdZNchXUqBaM_t&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:09 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1t41jgWEZAxfWj55PJyio9txMlensy6SU3J_EhzPCdsg/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:07:09 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 16:07:09 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:07:09 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "3",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-29T16:07:03.309Z"
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:09 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1t41jgWEZAxfWj55PJyio9txMlensy6SU3J_EhzPCdsg&s=AMedNnoAAAAAW9dMTOaNd3LqYQ3wXeDdZNchXUqBaM_t&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:07:09 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Mon, 29 Oct 2018 16:07:09 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:10 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1byTszweq-n_K1oavBbQ3XrIXLTy3x2bU
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:07:10 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:07:10 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:10 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/VCS_StagedFile/it_should_behave_like_vcs_including_syncable_integration/_pull/when_file_is_removed/1_2_2_3_1.yml
+++ b/spec/support/fixtures/vcr_cassettes/VCS_StagedFile/it_should_behave_like_vcs_including_syncable_integration/_pull/when_file_is_removed/1_2_2_3_1.yml
@@ -1,0 +1,503 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://oauth2.googleapis.com/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR TRACKING ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Mon, 29 Oct 2018 16:07:24 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:24 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-29
+        16:07:24 UTC","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:07:24 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:07:25 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1MoSgSodAUJa-AyQAJVJNoQqfSYSuNWhE",
+         "name": "Test @ 2018-10-29 16:07:24 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:25 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1MoSgSodAUJa-AyQAJVJNoQqfSYSuNWhE"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:07:25 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:07:27 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1RX1qFFCShrMQBLvk0e4lg0_9uKSwyXXg_9YhgqflR8g",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1MoSgSodAUJa-AyQAJVJNoQqfSYSuNWhE"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:27 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/upload/drive/v3/files/1RX1qFFCShrMQBLvk0e4lg0_9uKSwyXXg_9YhgqflR8g
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:07:27 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      X-Goog-Upload-Protocol:
+      - resumable
+      X-Goog-Upload-Command:
+      - start
+      X-Goog-Upload-Header-Content-Length:
+      - '16'
+      X-Goog-Upload-Header-Content-Type:
+      - application/octet-stream
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Guploader-Uploadid:
+      - AEnB2UpHB1JxDN9_XRPd9DUrR_Lf99SdIBYq2PYAzi-PPeZ3_UxJWoq4DK7doNxDhF_fKOvBk30XmzvarcuCMMh-ztGGu8V5Zmj194SKDdKqg43cvFoXVX8
+      X-Goog-Upload-Status:
+      - active
+      X-Goog-Upload-Url:
+      - https://www.googleapis.com/upload/drive/v3/files/1RX1qFFCShrMQBLvk0e4lg0_9uKSwyXXg_9YhgqflR8g?upload_id=AEnB2UpHB1JxDN9_XRPd9DUrR_Lf99SdIBYq2PYAzi-PPeZ3_UxJWoq4DK7doNxDhF_fKOvBk30XmzvarcuCMMh-ztGGu8V5Zmj194SKDdKqg43cvFoXVX8&upload_protocol=resumable
+      X-Goog-Upload-Control-Url:
+      - https://www.googleapis.com/upload/drive/v3/files/1RX1qFFCShrMQBLvk0e4lg0_9uKSwyXXg_9YhgqflR8g?upload_id=AEnB2UpHB1JxDN9_XRPd9DUrR_Lf99SdIBYq2PYAzi-PPeZ3_UxJWoq4DK7doNxDhF_fKOvBk30XmzvarcuCMMh-ztGGu8V5Zmj194SKDdKqg43cvFoXVX8&upload_protocol=resumable
+      X-Goog-Upload-Chunk-Granularity:
+      - '262144'
+      X-Goog-Upload-Header-Vary:
+      - Origin
+      - X-Origin
+      X-Goog-Upload-Header-X-Google-Backends:
+      - oibu2:4388
+      X-Goog-Upload-Header-X-Google-Session-Info:
+      - CLrLzJuGFRoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x4RkJ0b3VYTklqYkpWcHdGZ0Y1YWZ6ZkM5Q1NWMDVTcmFIQ0JxTzNGUTM5QWhkbzQyaV9vdXB4OFpCYno5V0E1RGxUaU9uVXc4M2RxQlItX3F2Q2pQU3lTMGZ6RmpKWVdYMnFweWtqUkRhWW9zSG9IWEJBZkpGZWRmVHlBMAQ6DTEvMk0zUkd3d1ZsWn4
+      X-Goog-Upload-Header-Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      X-Goog-Upload-Header-Pragma:
+      - no-cache
+      X-Goog-Upload-Header-Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      X-Goog-Upload-Header-Date:
+      - Mon, 29 Oct 2018 16:07:27 GMT
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 29 Oct 2018 16:07:27 GMT
+      Server:
+      - UploadServer
+      Content-Type:
+      - text/html; charset=UTF-8
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:27 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/upload/drive/v3/files/1RX1qFFCShrMQBLvk0e4lg0_9uKSwyXXg_9YhgqflR8g?upload_id=AEnB2UpHB1JxDN9_XRPd9DUrR_Lf99SdIBYq2PYAzi-PPeZ3_UxJWoq4DK7doNxDhF_fKOvBk30XmzvarcuCMMh-ztGGu8V5Zmj194SKDdKqg43cvFoXVX8&upload_protocol=resumable
+    body:
+      encoding: UTF-8
+      string: new file content
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:07:27 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      X-Goog-Upload-Command:
+      - upload, finalize
+      X-Goog-Upload-Offset:
+      - '0'
+      Content-Type:
+      - application/octet-stream
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Guploader-Uploadid:
+      - AEnB2UpHB1JxDN9_XRPd9DUrR_Lf99SdIBYq2PYAzi-PPeZ3_UxJWoq4DK7doNxDhF_fKOvBk30XmzvarcuCMMh-ztGGu8V5Zmj194SKDdKqg43cvFoXVX8
+      X-Goog-Upload-Status:
+      - final
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:07:29 GMT
+      Content-Length:
+      - '156'
+      Server:
+      - UploadServer
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#file",
+         "id": "1RX1qFFCShrMQBLvk0e4lg0_9uKSwyXXg_9YhgqflR8g",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document"
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:29 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1RX1qFFCShrMQBLvk0e4lg0_9uKSwyXXg_9YhgqflR8g
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:07:34 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:07:34 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:34 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1RX1qFFCShrMQBLvk0e4lg0_9uKSwyXXg_9YhgqflR8g?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:07:34 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Mon, 29 Oct 2018 16:07:35 GMT
+      Expires:
+      - Mon, 29 Oct 2018 16:07:35 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "notFound",
+            "message": "File not found: 1RX1qFFCShrMQBLvk0e4lg0_9uKSwyXXg_9YhgqflR8g.",
+            "locationType": "parameter",
+            "location": "fileId"
+           }
+          ],
+          "code": 404,
+          "message": "File not found: 1RX1qFFCShrMQBLvk0e4lg0_9uKSwyXXg_9YhgqflR8g."
+         }
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:35 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1MoSgSodAUJa-AyQAJVJNoQqfSYSuNWhE
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:07:35 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:07:35 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:35 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/VCS_StagedFile/it_should_behave_like_vcs_including_syncable_integration/_pull/when_file_is_trashed/1_2_2_2_1.yml
+++ b/spec/support/fixtures/vcr_cassettes/VCS_StagedFile/it_should_behave_like_vcs_including_syncable_integration/_pull/when_file_is_trashed/1_2_2_2_1.yml
@@ -1,0 +1,544 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://oauth2.googleapis.com/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR TRACKING ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Mon, 29 Oct 2018 16:07:11 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:11 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-29
+        16:07:11 UTC","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:07:11 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:07:12 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1DaC44eOR6Mj1bctnYmrWLSv-hM2t7XBu",
+         "name": "Test @ 2018-10-29 16:07:11 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:12 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["1DaC44eOR6Mj1bctnYmrWLSv-hM2t7XBu"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:07:12 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:07:14 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "16adIvjaP2WqdL-67EVs8lvrHuUCY1kxNMSJ8oan1Njg",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1DaC44eOR6Mj1bctnYmrWLSv-hM2t7XBu"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:15 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/upload/drive/v3/files/16adIvjaP2WqdL-67EVs8lvrHuUCY1kxNMSJ8oan1Njg
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:07:15 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      X-Goog-Upload-Protocol:
+      - resumable
+      X-Goog-Upload-Command:
+      - start
+      X-Goog-Upload-Header-Content-Length:
+      - '16'
+      X-Goog-Upload-Header-Content-Type:
+      - application/octet-stream
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Guploader-Uploadid:
+      - AEnB2Ur46_7WyPK1Wr53NQyPtlsGBPO9-ImjFni7w5U6pWFcVS4ksx8agtf5GdB2_mQYZDVL2Sj9cBZZzE93urQaUttHSF7Q9Q
+      X-Goog-Upload-Status:
+      - active
+      X-Goog-Upload-Url:
+      - https://www.googleapis.com/upload/drive/v3/files/16adIvjaP2WqdL-67EVs8lvrHuUCY1kxNMSJ8oan1Njg?upload_id=AEnB2Ur46_7WyPK1Wr53NQyPtlsGBPO9-ImjFni7w5U6pWFcVS4ksx8agtf5GdB2_mQYZDVL2Sj9cBZZzE93urQaUttHSF7Q9Q&upload_protocol=resumable
+      X-Goog-Upload-Control-Url:
+      - https://www.googleapis.com/upload/drive/v3/files/16adIvjaP2WqdL-67EVs8lvrHuUCY1kxNMSJ8oan1Njg?upload_id=AEnB2Ur46_7WyPK1Wr53NQyPtlsGBPO9-ImjFni7w5U6pWFcVS4ksx8agtf5GdB2_mQYZDVL2Sj9cBZZzE93urQaUttHSF7Q9Q&upload_protocol=resumable
+      X-Goog-Upload-Chunk-Granularity:
+      - '262144'
+      X-Goog-Upload-Header-Vary:
+      - Origin
+      - X-Origin
+      X-Goog-Upload-Header-X-Google-Backends:
+      - oige202:4193
+      X-Goog-Upload-Header-X-Google-Session-Info:
+      - CLrLzJuGFRoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x4RkJoLW1HdnVyZ3lNWjhKZVRhbFlrY1R5SWwtNHdUQ0V1TExJNWxJSjgwcktHb0lGMkUzNGc2dVVpQTA5MkxrTEFoU3BGX3J1ckZvSXVlX3Z6WDBDYWk5YVlwNjFzcE83dFh2Z1I4UDdlZkdCQ3Y4cnJ2aVRMM25sZ1FBMAQ6DTEvMk0zUkd3d1ZsWn4
+      X-Goog-Upload-Header-Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      X-Goog-Upload-Header-Pragma:
+      - no-cache
+      X-Goog-Upload-Header-Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      X-Goog-Upload-Header-Date:
+      - Mon, 29 Oct 2018 16:07:15 GMT
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 29 Oct 2018 16:07:15 GMT
+      Server:
+      - UploadServer
+      Content-Type:
+      - text/html; charset=UTF-8
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:16 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/upload/drive/v3/files/16adIvjaP2WqdL-67EVs8lvrHuUCY1kxNMSJ8oan1Njg?upload_id=AEnB2Ur46_7WyPK1Wr53NQyPtlsGBPO9-ImjFni7w5U6pWFcVS4ksx8agtf5GdB2_mQYZDVL2Sj9cBZZzE93urQaUttHSF7Q9Q&upload_protocol=resumable
+    body:
+      encoding: UTF-8
+      string: new file content
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:07:16 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      X-Goog-Upload-Command:
+      - upload, finalize
+      X-Goog-Upload-Offset:
+      - '0'
+      Content-Type:
+      - application/octet-stream
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Guploader-Uploadid:
+      - AEnB2Ur46_7WyPK1Wr53NQyPtlsGBPO9-ImjFni7w5U6pWFcVS4ksx8agtf5GdB2_mQYZDVL2Sj9cBZZzE93urQaUttHSF7Q9Q
+      X-Goog-Upload-Status:
+      - final
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:07:17 GMT
+      Content-Length:
+      - '156'
+      Server:
+      - UploadServer
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#file",
+         "id": "16adIvjaP2WqdL-67EVs8lvrHuUCY1kxNMSJ8oan1Njg",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document"
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:17 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/drive/v3/files/16adIvjaP2WqdL-67EVs8lvrHuUCY1kxNMSJ8oan1Njg?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"trashed":"true"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:07:22 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:07:22 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "16adIvjaP2WqdL-67EVs8lvrHuUCY1kxNMSJ8oan1Njg",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": true,
+         "parents": [
+          "1DaC44eOR6Mj1bctnYmrWLSv-hM2t7XBu"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=16adIvjaP2WqdL-67EVs8lvrHuUCY1kxNMSJ8oan1Njg&v=1&s=AMedNnoAAAAAW9dMWn6psMbDcxzok5V8zSJexqSUL9SZ&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:22 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/16adIvjaP2WqdL-67EVs8lvrHuUCY1kxNMSJ8oan1Njg?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:07:22 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Mon, 29 Oct 2018 16:07:23 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:07:23 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "16adIvjaP2WqdL-67EVs8lvrHuUCY1kxNMSJ8oan1Njg",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": true,
+         "parents": [
+          "1DaC44eOR6Mj1bctnYmrWLSv-hM2t7XBu"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=16adIvjaP2WqdL-67EVs8lvrHuUCY1kxNMSJ8oan1Njg&v=1&s=AMedNnoAAAAAW9dMW8j3DZDYqb2_LonczIY7x6qESMWu&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:23 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1DaC44eOR6Mj1bctnYmrWLSv-hM2t7XBu
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Mon, 29 Oct 2018 16:07:23 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Mon, 29 Oct 2018 16:07:23 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 29 Oct 2018 16:07:24 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/VCS_StagedFile/it_should_behave_like_vcs_including_syncable_integration/_pull_children/has_children_subfile1_and_subfile2.yml
+++ b/spec/support/fixtures/vcr_cassettes/VCS_StagedFile/it_should_behave_like_vcs_including_syncable_integration/_pull_children/has_children_subfile1_and_subfile2.yml
@@ -1,0 +1,786 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://oauth2.googleapis.com/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR TRACKING ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Wed, 31 Oct 2018 00:41:27 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:27 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-31
+        00:41:27 UTC","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:41:27 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:41:28 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1nu2ZlPmTndhC_wnBXhJYlbBbdlowCBUm",
+         "name": "Test @ 2018-10-31 00:41:27 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:28 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["1nu2ZlPmTndhC_wnBXhJYlbBbdlowCBUm"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:41:29 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:41:29 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1gAsyKHsO8-DY6tMi7AWyW81IKcGqCB3t",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "1nu2ZlPmTndhC_wnBXhJYlbBbdlowCBUm"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:29 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"sub1","parents":["1gAsyKHsO8-DY6tMi7AWyW81IKcGqCB3t"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:41:29 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:41:30 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1xbmDOqBXxjJ-aCD7uXylVSZxCnGyGIt9",
+         "name": "sub1",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "1gAsyKHsO8-DY6tMi7AWyW81IKcGqCB3t"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:30 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"sub2","parents":["1gAsyKHsO8-DY6tMi7AWyW81IKcGqCB3t"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:41:30 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:41:31 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1ayJfTh69WKyh-2JSGsecfWxyHJUNHFCY",
+         "name": "sub2",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "1gAsyKHsO8-DY6tMi7AWyW81IKcGqCB3t"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:31 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1gAsyKHsO8-DY6tMi7AWyW81IKcGqCB3t?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:41:31 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Wed, 31 Oct 2018 00:41:31 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:41:31 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1gAsyKHsO8-DY6tMi7AWyW81IKcGqCB3t",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "1nu2ZlPmTndhC_wnBXhJYlbBbdlowCBUm"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:31 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1gAsyKHsO8-DY6tMi7AWyW81IKcGqCB3t/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:41:31 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Wed, 31 Oct 2018 00:41:32 GMT
+      Expires:
+      - Wed, 31 Oct 2018 00:41:32 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:32 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271gAsyKHsO8-DY6tMi7AWyW81IKcGqCB3t%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:41:32 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Wed, 31 Oct 2018 00:41:32 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:41:32 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "files": [
+          {
+           "id": "1ayJfTh69WKyh-2JSGsecfWxyHJUNHFCY",
+           "name": "sub2",
+           "mimeType": "application/vnd.google-apps.folder",
+           "trashed": false,
+           "parents": [
+            "1gAsyKHsO8-DY6tMi7AWyW81IKcGqCB3t"
+           ],
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "owner",
+             "displayName": "Upshift One",
+             "deleted": false
+            }
+           ]
+          },
+          {
+           "id": "1xbmDOqBXxjJ-aCD7uXylVSZxCnGyGIt9",
+           "name": "sub1",
+           "mimeType": "application/vnd.google-apps.folder",
+           "trashed": false,
+           "parents": [
+            "1gAsyKHsO8-DY6tMi7AWyW81IKcGqCB3t"
+           ],
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "owner",
+             "displayName": "Upshift One",
+             "deleted": false
+            }
+           ]
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:32 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1ayJfTh69WKyh-2JSGsecfWxyHJUNHFCY/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:41:32 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Wed, 31 Oct 2018 00:41:32 GMT
+      Expires:
+      - Wed, 31 Oct 2018 00:41:32 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:32 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1xbmDOqBXxjJ-aCD7uXylVSZxCnGyGIt9/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:41:32 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Wed, 31 Oct 2018 00:41:32 GMT
+      Expires:
+      - Wed, 31 Oct 2018 00:41:32 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:32 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1nu2ZlPmTndhC_wnBXhJYlbBbdlowCBUm
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:41:32 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:41:33 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:33 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/VCS_StagedFile/it_should_behave_like_vcs_including_syncable_integration/_pull_children/when_subfile1_is_deleted_and_subfile3_is_added/updates_children_to_subfile2_and_subfile3.yml
+++ b/spec/support/fixtures/vcr_cassettes/VCS_StagedFile/it_should_behave_like_vcs_including_syncable_integration/_pull_children/when_subfile1_is_deleted_and_subfile3_is_added/updates_children_to_subfile2_and_subfile3.yml
@@ -1,0 +1,1143 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://oauth2.googleapis.com/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR TRACKING ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Wed, 31 Oct 2018 00:41:33 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:33 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-31
+        00:41:33 UTC","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:41:33 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:41:34 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1_dfccLBy6wjyH_2evwW26-Fy2gMDOuCo",
+         "name": "Test @ 2018-10-31 00:41:33 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:34 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test File","parents":["1_dfccLBy6wjyH_2evwW26-Fy2gMDOuCo"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:41:34 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:41:34 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1K_wFnBNTb7hWVKdhLCznsk7yf8gJXcec",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "1_dfccLBy6wjyH_2evwW26-Fy2gMDOuCo"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:35 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"sub1","parents":["1K_wFnBNTb7hWVKdhLCznsk7yf8gJXcec"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:41:35 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:41:35 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1agplusfzoyy81fXMbQnbAAthpxNBzlst",
+         "name": "sub1",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "1K_wFnBNTb7hWVKdhLCznsk7yf8gJXcec"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:35 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"sub2","parents":["1K_wFnBNTb7hWVKdhLCznsk7yf8gJXcec"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:41:35 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:41:36 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1pavVHHTWum1YTde28nF1DuI_59l1WzoQ",
+         "name": "sub2",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "1K_wFnBNTb7hWVKdhLCznsk7yf8gJXcec"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:36 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1K_wFnBNTb7hWVKdhLCznsk7yf8gJXcec?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:41:36 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Wed, 31 Oct 2018 00:41:36 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:41:36 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1K_wFnBNTb7hWVKdhLCznsk7yf8gJXcec",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "1_dfccLBy6wjyH_2evwW26-Fy2gMDOuCo"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:36 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1K_wFnBNTb7hWVKdhLCznsk7yf8gJXcec/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:41:36 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Wed, 31 Oct 2018 00:41:36 GMT
+      Expires:
+      - Wed, 31 Oct 2018 00:41:36 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:36 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271K_wFnBNTb7hWVKdhLCznsk7yf8gJXcec%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:41:36 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Wed, 31 Oct 2018 00:41:37 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:41:37 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "files": [
+          {
+           "id": "1pavVHHTWum1YTde28nF1DuI_59l1WzoQ",
+           "name": "sub2",
+           "mimeType": "application/vnd.google-apps.folder",
+           "trashed": false,
+           "parents": [
+            "1K_wFnBNTb7hWVKdhLCznsk7yf8gJXcec"
+           ],
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "owner",
+             "displayName": "Upshift One",
+             "deleted": false
+            }
+           ]
+          },
+          {
+           "id": "1agplusfzoyy81fXMbQnbAAthpxNBzlst",
+           "name": "sub1",
+           "mimeType": "application/vnd.google-apps.folder",
+           "trashed": false,
+           "parents": [
+            "1K_wFnBNTb7hWVKdhLCznsk7yf8gJXcec"
+           ],
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "owner",
+             "displayName": "Upshift One",
+             "deleted": false
+            }
+           ]
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:37 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1pavVHHTWum1YTde28nF1DuI_59l1WzoQ/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:41:37 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Wed, 31 Oct 2018 00:41:37 GMT
+      Expires:
+      - Wed, 31 Oct 2018 00:41:37 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:37 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1agplusfzoyy81fXMbQnbAAthpxNBzlst/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:41:37 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Wed, 31 Oct 2018 00:41:37 GMT
+      Expires:
+      - Wed, 31 Oct 2018 00:41:37 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:37 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1agplusfzoyy81fXMbQnbAAthpxNBzlst
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:41:37 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:41:38 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:38 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"sub3","parents":["1K_wFnBNTb7hWVKdhLCznsk7yf8gJXcec"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:41:38 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:41:38 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "10l_THvc5cHd7i2tM784KsNjUlsztdPpW",
+         "name": "sub3",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "1K_wFnBNTb7hWVKdhLCznsk7yf8gJXcec"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:39 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271K_wFnBNTb7hWVKdhLCznsk7yf8gJXcec%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:41:39 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Wed, 31 Oct 2018 00:41:39 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:41:39 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "files": [
+          {
+           "id": "10l_THvc5cHd7i2tM784KsNjUlsztdPpW",
+           "name": "sub3",
+           "mimeType": "application/vnd.google-apps.folder",
+           "trashed": false,
+           "parents": [
+            "1K_wFnBNTb7hWVKdhLCznsk7yf8gJXcec"
+           ],
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "owner",
+             "displayName": "Upshift One",
+             "deleted": false
+            }
+           ]
+          },
+          {
+           "id": "1pavVHHTWum1YTde28nF1DuI_59l1WzoQ",
+           "name": "sub2",
+           "mimeType": "application/vnd.google-apps.folder",
+           "trashed": false,
+           "parents": [
+            "1K_wFnBNTb7hWVKdhLCznsk7yf8gJXcec"
+           ],
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "owner",
+             "displayName": "Upshift One",
+             "deleted": false
+            }
+           ]
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:39 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/10l_THvc5cHd7i2tM784KsNjUlsztdPpW/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:41:39 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Wed, 31 Oct 2018 00:41:39 GMT
+      Expires:
+      - Wed, 31 Oct 2018 00:41:39 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:39 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1agplusfzoyy81fXMbQnbAAthpxNBzlst?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:41:39 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Wed, 31 Oct 2018 00:41:39 GMT
+      Expires:
+      - Wed, 31 Oct 2018 00:41:39 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "notFound",
+            "message": "File not found: 1agplusfzoyy81fXMbQnbAAthpxNBzlst.",
+            "locationType": "parameter",
+            "location": "fileId"
+           }
+          ],
+          "code": 404,
+          "message": "File not found: 1agplusfzoyy81fXMbQnbAAthpxNBzlst."
+         }
+        }
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:39 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1_dfccLBy6wjyH_2evwW26-Fy2gMDOuCo
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 31 Oct 2018 00:41:39 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 31 Oct 2018 00:41:40 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 31 Oct 2018 00:41:40 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/VCS_StagedFile/snapshotable_syncable/can_pull_a_snapshot_of_a_new_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/VCS_StagedFile/snapshotable_syncable/can_pull_a_snapshot_of_a_new_file.yml
@@ -1,0 +1,533 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://oauth2.googleapis.com/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR TRACKING ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Sun, 28 Oct 2018 00:17:23 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:23 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-28
+        00:17:23 UTC","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:23 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sun, 28 Oct 2018 00:17:23 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "12Oevvjuxo67PYRA9coAeyBAc2mYjiyWN",
+         "name": "Test @ 2018-10-28 00:17:23 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:23 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["12Oevvjuxo67PYRA9coAeyBAc2mYjiyWN"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:23 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sun, 28 Oct 2018 00:17:24 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1QmU5QH0pDFH5PSuOOVJWv-UnnfCsOJgGnMhIJtwCQhc",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "12Oevvjuxo67PYRA9coAeyBAc2mYjiyWN"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:25 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/12Oevvjuxo67PYRA9coAeyBAc2mYjiyWN?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:25 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 28 Oct 2018 00:17:25 GMT
+      Date:
+      - Sun, 28 Oct 2018 00:17:25 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "12Oevvjuxo67PYRA9coAeyBAc2mYjiyWN",
+         "name": "Test @ 2018-10-28 00:17:23 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:25 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/12Oevvjuxo67PYRA9coAeyBAc2mYjiyWN/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:25 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Sun, 28 Oct 2018 00:17:25 GMT
+      Expires:
+      - Sun, 28 Oct 2018 00:17:25 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:25 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1QmU5QH0pDFH5PSuOOVJWv-UnnfCsOJgGnMhIJtwCQhc?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:25 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 28 Oct 2018 00:17:25 GMT
+      Date:
+      - Sun, 28 Oct 2018 00:17:25 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1QmU5QH0pDFH5PSuOOVJWv-UnnfCsOJgGnMhIJtwCQhc",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "12Oevvjuxo67PYRA9coAeyBAc2mYjiyWN"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:25 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1QmU5QH0pDFH5PSuOOVJWv-UnnfCsOJgGnMhIJtwCQhc/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:25 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 28 Oct 2018 00:17:25 GMT
+      Date:
+      - Sun, 28 Oct 2018 00:17:25 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-28T00:17:24.158Z"
+        }
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:25 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/12Oevvjuxo67PYRA9coAeyBAc2mYjiyWN
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:25 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sun, 28 Oct 2018 00:17:26 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:26 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/VCS_StagedFile/snapshotable_syncable/can_pull_a_snapshot_of_a_removed_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/VCS_StagedFile/snapshotable_syncable/can_pull_a_snapshot_of_a_removed_file.yml
@@ -1,0 +1,646 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://oauth2.googleapis.com/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR TRACKING ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Sun, 28 Oct 2018 00:17:18 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:18 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-28
+        00:17:18 UTC","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:18 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sun, 28 Oct 2018 00:17:19 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "134T03p6NSf8SXGPvI0-fe_nTpACAGHmF",
+         "name": "Test @ 2018-10-28 00:17:18 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:19 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["134T03p6NSf8SXGPvI0-fe_nTpACAGHmF"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:19 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sun, 28 Oct 2018 00:17:21 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1BCIyg-lQ1yLSBSq7c0p1Hl0qYymTuDPGIEOATf1vGm8",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "134T03p6NSf8SXGPvI0-fe_nTpACAGHmF"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:21 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/134T03p6NSf8SXGPvI0-fe_nTpACAGHmF?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:21 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 28 Oct 2018 00:17:21 GMT
+      Date:
+      - Sun, 28 Oct 2018 00:17:21 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "134T03p6NSf8SXGPvI0-fe_nTpACAGHmF",
+         "name": "Test @ 2018-10-28 00:17:18 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:21 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/134T03p6NSf8SXGPvI0-fe_nTpACAGHmF/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:21 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Sun, 28 Oct 2018 00:17:21 GMT
+      Expires:
+      - Sun, 28 Oct 2018 00:17:21 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:21 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1BCIyg-lQ1yLSBSq7c0p1Hl0qYymTuDPGIEOATf1vGm8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:21 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 28 Oct 2018 00:17:21 GMT
+      Date:
+      - Sun, 28 Oct 2018 00:17:21 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1BCIyg-lQ1yLSBSq7c0p1Hl0qYymTuDPGIEOATf1vGm8",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "134T03p6NSf8SXGPvI0-fe_nTpACAGHmF"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:21 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1BCIyg-lQ1yLSBSq7c0p1Hl0qYymTuDPGIEOATf1vGm8/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:21 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 28 Oct 2018 00:17:22 GMT
+      Date:
+      - Sun, 28 Oct 2018 00:17:22 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-28T00:17:20.295Z"
+        }
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:22 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1BCIyg-lQ1yLSBSq7c0p1Hl0qYymTuDPGIEOATf1vGm8
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:22 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sun, 28 Oct 2018 00:17:22 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:22 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1BCIyg-lQ1yLSBSq7c0p1Hl0qYymTuDPGIEOATf1vGm8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:22 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Sun, 28 Oct 2018 00:17:22 GMT
+      Expires:
+      - Sun, 28 Oct 2018 00:17:22 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "notFound",
+            "message": "File not found: 1BCIyg-lQ1yLSBSq7c0p1Hl0qYymTuDPGIEOATf1vGm8.",
+            "locationType": "parameter",
+            "location": "fileId"
+           }
+          ],
+          "code": 404,
+          "message": "File not found: 1BCIyg-lQ1yLSBSq7c0p1Hl0qYymTuDPGIEOATf1vGm8."
+         }
+        }
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:22 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/134T03p6NSf8SXGPvI0-fe_nTpACAGHmF
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:22 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sun, 28 Oct 2018 00:17:23 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:23 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/VCS_StagedFile/snapshotable_syncable/can_pull_a_snapshot_of_an_existing_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/VCS_StagedFile/snapshotable_syncable/can_pull_a_snapshot_of_an_existing_file.yml
@@ -1,0 +1,940 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://oauth2.googleapis.com/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR TRACKING ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Sun, 28 Oct 2018 00:17:26 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:26 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-28
+        00:17:26 UTC","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:26 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sun, 28 Oct 2018 00:17:26 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "12jEPJr__LtJI0q6A1aUne4Dc6YX73-jY",
+         "name": "Test @ 2018-10-28 00:17:26 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:27 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Test File","parents":["12jEPJr__LtJI0q6A1aUne4Dc6YX73-jY"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:27 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sun, 28 Oct 2018 00:17:28 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1CAZnieVR78Tl4-PPdV6ZhWxhFhp4mAQPzkKOhZmB7ik",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "12jEPJr__LtJI0q6A1aUne4Dc6YX73-jY"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:28 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/12jEPJr__LtJI0q6A1aUne4Dc6YX73-jY?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:28 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 28 Oct 2018 00:17:28 GMT
+      Date:
+      - Sun, 28 Oct 2018 00:17:28 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "12jEPJr__LtJI0q6A1aUne4Dc6YX73-jY",
+         "name": "Test @ 2018-10-28 00:17:26 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:28 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/12jEPJr__LtJI0q6A1aUne4Dc6YX73-jY/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:28 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Sun, 28 Oct 2018 00:17:29 GMT
+      Expires:
+      - Sun, 28 Oct 2018 00:17:29 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:29 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1CAZnieVR78Tl4-PPdV6ZhWxhFhp4mAQPzkKOhZmB7ik?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:29 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 28 Oct 2018 00:17:29 GMT
+      Date:
+      - Sun, 28 Oct 2018 00:17:29 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1CAZnieVR78Tl4-PPdV6ZhWxhFhp4mAQPzkKOhZmB7ik",
+         "name": "Test File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "12jEPJr__LtJI0q6A1aUne4Dc6YX73-jY"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:29 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1CAZnieVR78Tl4-PPdV6ZhWxhFhp4mAQPzkKOhZmB7ik/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:29 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 28 Oct 2018 00:17:29 GMT
+      Date:
+      - Sun, 28 Oct 2018 00:17:29 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-28T00:17:27.252Z"
+        }
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:29 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/drive/v3/files/1CAZnieVR78Tl4-PPdV6ZhWxhFhp4mAQPzkKOhZmB7ik?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"my new file name"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:29 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sun, 28 Oct 2018 00:17:29 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1CAZnieVR78Tl4-PPdV6ZhWxhFhp4mAQPzkKOhZmB7ik",
+         "name": "my new file name",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "12jEPJr__LtJI0q6A1aUne4Dc6YX73-jY"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:30 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/upload/drive/v3/files/1CAZnieVR78Tl4-PPdV6ZhWxhFhp4mAQPzkKOhZmB7ik
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:30 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      X-Goog-Upload-Protocol:
+      - resumable
+      X-Goog-Upload-Command:
+      - start
+      X-Goog-Upload-Header-Content-Length:
+      - '16'
+      X-Goog-Upload-Header-Content-Type:
+      - application/octet-stream
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Guploader-Uploadid:
+      - AEnB2Ur8ni76vaic4xYr0_GSZ-h6pDqMT3iaPNjuK_tPAULFijcOl2jPvL79pAIWLOOTUUBK-agvafrpVnQiYnepg4jRvaOGJ93NqVQIPo9pciOuYyAqSbI
+      X-Goog-Upload-Status:
+      - active
+      X-Goog-Upload-Url:
+      - https://www.googleapis.com/upload/drive/v3/files/1CAZnieVR78Tl4-PPdV6ZhWxhFhp4mAQPzkKOhZmB7ik?upload_id=AEnB2Ur8ni76vaic4xYr0_GSZ-h6pDqMT3iaPNjuK_tPAULFijcOl2jPvL79pAIWLOOTUUBK-agvafrpVnQiYnepg4jRvaOGJ93NqVQIPo9pciOuYyAqSbI&upload_protocol=resumable
+      X-Goog-Upload-Control-Url:
+      - https://www.googleapis.com/upload/drive/v3/files/1CAZnieVR78Tl4-PPdV6ZhWxhFhp4mAQPzkKOhZmB7ik?upload_id=AEnB2Ur8ni76vaic4xYr0_GSZ-h6pDqMT3iaPNjuK_tPAULFijcOl2jPvL79pAIWLOOTUUBK-agvafrpVnQiYnepg4jRvaOGJ93NqVQIPo9pciOuYyAqSbI&upload_protocol=resumable
+      X-Goog-Upload-Chunk-Granularity:
+      - '262144'
+      X-Goog-Upload-Header-Vary:
+      - Origin
+      - X-Origin
+      X-Goog-Upload-Header-X-Google-Backends:
+      - iojl14:4110
+      X-Goog-Upload-Header-X-Google-Session-Info:
+      - CLrLzJuGFRoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x4RUJyZWJjVU9NaTJPVXF0MkZER0VGR21Vc1dKZUFhX1hOXzA3UGxMMzFZdlNOLXR6QUxicjFObDBlZ21nLXMxRV91U1U4Sy1fdG1XNktmVHk4NHl6cWplYU5ScWkySmV0aFdCVmdKU0I2d3ptajlBWWE3QzhIRDhFbGJ3MAQ6DTEvMk0zUkd3d1ZsWn4
+      X-Goog-Upload-Header-Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      X-Goog-Upload-Header-Pragma:
+      - no-cache
+      X-Goog-Upload-Header-Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      X-Goog-Upload-Header-Date:
+      - Sun, 28 Oct 2018 00:17:30 GMT
+      Content-Length:
+      - '0'
+      Date:
+      - Sun, 28 Oct 2018 00:17:30 GMT
+      Server:
+      - UploadServer
+      Content-Type:
+      - text/html; charset=UTF-8
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:30 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/upload/drive/v3/files/1CAZnieVR78Tl4-PPdV6ZhWxhFhp4mAQPzkKOhZmB7ik?upload_id=AEnB2Ur8ni76vaic4xYr0_GSZ-h6pDqMT3iaPNjuK_tPAULFijcOl2jPvL79pAIWLOOTUUBK-agvafrpVnQiYnepg4jRvaOGJ93NqVQIPo9pciOuYyAqSbI&upload_protocol=resumable
+    body:
+      encoding: UTF-8
+      string: new file content
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:30 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      X-Goog-Upload-Command:
+      - upload, finalize
+      X-Goog-Upload-Offset:
+      - '0'
+      Content-Type:
+      - application/octet-stream
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Guploader-Uploadid:
+      - AEnB2Ur8ni76vaic4xYr0_GSZ-h6pDqMT3iaPNjuK_tPAULFijcOl2jPvL79pAIWLOOTUUBK-agvafrpVnQiYnepg4jRvaOGJ93NqVQIPo9pciOuYyAqSbI
+      X-Goog-Upload-Status:
+      - final
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sun, 28 Oct 2018 00:17:31 GMT
+      Content-Length:
+      - '163'
+      Server:
+      - UploadServer
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#file",
+         "id": "1CAZnieVR78Tl4-PPdV6ZhWxhFhp4mAQPzkKOhZmB7ik",
+         "name": "my new file name",
+         "mimeType": "application/vnd.google-apps.document"
+        }
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:31 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1CAZnieVR78Tl4-PPdV6ZhWxhFhp4mAQPzkKOhZmB7ik?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:36 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 28 Oct 2018 00:17:36 GMT
+      Date:
+      - Sun, 28 Oct 2018 00:17:36 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1CAZnieVR78Tl4-PPdV6ZhWxhFhp4mAQPzkKOhZmB7ik",
+         "name": "my new file name",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "12jEPJr__LtJI0q6A1aUne4Dc6YX73-jY"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1CAZnieVR78Tl4-PPdV6ZhWxhFhp4mAQPzkKOhZmB7ik&v=1&s=AMedNnoAAAAAW9UcQFkkQexCEbFxOHoIMWnvoZRoc3zs&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:36 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1CAZnieVR78Tl4-PPdV6ZhWxhFhp4mAQPzkKOhZmB7ik/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:36 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sun, 28 Oct 2018 00:17:36 GMT
+      Date:
+      - Sun, 28 Oct 2018 00:17:36 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "3",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-10-28T00:17:30.804Z"
+        }
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:36 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1CAZnieVR78Tl4-PPdV6ZhWxhFhp4mAQPzkKOhZmB7ik&s=AMedNnoAAAAAW9UcQFkkQexCEbFxOHoIMWnvoZRoc3zs&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:36 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sun, 28 Oct 2018 00:17:36 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:36 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/12jEPJr__LtJI0q6A1aUne4Dc6YX73-jY
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sun, 28 Oct 2018 00:17:36 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sun, 28 Oct 2018 00:17:37 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 00:17:37 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
Move from single to multi source model, where each repository contains
its own set of file records (as opposed to global file resources shared
between repositories). The reason for the multi source decision is that
this makes it possible to have different versions of the same file in
different repositories (which may be necessary due to two files having
different owners who have different levels of file access).

We decided not to touch existing models, so that we can get the new
infrastructure working, then deploy, and then manually migrate data from
the single to the multi source model. That is easiest if the existing
models are not touched.

We are also remodeling the infrastructure to prepare for multi branch
support and backups.