### PR TITLE
Hotfix v0.26.1: Fix Capistrano deploy version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v0.26.1 (Nov 1, 2018)
+
+**Fixes:**
+- Bump Capistrano version in deploy.rb to v3.11.0 (to reenable Capistrano CLI)
+
 ## v0.26 (Oct 31, 2018)
 
 **New Features:**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Openly One
 
-[![GitHub release](https://img.shields.io/badge/version-0.26-blue.svg)](https://github.com/OpenlyOne/openly)
+[![GitHub release](https://img.shields.io/github/release/OpenlyOne/openly.svg)](https://github.com/OpenlyOne/openly)
 [![Build Status](https://travis-ci.org/OpenlyOne/openly.svg?branch=master)](https://travis-ci.org/OpenlyOne/openly)
 [![codecov](https://codecov.io/gh/OpenlyOne/openly/branch/master/graph/badge.svg)](https://codecov.io/gh/OpenlyOne/openly)
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -3,7 +3,7 @@
 # rubocop:disable Metrics/BlockLength
 
 # config valid only for current version of Capistrano
-lock '3.10.1'
+lock '3.11.0'
 
 # Load default settings
 require 'config'


### PR DESCRIPTION
**Fixes:**
- Bump Capistrano version in deploy.rb to v3.11.0 (to reenable Capistrano CLI)