### PR TITLE
Add VCS::Content model

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,3 +26,8 @@ Style/Documentation:
   Enabled: true
   Exclude:
     - db/migrate/*
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  Exclude:
+    - db/migrate/*

--- a/app/controllers/file_restores_controller.rb
+++ b/app/controllers/file_restores_controller.rb
@@ -34,11 +34,19 @@ class FileRestoresController < ApplicationController
   end
 
   def file_info_path
+    # TODO: Redirect to file infos path by file record ID. That is the only
+    # =>    stable identifier.
     profile_project_file_infos_path(@project.owner, @project,
-                                    @snapshot.external_id)
+                                    staged_file.external_id)
   end
 
   def set_file_snapshot
     @snapshot = VCS::FileSnapshot.find(params[:id])
+  end
+
+  # TODO: Remove after redirecting to file infos path based on file record ID
+  def staged_file
+    @master_branch
+      .staged_files.find_by(file_record_id: @snapshot.file_record_id)
   end
 end

--- a/app/models/concerns/vcs/diffing.rb
+++ b/app/models/concerns/vcs/diffing.rb
@@ -13,7 +13,7 @@ module VCS
              to: :current_or_previous_snapshot
 
     delegate_methods = %i[content_version name parent_id file_record_parent_id
-                          file_record_id]
+                          file_record_id content_id]
     delegate(*delegate_methods,
              to: :current_snapshot, prefix: :current, allow_nil: true)
     delegate(*delegate_methods,
@@ -75,7 +75,7 @@ module VCS
     def modification?
       return false unless update?
 
-      current_content_version != previous_content_version
+      current_content_id != previous_content_id
     end
 
     def movement?

--- a/app/models/file_diff/changes/modification.rb
+++ b/app/models/file_diff/changes/modification.rb
@@ -29,12 +29,16 @@ class FileDiff
       end
 
       # Undo modification of the file resource
+      # TODO: Remove rolling back of external ID & content version
+      # rubocop:disable Metrics/AbcSize
       def unapply
+        current_snapshot.content_id      = previous_snapshot.content_id
         current_snapshot.content_version = previous_snapshot.content_version
         current_snapshot.mime_type       = previous_snapshot.mime_type
         current_snapshot.external_id     = previous_snapshot.external_id
         current_snapshot.thumbnail_id    = previous_snapshot.thumbnail_id
       end
+      # rubocop:enable Metrics/AbcSize
     end
   end
 end

--- a/app/models/vcs/content.rb
+++ b/app/models/vcs/content.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module VCS
+  # The content of a file (equivalent of a blob in Git)
+  class Content < ApplicationRecord
+    # Associations
+    belongs_to :repository
+  end
+end

--- a/app/models/vcs/content.rb
+++ b/app/models/vcs/content.rb
@@ -5,5 +5,6 @@ module VCS
   class Content < ApplicationRecord
     # Associations
     belongs_to :repository
+    has_many :remote_contents, dependent: :delete_all
   end
 end

--- a/app/models/vcs/file_snapshot.rb
+++ b/app/models/vcs/file_snapshot.rb
@@ -9,6 +9,7 @@ module VCS
     belongs_to :file_record, autosave: false
     belongs_to :file_record_parent, class_name: 'VCS::FileRecord',
                                     optional: true
+    belongs_to :content, optional: true
 
     has_many :staging_files, class_name: 'VCS::StagedFile',
                              foreign_key: :file_record_id
@@ -18,6 +19,7 @@ module VCS
 
     has_one :backup, class_name: 'VCS::FileBackup', dependent: :destroy,
                      inverse_of: :file_snapshot
+    has_one :repository, through: :file_record
 
     # Callbacks
     # Prevent updates to file snapshot; snapshots are immutable.

--- a/app/models/vcs/file_snapshot.rb
+++ b/app/models/vcs/file_snapshot.rb
@@ -83,8 +83,7 @@ module VCS
     validates :external_id,       presence: true
     validates :file_record_id,
               uniqueness: {
-                scope: %i[external_id content_version mime_type name
-                          file_record_parent_id],
+                scope: %i[name content_id mime_type file_record_parent_id],
                 message: 'already has a snapshot with these attributes'
               },
               if: :new_record?
@@ -97,15 +96,36 @@ module VCS
       )
     end
 
+    # TODO: Content generation should not be happening here. Move to StagedFile
+    # =>    instead
+    def self.repository(attributes)
+      VCS::FileRecord.find(attributes[:file_record_id])&.repository
+    end
+
+    # TODO: Content generation should not be happening here. Move to StagedFile
+    # =>    instead
+    def self.content_id(attributes)
+      attributes.symbolize_keys!
+      VCS::Operations::ContentGenerator.generate(
+        repository: repository(attributes),
+        remote_file_id: attributes[:external_id],
+        remote_content_version_id: attributes[:content_version]
+      )&.id
+    end
+
+    # TODO: Content generation should not be happening here. Move to StagedFile
+    # =>    instead
     # The set of core attributes that uniquely identify a snapshot
     def self.core_attributes(attributes)
-      attributes.symbolize_keys.slice(*core_attribute_keys)
+      attributes
+        .symbolize_keys
+        .reverse_merge(content_id: content_id(attributes))
+        .slice(*core_attribute_keys)
     end
 
     # The set of core attributes that uniquely identify a snapshot
     def self.core_attribute_keys
-      %i[file_record_id name external_id content_version mime_type
-         file_record_parent_id]
+      %i[file_record_id name content_id mime_type file_record_parent_id]
     end
 
     # Find or create a snapshot from the set of core attributes, optionally
@@ -123,7 +143,7 @@ module VCS
 
     # The set of supplemental attributes to a snapshot
     def self.supplemental_attribute_keys
-      %i[thumbnail_id]
+      %i[thumbnail_id external_id content_version]
     end
 
     # Return provider ID of file resource, either preloaded or from file

--- a/app/models/vcs/file_snapshot.rb
+++ b/app/models/vcs/file_snapshot.rb
@@ -9,7 +9,7 @@ module VCS
     belongs_to :file_record, autosave: false
     belongs_to :file_record_parent, class_name: 'VCS::FileRecord',
                                     optional: true
-    belongs_to :content, optional: true
+    belongs_to :content
 
     has_many :staging_files, class_name: 'VCS::StagedFile',
                              foreign_key: :file_record_id

--- a/app/models/vcs/operations/content_generator.rb
+++ b/app/models/vcs/operations/content_generator.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module VCS
+  module Operations
+    # Generate (find or create) VCS::Content based on the passed attributes
+    class ContentGenerator
+      # Attributes
+      attr_accessor :repository, :remote_file_id, :remote_content_version_id
+
+      # Initialize a new instance and generate content
+      def self.generate(attributes)
+        new(attributes).generate
+      end
+
+      def initialize(attributes)
+        self.repository = attributes.fetch(:repository)
+        self.remote_file_id = attributes.fetch(:remote_file_id)
+        self.remote_content_version_id =
+          attributes.fetch(:remote_content_version_id)
+      end
+
+      # Find or create the VCS::Content
+      def generate
+        remote_content.content
+      end
+
+      private
+
+      def build_content
+        VCS::Content.new(repository: repository)
+      end
+
+      def remote_content
+        @remote_content ||=
+          VCS::RemoteContent
+          .create_with(content: build_content)
+          .find_or_create_by(
+            repository: repository,
+            remote_file_id: remote_file_id,
+            remote_content_version_id: remote_content_version_id
+          )
+      end
+    end
+  end
+end

--- a/app/models/vcs/remote_content.rb
+++ b/app/models/vcs/remote_content.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module VCS
+  # Mapping of remote file ID & content to local content
+  # Allows multiple remote files to map to the same content version
+  class RemoteContent < ApplicationRecord
+    # Associations
+    belongs_to :repository
+    belongs_to :content
+
+    # Validations
+    validates :remote_file_id,
+              presence: true,
+              uniqueness: { scope: %i[repository_id remote_content_version_id] }
+    validates :remote_content_version_id, presence: true
+  end
+end

--- a/app/models/vcs/repository.rb
+++ b/app/models/vcs/repository.rb
@@ -7,9 +7,11 @@ module VCS
 
     has_one :archive, dependent: :destroy
     has_many :file_records, dependent: :destroy
-    has_many :contents, dependent: :destroy
     has_many :file_snapshots, through: :file_records
     has_many :file_backups, through: :file_snapshots, source: :backup
+
+    has_many :contents, dependent: :destroy
+    has_many :remote_contents, dependent: :delete_all
 
     # TODO: Delete all associated records in this repository on destroy rather
     # =>    than deleting them 1 by 1

--- a/app/models/vcs/repository.rb
+++ b/app/models/vcs/repository.rb
@@ -7,6 +7,7 @@ module VCS
 
     has_one :archive, dependent: :destroy
     has_many :file_records, dependent: :destroy
+    has_many :contents, dependent: :destroy
     has_many :file_snapshots, through: :file_records
     has_many :file_backups, through: :file_snapshots, source: :backup
 

--- a/db/migrate/20181107173759_create_vcs_contents.rb
+++ b/db/migrate/20181107173759_create_vcs_contents.rb
@@ -1,0 +1,10 @@
+class CreateVcsContents < ActiveRecord::Migration[5.2]
+  def change
+    create_table :vcs_contents do |t|
+      t.belongs_to :repository, foreign_key: { to_table: :vcs_repositories },
+                                null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20181107175325_create_vcs_remote_contents.rb
+++ b/db/migrate/20181107175325_create_vcs_remote_contents.rb
@@ -1,0 +1,18 @@
+class CreateVcsRemoteContents < ActiveRecord::Migration[5.2]
+  def change
+    create_table :vcs_remote_contents do |t|
+      t.belongs_to :repository, foreign_key: { to_table: :vcs_repositories },
+                                null: false
+      t.belongs_to :content, foreign_key: { to_table: :vcs_contents },
+                             null: false
+      t.text :remote_file_id, null: false
+      t.text :remote_content_version_id, null: false
+
+      t.index %i[repository_id remote_file_id remote_content_version_id],
+              name: 'index_vcs_remote_contents_on_remote_file_contents',
+              unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20181107181029_add_content_id_to_vcs_file_snapshots.rb
+++ b/db/migrate/20181107181029_add_content_id_to_vcs_file_snapshots.rb
@@ -1,0 +1,14 @@
+class AddContentIdToVcsFileSnapshots < ActiveRecord::Migration[5.2]
+  def up
+    add_column :vcs_file_snapshots, :content_id, :bigint, null: true
+    add_foreign_key :vcs_file_snapshots, :vcs_contents, column: :content_id
+
+    # migrate snapshots to use VCS::Content
+    Rake::Task['data_migration:file_snapshots_content'].invoke
+  end
+
+  def down
+    remove_foreign_key :vcs_file_snapshots, :vcs_contents
+    remove_column :vcs_file_snapshots, :content_id
+  end
+end

--- a/db/migrate/20181107235258_change_unique_constraint_vcs_file_snapshots.rb
+++ b/db/migrate/20181107235258_change_unique_constraint_vcs_file_snapshots.rb
@@ -1,0 +1,38 @@
+# Modify the unique index on snapshots to use the new content ID column as a
+# replacement for external_id and content_version
+class ChangeUniqueConstraintVcsFileSnapshots < ActiveRecord::Migration[5.2]
+  def up
+    remove_index :vcs_file_snapshots,
+                 name: :index_vcs_file_snapshots_on_metadata
+    remove_index :vcs_file_snapshots,
+                 name: :index_vcs_file_snapshots_on_metadata_without_parent
+    add_index :vcs_file_snapshots,
+              %i[file_record_id content_id file_record_parent_id name
+                 mime_type],
+              unique: true,
+              name: :index_vcs_file_snapshots_on_metadata
+    add_index :vcs_file_snapshots,
+              %i[file_record_id content_id name mime_type],
+              where: '(file_record_parent_id IS NULL)',
+              unique: true,
+              name: :index_vcs_file_snapshots_on_metadata_without_parent
+  end
+
+  def down
+    remove_index :vcs_file_snapshots,
+                 name: :index_vcs_file_snapshots_on_metadata
+    remove_index :vcs_file_snapshots,
+                 name: :index_vcs_file_snapshots_on_metadata_without_parent
+
+    add_index :vcs_file_snapshots,
+              %i[file_record_id external_id content_version mime_type name
+                 file_record_parent_id],
+              unique: true,
+              name: :index_vcs_file_snapshots_on_metadata
+    add_index :vcs_file_snapshots,
+              %i[file_record_id external_id content_version mime_type name],
+              where: '(file_record_parent_id IS NULL)',
+              unique: true,
+              name: :index_vcs_file_snapshots_on_metadata_without_parent
+  end
+end

--- a/db/migrate/20181108015945_change_column_null_of_vcs_file_snapshots_content_id.rb
+++ b/db/migrate/20181108015945_change_column_null_of_vcs_file_snapshots_content_id.rb
@@ -1,0 +1,9 @@
+class ChangeColumnNullOfVcsFileSnapshotsContentId < ActiveRecord::Migration[5.2]
+  def up
+    change_column_null :vcs_file_snapshots, :content_id, false
+  end
+
+  def down
+    change_column_null :vcs_file_snapshots, :content_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_07_175325) do
+ActiveRecord::Schema.define(version: 2018_11_07_181029) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -383,6 +383,7 @@ ActiveRecord::Schema.define(version: 2018_11_07_175325) do
     t.bigint "thumbnail_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "content_id"
     t.index ["file_record_id", "external_id", "content_version", "mime_type", "name", "file_record_parent_id"], name: "index_vcs_file_snapshots_on_metadata", unique: true
     t.index ["file_record_id", "external_id", "content_version", "mime_type", "name"], name: "index_vcs_file_snapshots_on_metadata_without_parent", unique: true, where: "(file_record_parent_id IS NULL)"
     t.index ["file_record_id"], name: "index_vcs_file_snapshots_on_file_record_id"
@@ -485,6 +486,7 @@ ActiveRecord::Schema.define(version: 2018_11_07_175325) do
   add_foreign_key "vcs_file_diffs", "vcs_file_snapshots", column: "new_snapshot_id"
   add_foreign_key "vcs_file_diffs", "vcs_file_snapshots", column: "old_snapshot_id"
   add_foreign_key "vcs_file_records", "vcs_repositories", column: "repository_id"
+  add_foreign_key "vcs_file_snapshots", "vcs_contents", column: "content_id"
   add_foreign_key "vcs_file_snapshots", "vcs_file_records", column: "file_record_id"
   add_foreign_key "vcs_file_snapshots", "vcs_file_records", column: "file_record_parent_id"
   add_foreign_key "vcs_file_snapshots", "vcs_file_thumbnails", column: "thumbnail_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_07_181029) do
+ActiveRecord::Schema.define(version: 2018_11_07_235258) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -384,8 +384,8 @@ ActiveRecord::Schema.define(version: 2018_11_07_181029) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "content_id"
-    t.index ["file_record_id", "external_id", "content_version", "mime_type", "name", "file_record_parent_id"], name: "index_vcs_file_snapshots_on_metadata", unique: true
-    t.index ["file_record_id", "external_id", "content_version", "mime_type", "name"], name: "index_vcs_file_snapshots_on_metadata_without_parent", unique: true, where: "(file_record_parent_id IS NULL)"
+    t.index ["file_record_id", "content_id", "file_record_parent_id", "name", "mime_type"], name: "index_vcs_file_snapshots_on_metadata", unique: true
+    t.index ["file_record_id", "content_id", "name", "mime_type"], name: "index_vcs_file_snapshots_on_metadata_without_parent", unique: true, where: "(file_record_parent_id IS NULL)"
     t.index ["file_record_id"], name: "index_vcs_file_snapshots_on_file_record_id"
     t.index ["file_record_parent_id"], name: "index_vcs_file_snapshots_on_file_record_parent_id"
     t.index ["thumbnail_id"], name: "index_vcs_file_snapshots_on_thumbnail_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_07_235258) do
+ActiveRecord::Schema.define(version: 2018_11_08_015945) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -383,7 +383,7 @@ ActiveRecord::Schema.define(version: 2018_11_07_235258) do
     t.bigint "thumbnail_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "content_id"
+    t.bigint "content_id", null: false
     t.index ["file_record_id", "content_id", "file_record_parent_id", "name", "mime_type"], name: "index_vcs_file_snapshots_on_metadata", unique: true
     t.index ["file_record_id", "content_id", "name", "mime_type"], name: "index_vcs_file_snapshots_on_metadata_without_parent", unique: true, where: "(file_record_parent_id IS NULL)"
     t.index ["file_record_id"], name: "index_vcs_file_snapshots_on_file_record_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_07_063808) do
+ActiveRecord::Schema.define(version: 2018_11_07_173759) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -339,6 +339,13 @@ ActiveRecord::Schema.define(version: 2018_11_07_063808) do
     t.index ["file_snapshot_id"], name: "index_vcs_committed_files_on_file_snapshot_id"
   end
 
+  create_table "vcs_contents", force: :cascade do |t|
+    t.bigint "repository_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["repository_id"], name: "index_vcs_contents_on_repository_id"
+  end
+
   create_table "vcs_file_backups", force: :cascade do |t|
     t.bigint "file_snapshot_id", null: false
     t.text "external_id", null: false
@@ -460,6 +467,7 @@ ActiveRecord::Schema.define(version: 2018_11_07_063808) do
   add_foreign_key "vcs_commits", "vcs_commits", column: "parent_id"
   add_foreign_key "vcs_committed_files", "vcs_commits", column: "commit_id"
   add_foreign_key "vcs_committed_files", "vcs_file_snapshots", column: "file_snapshot_id"
+  add_foreign_key "vcs_contents", "vcs_repositories", column: "repository_id"
   add_foreign_key "vcs_file_backups", "vcs_file_snapshots", column: "file_snapshot_id"
   add_foreign_key "vcs_file_diffs", "vcs_commits", column: "commit_id"
   add_foreign_key "vcs_file_diffs", "vcs_file_snapshots", column: "new_snapshot_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_07_173759) do
+ActiveRecord::Schema.define(version: 2018_11_07_175325) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -402,6 +402,18 @@ ActiveRecord::Schema.define(version: 2018_11_07_173759) do
     t.bigint "file_record_id", null: false
   end
 
+  create_table "vcs_remote_contents", force: :cascade do |t|
+    t.bigint "repository_id", null: false
+    t.bigint "content_id", null: false
+    t.text "remote_file_id", null: false
+    t.text "remote_content_version_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["content_id"], name: "index_vcs_remote_contents_on_content_id"
+    t.index ["repository_id", "remote_file_id", "remote_content_version_id"], name: "index_vcs_remote_contents_on_remote_file_contents", unique: true
+    t.index ["repository_id"], name: "index_vcs_remote_contents_on_repository_id"
+  end
+
   create_table "vcs_repositories", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -477,6 +489,8 @@ ActiveRecord::Schema.define(version: 2018_11_07_173759) do
   add_foreign_key "vcs_file_snapshots", "vcs_file_records", column: "file_record_parent_id"
   add_foreign_key "vcs_file_snapshots", "vcs_file_thumbnails", column: "thumbnail_id"
   add_foreign_key "vcs_file_thumbnails", "vcs_file_records", column: "file_record_id"
+  add_foreign_key "vcs_remote_contents", "vcs_contents", column: "content_id"
+  add_foreign_key "vcs_remote_contents", "vcs_repositories", column: "repository_id"
   add_foreign_key "vcs_staged_files", "vcs_branches", column: "branch_id"
   add_foreign_key "vcs_staged_files", "vcs_file_records", column: "file_record_id"
   add_foreign_key "vcs_staged_files", "vcs_file_records", column: "file_record_parent_id"

--- a/lib/tasks/data_migration/file_snapshots_content.rake
+++ b/lib/tasks/data_migration/file_snapshots_content.rake
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Migrate file snapshots to use VCS::Content and VCS::RemoteContent instead of
+# storing external ID and content version directly on the snapshot. Using
+# VCS::Content will allow us to map several remote files to the same content
+# instance (useful for restoring, branching, and merging).
+desc 'Data Migration: Migrate file snapshots to use VCS::Content'
+namespace :data_migration do
+  task file_snapshots_content: :environment do
+    VCS::FileSnapshot.reset_column_information
+
+    snapshots_to_migrate = VCS::FileSnapshot.where(content_id: nil)
+
+    puts "Migrating #{snapshots_to_migrate.count} snapshots"
+
+    ActiveRecord::Base.transaction do
+      snapshots_to_migrate.find_each do |snapshot|
+        puts ".Migrating #{snapshot.id}"
+
+        # build VCS::Content
+        content = VCS::Content.new(
+          repository: snapshot.repository
+        )
+
+        # create VCS::RemoteContent
+        remote_content =
+          VCS::RemoteContent
+          .create_with(content: content)
+          .find_or_create_by!(
+            repository: snapshot.repository,
+            remote_file_id: snapshot.external_id,
+            remote_content_version_id: snapshot.content_version
+          )
+
+        content = remote_content.content
+
+        # update column
+        puts "..New content ID #{content.id}"
+
+        snapshot.update_column(:content_id, content.id)
+
+        puts '..Done'
+      end
+    end
+  end
+end

--- a/spec/factories/vcs/vcs_contents.rb
+++ b/spec/factories/vcs/vcs_contents.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :vcs_content, class: 'VCS::Content' do
+    association :repository, factory: :vcs_repository
+  end
+end

--- a/spec/factories/vcs/vcs_file_snapshots.rb
+++ b/spec/factories/vcs/vcs_file_snapshots.rb
@@ -27,5 +27,14 @@ FactoryBot.define do
               file_snapshot: VCS::FileSnapshot.new)
       end
     end
+
+    after(:build) do |snapshot|
+      snapshot.content =
+        VCS::Operations::ContentGenerator.generate(
+          repository: snapshot.repository,
+          remote_file_id: snapshot.external_id,
+          remote_content_version_id: snapshot.content_version
+        )
+    end
   end
 end

--- a/spec/factories/vcs/vcs_remote_contents.rb
+++ b/spec/factories/vcs/vcs_remote_contents.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :vcs_remote_content, class: 'VCS::RemoteContent' do
+    association :content, factory: :vcs_content
+    repository                { content.repository }
+    remote_file_id            { Faker::Crypto.unique.sha1 }
+    remote_content_version_id { Faker::Crypto.sha1.first(4) }
+  end
+end

--- a/spec/features/revision_restore_spec.rb
+++ b/spec/features/revision_restore_spec.rb
@@ -84,7 +84,6 @@ feature 'Revision Restore', :vcr, :delayed_job do
     click_on 'Capture Changes'
 
     # then I should see no changes
-    pending 'Requires implementation of file_content'
     expect(page).to have_text 'No files changed'
 
     # when I pull each file in stage

--- a/spec/integrations/vcs/operations/content_generator_spec.rb
+++ b/spec/integrations/vcs/operations/content_generator_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.describe VCS::Operations::ContentGenerator, type: :model do
+  subject(:generator) { described_class.new(attributes) }
+
+  let(:attributes) do
+    {
+      repository: repository,
+      remote_file_id: remote_file_id,
+      remote_content_version_id: remote_content_version_id
+    }
+  end
+  let(:repository) { create :vcs_repository }
+  let(:remote_file_id) { 'remote-id' }
+  let(:remote_content_version_id) { 'content-vers' }
+
+  describe '#generate(attributes)' do
+    subject(:content) { generator.generate }
+
+    it 'returns a new, persisted instance of VCS::Content' do
+      expect(content).to be_a VCS::Content
+      expect(content).to have_attributes(repository: repository)
+    end
+
+    context 'when content for those attributes already exists' do
+      let!(:existing_content) { described_class.new(attributes).generate }
+
+      it 'returns the existing VCS::Content' do
+        expect(content).to eq existing_content
+      end
+    end
+  end
+end

--- a/spec/integrations/vcs/operations/file_restore_spec.rb
+++ b/spec/integrations/vcs/operations/file_restore_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe VCS::Operations::FileRestore, type: :model, vcr: true do
     let(:expected_parent)           { parent_of_snapshot_to_restore }
     let(:expected_content_version)  { snapshot_to_restore.content_version }
     let(:expected_deletion_status)  { false }
+    let(:expected_snapshot_id)      { snapshot_to_restore&.id }
 
     before do
       # capture the initial snapshot which we will later restore
@@ -90,6 +91,7 @@ RSpec.describe VCS::Operations::FileRestore, type: :model, vcr: true do
     end
 
     after do
+      expect(file.current_snapshot_id).to eq expected_snapshot_id
       expect(file).to have_attributes(
         file_record_id: file.file_record_id,
         name: snapshot_to_restore&.name,
@@ -132,6 +134,7 @@ RSpec.describe VCS::Operations::FileRestore, type: :model, vcr: true do
 
         it 'is added' do
           expect(file_change).to be_addition
+          expect(file.current_snapshot_id).to eq snapshot_to_restore.id
         end
       end
     end
@@ -158,6 +161,7 @@ RSpec.describe VCS::Operations::FileRestore, type: :model, vcr: true do
 
       it 'moves the file' do
         expect(file_change).to be_movement
+        expect(file.current_snapshot_id).to eq snapshot_to_restore.id
       end
 
       context 'when parent of snapshot to restore does not exist' do
@@ -167,6 +171,7 @@ RSpec.describe VCS::Operations::FileRestore, type: :model, vcr: true do
           subfolder.reload.pull
         end
         let(:expected_parent) { root }
+        let(:expected_snapshot_id) { file.current_snapshot_id }
 
         it 'moves snapshot to home folder' do
           expect(file_change).to be_movement
@@ -179,6 +184,7 @@ RSpec.describe VCS::Operations::FileRestore, type: :model, vcr: true do
 
       it 'renames the file' do
         expect(file_change).to be_rename
+        expect(file.current_snapshot_id).to eq snapshot_to_restore.id
       end
     end
 
@@ -191,6 +197,7 @@ RSpec.describe VCS::Operations::FileRestore, type: :model, vcr: true do
       it 'is modifies the file' do
         expect(file_change).to be_modification
         expect(file.external_id).not_to eq remote_file.id
+        expect(file.current_snapshot_id).to eq snapshot_to_restore.id
       end
     end
 

--- a/spec/lib/tasks/data_migration/file_snapshots_content_spec.rb
+++ b/spec/lib/tasks/data_migration/file_snapshots_content_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'lib/shared_contexts/rake.rb'
+
+RSpec.describe 'data_migration:file_snapshots_content' do
+  include_context 'rake'
+
+  let(:run_the_task) { subject.invoke }
+  let(:task_path)    { "lib/tasks/#{task_name.tr(':', '/')}" }
+
+  let!(:snapshots) { create_list(:vcs_file_snapshot, 3) }
+
+  before { allow(STDOUT).to receive(:puts) }
+
+  before do
+    # verify that content ID is null
+    snapshots.each do |snapshot|
+      expect(snapshot.content_id).to be_nil
+    end
+  end
+
+  it 'creates a content for each snapshot' do
+    run_the_task
+
+    snapshots.each do |snapshot|
+      snapshot.reload
+      expect(snapshot.content).to have_attributes(
+        repository_id: snapshot.repository.id
+      )
+      expect(VCS::RemoteContent).to be_exists(
+        repository_id: snapshot.repository.id,
+        content_id: snapshot.content_id,
+        remote_file_id: snapshot.external_id,
+        remote_content_version_id: snapshot.content_version
+      )
+    end
+  end
+
+  context 'when multiple snapshots have the same content version' do
+    let(:snapshots) do
+      create_list :vcs_file_snapshot, 2,
+                  file_record: fr, external_id: 'id', content_version: 'v'
+    end
+    let(:fr) { create :vcs_file_record }
+
+    it 'assigns both snapshots the same content' do
+      run_the_task
+
+      expect(VCS::Content.count).to eq 1
+      expect(snapshots.first.content_id).to eq(snapshots.second.content_id)
+    end
+  end
+end

--- a/spec/lib/tasks/data_migration/file_snapshots_content_spec.rb
+++ b/spec/lib/tasks/data_migration/file_snapshots_content_spec.rb
@@ -2,7 +2,7 @@
 
 require 'lib/shared_contexts/rake.rb'
 
-RSpec.describe 'data_migration:file_snapshots_content' do
+RSpec.describe 'data_migration:file_snapshots_content', :archived do
   include_context 'rake'
 
   let(:run_the_task) { subject.invoke }

--- a/spec/lib/tasks/data_migration/file_thumbnails_spec.rb
+++ b/spec/lib/tasks/data_migration/file_thumbnails_spec.rb
@@ -3,7 +3,7 @@
 require 'lib/shared_contexts/rake.rb'
 
 # TODO: Archive because no longer relevant as data has been migrated
-RSpec.describe 'data_migration:file_thumbnails', skip: true do
+RSpec.describe 'data_migration:file_thumbnails', :archived do
   include_context 'rake'
 
   let(:run_the_task) { subject.invoke }

--- a/spec/models/file_diff/changes/modification_spec.rb
+++ b/spec/models/file_diff/changes/modification_spec.rb
@@ -4,7 +4,7 @@ require 'models/shared_examples/being_a_file_diff_change.rb'
 
 RSpec.describe FileDiff::Changes::Modification, type: :model do
   subject(:change)  { described_class.new(diff: diff) }
-  let(:diff)        { instance_double FileDiff }
+  let(:diff)        { instance_double VCS::FileDiff }
 
   it_should_behave_like 'being a file diff change' do
     before { allow(diff).to receive(:ancestor_path).and_return 'path' }
@@ -19,12 +19,14 @@ RSpec.describe FileDiff::Changes::Modification, type: :model do
 
   describe '#unapply' do
     subject { change.current_snapshot }
-    let(:current_snapshot) { instance_double FileResource::Snapshot }
-    let(:previous_snapshot) { instance_double FileResource::Snapshot }
+    let(:current_snapshot) { instance_double VCS::FileSnapshot }
+    let(:previous_snapshot) { instance_double VCS::FileSnapshot }
 
     before do
       allow(change).to receive(:current_snapshot).and_return current_snapshot
       allow(change).to receive(:previous_snapshot).and_return previous_snapshot
+      allow(previous_snapshot)
+        .to receive(:content_id).and_return 'previous-content-id'
       allow(previous_snapshot)
         .to receive(:content_version).and_return 'previous-content-version'
       allow(previous_snapshot)
@@ -38,6 +40,7 @@ RSpec.describe FileDiff::Changes::Modification, type: :model do
     after { change.send :unapply }
 
     it 'resets content' do
+      is_expected.to receive(:content_id=).with 'previous-content-id'
       is_expected.to receive(:content_version=).with 'previous-content-version'
       is_expected.to receive(:mime_type=).with 'previous-mime-type'
       is_expected.to receive(:external_id=).with 'previous-external-id'

--- a/spec/models/shared_examples/vcs/being_diffing.rb
+++ b/spec/models/shared_examples/vcs/being_diffing.rb
@@ -1,0 +1,351 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'vcs: being diffing' do
+  subject { diffing }
+
+  describe 'delegations' do
+    let(:snapshot) { :current_or_previous_snapshot }
+
+    it { is_expected.to delegate_method(:id).to(snapshot).with_prefix }
+    it { is_expected.to delegate_method(:external_id).to(snapshot) }
+    it { is_expected.to delegate_method(:external_link).to(snapshot) }
+    it { is_expected.to delegate_method(:folder?).to(snapshot) }
+    it { is_expected.to delegate_method(:icon).to(snapshot) }
+    it { is_expected.to delegate_method(:mime_type).to(snapshot) }
+    it { is_expected.to delegate_method(:name).to(snapshot) }
+    it { is_expected.to delegate_method(:parent_id).to(snapshot) }
+    it { is_expected.to delegate_method(:provider).to(snapshot) }
+    it { is_expected.to delegate_method(:symbolic_mime_type).to(snapshot) }
+    it { is_expected.to delegate_method(:thumbnail_id).to(snapshot) }
+    it { is_expected.to delegate_method(:thumbnail_image).to(snapshot) }
+    it do
+      is_expected.to delegate_method(:thumbnail_image_or_fallback).to(snapshot)
+    end
+
+    it do
+      is_expected
+        .to delegate_method(:content_version)
+        .to(:current_snapshot).with_prefix(:current)
+    end
+    it do
+      is_expected
+        .to delegate_method(:name)
+        .to(:current_snapshot).with_prefix(:current)
+    end
+    it do
+      is_expected
+        .to delegate_method(:parent_id)
+        .to(:current_snapshot).with_prefix(:current)
+    end
+
+    it do
+      is_expected
+        .to delegate_method(:content_version)
+        .to(:previous_snapshot).with_prefix(:previous)
+    end
+    it do
+      is_expected
+        .to delegate_method(:name)
+        .to(:previous_snapshot).with_prefix(:previous)
+    end
+    it do
+      is_expected
+        .to delegate_method(:parent_id)
+        .to(:previous_snapshot).with_prefix(:previous)
+    end
+
+    it { is_expected.to delegate_method(:color).to(:primary_change).allow_nil }
+    it do
+      is_expected.to delegate_method(:text_color).to(:primary_change).allow_nil
+    end
+  end
+
+  describe '#added?' do
+    before do
+      allow(diffing).to receive(:current_snapshot_id).and_return 123
+      allow(diffing)
+        .to receive(:previous_snapshot_id).and_return previous_snapshot_id
+    end
+
+    context 'when previous_snapshot_id is nil' do
+      let(:previous_snapshot_id) { nil }
+      it { is_expected.to be_addition }
+    end
+
+    context 'when previous_snapshot_id is not nil' do
+      let(:previous_snapshot_id) { 456 }
+      it { is_expected.not_to be_addition }
+    end
+  end
+
+  describe '#ancestor_path' do
+    subject { diffing.ancestor_path }
+    before  do
+      allow(diffing).to receive(:first_three_ancestors).and_return ancestors
+    end
+
+    context 'when first_three_ancestors = []' do
+      let(:ancestors) { [] }
+      it { is_expected.to eq 'Home' }
+    end
+
+    context 'when first_three_ancestors = [anc1]' do
+      let(:ancestors) { %w[anc1] }
+      it { is_expected.to eq 'anc1' }
+    end
+
+    context 'when first_three_ancestors = [anc1 anc2]' do
+      let(:ancestors) { %w[anc1 anc2] }
+      it { is_expected.to eq 'anc2 > anc1' }
+    end
+
+    context 'when first_three_ancestors = [anc1 anc2 anc3]' do
+      let(:ancestors) { %w[anc1 anc2 anc3] }
+      it { is_expected.to eq '.. > anc2 > anc1' }
+    end
+  end
+
+  describe '#association(association_name)' do
+    let(:snapshot) { instance_double FileResource::Snapshot }
+
+    before do
+      allow(diffing)
+        .to receive(:current_or_previous_snapshot).and_return snapshot
+    end
+
+    after { diffing.association(association_name) }
+
+    context 'when association name is thumbnail' do
+      let(:association_name) { :thumbnail }
+
+      it { expect(snapshot).to receive(:association).with(:thumbnail) }
+    end
+  end
+
+  describe '#change?' do
+    let(:is_added)    { false }
+    let(:is_deleted)  { false }
+    let(:is_updated)  { false }
+
+    before do
+      allow(diffing).to receive(:addition?).and_return is_added
+      allow(diffing).to receive(:deletion?).and_return is_deleted
+      allow(diffing).to receive(:update?).and_return is_updated
+    end
+
+    it { is_expected.not_to be_change }
+
+    context 'when it is added' do
+      let(:is_added)  { true }
+      it              { is_expected.to be_change }
+    end
+
+    context 'when it is deleted' do
+      let(:is_deleted)  { true }
+      it                { is_expected.to be_change }
+    end
+
+    context 'when it is updated' do
+      let(:is_updated)  { true }
+      it                { is_expected.to be_change }
+    end
+  end
+
+  describe '#change_types' do
+    subject { diffing.change_types }
+    let(:is_added)    { false }
+    let(:is_deleted)  { false }
+    let(:is_modified) { false }
+    let(:is_moved)    { false }
+    let(:is_renamed)  { false }
+
+    before do
+      allow(diffing).to receive(:addition?).and_return is_added
+      allow(diffing).to receive(:deletion?).and_return is_deleted
+      allow(diffing).to receive(:modification?).and_return is_modified
+      allow(diffing).to receive(:movement?).and_return is_moved
+      allow(diffing).to receive(:rename?).and_return is_renamed
+    end
+
+    it { is_expected.to eq [] }
+
+    context 'when it is addition, rename, and deletion' do
+      let(:is_added)    { true }
+      let(:is_renamed)  { true }
+      let(:is_deleted)  { true }
+      it { is_expected.to contain_exactly :addition, :rename, :deletion }
+    end
+
+    context 'when file is moved, rename, and modified' do
+      let(:is_moved)    { true }
+      let(:is_renamed)  { true }
+      let(:is_modified) { true }
+
+      it 'the first change is movement' do
+        expect(subject.first).to eq :movement
+      end
+    end
+
+    context 'when file is renamed and modified' do
+      let(:is_renamed)  { true }
+      let(:is_modified) { true }
+
+      it 'the first change is rename' do
+        expect(subject.first).to eq :rename
+      end
+    end
+  end
+
+  describe '#changes' do
+    subject { diffing.changes }
+
+    before do
+      allow(diffing).to receive(:change_types).and_return %i[addition movement]
+      allow(FileDiff::Changes::Addition)
+        .to receive(:new).with(diff: diffing).and_return :c1
+      allow(FileDiff::Changes::Movement)
+        .to receive(:new).with(diff: diffing).and_return :c2
+    end
+
+    it { is_expected.to eq %i[c1 c2] }
+  end
+
+  describe '#deletion?' do
+    before do
+      allow(diffing).to receive(:previous_snapshot_id).and_return 123
+      allow(diffing)
+        .to receive(:current_snapshot_id).and_return current_snapshot_id
+    end
+
+    context 'when current_snapshot_id is nil' do
+      let(:current_snapshot_id) { nil }
+      it { is_expected.to be_deletion }
+    end
+
+    context 'when current_snapshot_id is not nil' do
+      let(:current_snapshot_id) { 456 }
+      it { is_expected.not_to be_deletion }
+    end
+  end
+
+  describe 'modification?' do
+    let(:current_content_id)  { 122 }
+    let(:previous_content_id) { 123 }
+    let(:is_updated)          { true }
+
+    before do
+      allow(diffing).to receive(:update?).and_return is_updated
+      allow(diffing)
+        .to receive(:current_content_id).and_return current_content_id
+      allow(diffing)
+        .to receive(:previous_content_id).and_return previous_content_id
+    end
+
+    it { expect(diffing).to be_modification }
+
+    context 'when content versions are the same' do
+      let(:current_content_id)  { 79 }
+      let(:previous_content_id) { 79 }
+
+      it { expect(diffing).not_to be_modification }
+    end
+
+    context 'when it is not updated' do
+      let(:is_updated) { false }
+      it { expect(diffing).not_to be_modification }
+    end
+  end
+
+  describe 'movement?' do
+    let(:current_parent_id)   { 51 }
+    let(:previous_parent_id)  { 99 }
+    let(:is_updated)          { true }
+
+    before do
+      allow(diffing).to receive(:update?).and_return is_updated
+      allow(diffing).to receive(:current_parent_id).and_return current_parent_id
+      allow(diffing)
+        .to receive(:previous_parent_id).and_return previous_parent_id
+    end
+
+    it { expect(diffing).to be_movement }
+
+    context 'when parents are the same' do
+      let(:current_parent_id)   { 100 }
+      let(:previous_parent_id)  { 100 }
+
+      it { expect(diffing).not_to be_movement }
+    end
+
+    context 'when it is not updated' do
+      let(:is_updated) { false }
+      it { expect(diffing).not_to be_movement }
+    end
+  end
+
+  describe '#primary_change' do
+    subject { diffing.primary_change }
+    before  { allow(diffing).to receive(:changes).and_return %w[c1 c2 c3] }
+    it      { is_expected.to be 'c1' }
+  end
+
+  describe 'rename?' do
+    let(:current_name)  { 'File A' }
+    let(:previous_name) { 'File B' }
+    let(:is_updated)    { true }
+
+    before do
+      allow(diffing).to receive(:update?).and_return is_updated
+      allow(diffing).to receive(:current_name).and_return current_name
+      allow(diffing).to receive(:previous_name).and_return previous_name
+    end
+
+    it { expect(diffing).to be_rename }
+
+    context 'when names are the same' do
+      let(:current_name)   { 'name' }
+      let(:previous_name)  { 'name' }
+
+      it { expect(diffing).not_to be_rename }
+    end
+
+    context 'when it is not updated' do
+      let(:is_updated) { false }
+      it { expect(diffing).not_to be_rename }
+    end
+  end
+
+  describe '#update?' do
+    let(:is_added)              { false }
+    let(:is_deleted)            { false }
+    let(:current_snapshot_id)   { 1 }
+    let(:previous_snapshot_id)  { 2 }
+
+    before do
+      allow(diffing).to receive(:addition?).and_return is_added
+      allow(diffing).to receive(:deletion?).and_return is_deleted
+      allow(diffing)
+        .to receive(:current_snapshot_id).and_return current_snapshot_id
+      allow(diffing)
+        .to receive(:previous_snapshot_id).and_return previous_snapshot_id
+    end
+
+    it { is_expected.to be_update }
+
+    context 'when snapshot IDs are the same' do
+      let(:current_snapshot_id)   { 13 }
+      let(:previous_snapshot_id)  { 13 }
+      it { is_expected.not_to be_update }
+    end
+
+    context 'when diffing is added' do
+      let(:is_added) { true }
+      it { is_expected.not_to be_update }
+    end
+
+    context 'when diffing is deleted' do
+      let(:is_deleted) { true }
+      it { is_expected.not_to be_update }
+    end
+  end
+end

--- a/spec/models/vcs/content_spec.rb
+++ b/spec/models/vcs/content_spec.rb
@@ -5,5 +5,6 @@ RSpec.describe VCS::Content, type: :model do
 
   describe 'associations' do
     it { is_expected.to belong_to(:repository).dependent(false) }
+    it { is_expected.to have_many(:remote_contents).dependent(:delete_all) }
   end
 end

--- a/spec/models/vcs/content_spec.rb
+++ b/spec/models/vcs/content_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.describe VCS::Content, type: :model do
+  subject { build :vcs_content }
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:repository).dependent(false) }
+  end
+end

--- a/spec/models/vcs/file_diff_spec.rb
+++ b/spec/models/vcs/file_diff_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'models/shared_examples/being_diffing.rb'
+require 'models/shared_examples/vcs/being_diffing.rb'
 
 RSpec.describe VCS::FileDiff, type: :model do
   subject(:diff) { build_stubbed :vcs_file_diff }
 
-  it_should_behave_like 'being diffing' do
+  it_should_behave_like 'vcs: being diffing' do
     let(:diffing) do
       build_stubbed :vcs_file_diff,
                     new_snapshot: new_snapshot,

--- a/spec/models/vcs/file_snapshot_spec.rb
+++ b/spec/models/vcs/file_snapshot_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe VCS::FileSnapshot, type: :model do
         .dependent(false)
         .optional
     end
-    it { is_expected.to belong_to(:content).optional }
+    it { is_expected.to belong_to(:content) }
     it do
       is_expected
         .to have_one(:backup)
@@ -52,6 +52,9 @@ RSpec.describe VCS::FileSnapshot, type: :model do
     it { is_expected.to validate_presence_of(:content_version) }
     it { is_expected.to validate_presence_of(:mime_type) }
     it { is_expected.to validate_presence_of(:external_id) }
+    it do
+      is_expected.to validate_presence_of(:content).with_message('must exist')
+    end
 
     context 'uniqueness validation' do
       subject(:snapshot) { build :vcs_file_snapshot }

--- a/spec/models/vcs/file_snapshot_spec.rb
+++ b/spec/models/vcs/file_snapshot_spec.rb
@@ -58,8 +58,7 @@ RSpec.describe VCS::FileSnapshot, type: :model do
       it do
         is_expected
           .to validate_uniqueness_of(:file_record_id)
-          .scoped_to(:external_id, :content_version, :mime_type, :name,
-                     :file_record_parent_id)
+          .scoped_to(:name, :content_id, :mime_type, :file_record_parent_id)
           .with_message('already has a snapshot with these attributes')
       end
     end

--- a/spec/models/vcs/file_snapshot_spec.rb
+++ b/spec/models/vcs/file_snapshot_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe VCS::FileSnapshot, type: :model do
         .dependent(false)
         .optional
     end
+    it { is_expected.to belong_to(:content).optional }
     it do
       is_expected
         .to have_one(:backup)
@@ -38,13 +39,7 @@ RSpec.describe VCS::FileSnapshot, type: :model do
         .with_foreign_key(:file_record_id)
         .dependent(false)
     end
-    # it do
-    #   is_expected
-    #     .to have_many(:committing_files)
-    #     .class_name('CommittedFile')
-    #     .with_foreign_key(:file_resource_snapshot_id)
-    #     .dependent(false)
-    # end
+    it { is_expected.to have_one(:repository).through(:file_record) }
   end
 
   describe 'attributes' do

--- a/spec/models/vcs/operations/content_generator_spec.rb
+++ b/spec/models/vcs/operations/content_generator_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+RSpec.describe VCS::Operations::ContentGenerator, type: :model do
+  subject(:generator) { described_class.new(attributes) }
+  let(:attributes) do
+    {
+      repository: repository,
+      remote_file_id: remote_file_id,
+      remote_content_version_id: remote_content_version_id
+    }
+  end
+  let(:repository) { instance_double VCS::Repository }
+  let(:remote_file_id) { 'remote-id' }
+  let(:remote_content_version_id) { 'content-vers' }
+
+  describe '.generate(attributes)' do
+    subject(:generate)  { described_class.generate(attributes) }
+    let(:attributes)    { 'attrs' }
+    let(:instance)      { instance_double described_class }
+
+    before do
+      allow(described_class).to receive(:new).and_return instance
+      allow(instance).to receive(:generate).and_return 'generated'
+    end
+
+    it 'initializes a new instance and calls #generate' do
+      generate
+      expect(described_class).to have_received(:new).with(attributes)
+      expect(instance).to have_received(:generate)
+      is_expected.to eq 'generated'
+    end
+  end
+
+  describe '#initialize(attributes)' do
+    subject(:init) { described_class.new(attributes) }
+
+    it { is_expected.to be_a described_class }
+
+    context 'when attributes is missing repository' do
+      before { attributes.except!(:repository) }
+
+      it { expect { init }.to raise_error(KeyError) }
+    end
+
+    context 'when attributes is missing remote_file_id' do
+      before { attributes.except!(:remote_file_id) }
+
+      it { expect { init }.to raise_error(KeyError) }
+    end
+
+    context 'when attributes is missing remote_content_version_id' do
+      before { attributes.except!(:remote_content_version_id) }
+
+      it { expect { init }.to raise_error(KeyError) }
+    end
+  end
+
+  describe '#generate' do
+    subject(:generate) { generator.generate }
+
+    before do
+      remote_content = instance_double VCS::RemoteContent
+      allow(generator).to receive(:remote_content).and_return remote_content
+      allow(remote_content).to receive(:content).and_return 'content'
+    end
+
+    it 'returns content of remote_content' do
+      is_expected.to eq 'content'
+    end
+  end
+end

--- a/spec/models/vcs/remote_content_spec.rb
+++ b/spec/models/vcs/remote_content_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.describe VCS::RemoteContent, type: :model do
+  subject(:remote_content) { build_stubbed :vcs_remote_content }
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:repository).dependent(false) }
+    it { is_expected.to belong_to(:content).dependent(false) }
+  end
+
+  describe 'validations' do
+    subject(:remote_content) { build :vcs_remote_content }
+
+    it do
+      is_expected
+        .to validate_presence_of(:repository).with_message('must exist')
+    end
+    it do
+      is_expected.to validate_presence_of(:content).with_message('must exist')
+    end
+    it { is_expected.to validate_presence_of(:remote_file_id) }
+    it { is_expected.to validate_presence_of(:remote_content_version_id) }
+
+    it do
+      is_expected
+        .to validate_uniqueness_of(:remote_file_id)
+        .scoped_to(%i[repository_id remote_content_version_id])
+    end
+  end
+end

--- a/spec/models/vcs/repository_spec.rb
+++ b/spec/models/vcs/repository_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe VCS::Repository, type: :model do
     it { is_expected.to have_many(:branches).dependent(:destroy) }
     it { is_expected.to have_one(:archive).dependent(:destroy) }
     it { is_expected.to have_many(:file_records).dependent(:destroy) }
+    it { is_expected.to have_many(:contents).dependent(:destroy) }
     it do
       is_expected
         .to have_many(:file_snapshots)

--- a/spec/models/vcs/repository_spec.rb
+++ b/spec/models/vcs/repository_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe VCS::Repository, type: :model do
     it { is_expected.to have_many(:branches).dependent(:destroy) }
     it { is_expected.to have_one(:archive).dependent(:destroy) }
     it { is_expected.to have_many(:file_records).dependent(:destroy) }
-    it { is_expected.to have_many(:contents).dependent(:destroy) }
     it do
       is_expected
         .to have_many(:file_snapshots)
@@ -21,5 +20,7 @@ RSpec.describe VCS::Repository, type: :model do
         .source(:backup)
         .dependent(false)
     end
+    it { is_expected.to have_many(:contents).dependent(:destroy) }
+    it { is_expected.to have_many(:remote_contents).dependent(:delete_all) }
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -85,6 +85,9 @@ RSpec.configure do |config|
     view.lookup_context.view_paths.unshift 'app/views/application'
   end
 
+  # Skip archived specs, such as data migrations
+  config.filter_run_excluding(archived: true)
+
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.

--- a/spec/support/fixtures/vcr_cassettes/File_Restore/restores_moved_renamed_and_modified_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Restore/restores_moved_renamed_and_modified_file.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Wed, 31 Oct 2018 06:15:16 GMT
+      - Thu, 08 Nov 2018 01:44:20 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:16 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:20 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Wed, 31 Oct 2018 06:15:16 GMT
+      - Thu, 08 Nov 2018 01:44:20 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:16 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:20 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-31
-        06:15:16 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-11-08
+        01:44:20 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:15:16 GMT
+      - Thu, 08 Nov 2018 01:44:20 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:15:16 GMT
+      - Thu, 08 Nov 2018 01:44:21 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1o2nVWxzNIIJnu5rimrgkQZOpHtJk6eQE",
-         "name": "Test @ 2018-10-31 06:15:16 UTC",
+         "id": "1bXDrr9l2y3AYsWeAyNHIKX0gC7xSclnU",
+         "name": "Test @ 2018-11-08 01:44:20 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,13 +185,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:17 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:21 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1o2nVWxzNIIJnu5rimrgkQZOpHtJk6eQE"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1bXDrr9l2y3AYsWeAyNHIKX0gC7xSclnU"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:15:17 GMT
+      - Thu, 08 Nov 2018 01:44:21 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:15:17 GMT
+      - Thu, 08 Nov 2018 01:44:22 GMT
       Vary:
       - Origin
       - X-Origin
@@ -241,12 +241,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1MhBo7E6tEDk5Pd3SOg99QpwD523Nif4O",
+         "id": "18HWXWET99kfPilDovx8oENyiUGge4WRJ",
          "name": "Folder",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1o2nVWxzNIIJnu5rimrgkQZOpHtJk6eQE"
+          "1bXDrr9l2y3AYsWeAyNHIKX0gC7xSclnU"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -262,14 +262,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:18 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:22 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.document","name":"original
-        name","parents":["1MhBo7E6tEDk5Pd3SOg99QpwD523Nif4O"]}'
+        name","parents":["18HWXWET99kfPilDovx8oENyiUGge4WRJ"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -278,7 +278,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:15:18 GMT
+      - Thu, 08 Nov 2018 01:44:22 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -295,7 +295,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:15:19 GMT
+      - Thu, 08 Nov 2018 01:44:23 GMT
       Vary:
       - Origin
       - X-Origin
@@ -319,12 +319,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1u6pr1Y-y75GTAJAaFjQucQaRQsSgA5O0SsMsFEjUsgs",
+         "id": "1IGMIqZaJXafY3dIRrkKKTXZrTH0Ws21WdTP074CNffg",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1MhBo7E6tEDk5Pd3SOg99QpwD523Nif4O"
+          "18HWXWET99kfPilDovx8oENyiUGge4WRJ"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -340,10 +340,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:19 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:23 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1o2nVWxzNIIJnu5rimrgkQZOpHtJk6eQE/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1bXDrr9l2y3AYsWeAyNHIKX0gC7xSclnU/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -355,7 +355,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:15:19 GMT
+      - Thu, 08 Nov 2018 01:44:23 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -372,7 +372,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:15:20 GMT
+      - Thu, 08 Nov 2018 01:44:25 GMT
       Vary:
       - Origin
       - X-Origin
@@ -402,14 +402,14 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:20 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:25 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"2 Starship
-        Titanic (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"25 Vogon Constructor
+        Fleet (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -418,7 +418,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:15:25 GMT
+      - Thu, 08 Nov 2018 01:44:30 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -435,7 +435,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:15:26 GMT
+      - Thu, 08 Nov 2018 01:44:31 GMT
       Vary:
       - Origin
       - X-Origin
@@ -459,8 +459,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1XUSBgnjfyPFKO8cFyOFtm-XgpA_f4-f7",
-         "name": "2 Starship Titanic (Archive)",
+         "id": "18XhGxum-eK2HqH0TX2ynMPK4K9ibn9lZ",
+         "name": "25 Vogon Constructor Fleet (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -480,10 +480,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:26 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:32 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1XUSBgnjfyPFKO8cFyOFtm-XgpA_f4-f7/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/18XhGxum-eK2HqH0TX2ynMPK4K9ibn9lZ/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -495,7 +495,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:15:26 GMT
+      - Thu, 08 Nov 2018 01:44:32 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -512,7 +512,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:15:26 GMT
+      - Thu, 08 Nov 2018 01:44:33 GMT
       Vary:
       - Origin
       - X-Origin
@@ -542,10 +542,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:27 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:33 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1o2nVWxzNIIJnu5rimrgkQZOpHtJk6eQE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1bXDrr9l2y3AYsWeAyNHIKX0gC7xSclnU?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -557,7 +557,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:15:27 GMT
+      - Thu, 08 Nov 2018 01:44:33 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -568,9 +568,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 06:15:27 GMT
+      - Thu, 08 Nov 2018 01:44:33 GMT
       Date:
-      - Wed, 31 Oct 2018 06:15:27 GMT
+      - Thu, 08 Nov 2018 01:44:33 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -596,8 +596,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1o2nVWxzNIIJnu5rimrgkQZOpHtJk6eQE",
-         "name": "Test @ 2018-10-31 06:15:16 UTC",
+         "id": "1bXDrr9l2y3AYsWeAyNHIKX0gC7xSclnU",
+         "name": "Test @ 2018-11-08 01:44:20 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -623,10 +623,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:27 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:33 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1o2nVWxzNIIJnu5rimrgkQZOpHtJk6eQE/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1bXDrr9l2y3AYsWeAyNHIKX0gC7xSclnU/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -638,7 +638,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:15:27 GMT
+      - Thu, 08 Nov 2018 01:44:33 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -656,9 +656,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 31 Oct 2018 06:15:27 GMT
+      - Thu, 08 Nov 2018 01:44:34 GMT
       Expires:
-      - Wed, 31 Oct 2018 06:15:27 GMT
+      - Thu, 08 Nov 2018 01:44:34 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -690,10 +690,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:27 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:34 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1o2nVWxzNIIJnu5rimrgkQZOpHtJk6eQE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271bXDrr9l2y3AYsWeAyNHIKX0gC7xSclnU%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -705,7 +705,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:15:27 GMT
+      - Thu, 08 Nov 2018 01:44:34 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -716,305 +716,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 06:15:27 GMT
+      - Thu, 08 Nov 2018 01:44:34 GMT
       Date:
-      - Wed, 31 Oct 2018 06:15:27 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1o2nVWxzNIIJnu5rimrgkQZOpHtJk6eQE",
-         "name": "Test @ 2018-10-31 06:15:16 UTC",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:27 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1o2nVWxzNIIJnu5rimrgkQZOpHtJk6eQE/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 31 Oct 2018 06:15:27 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Wed, 31 Oct 2018 06:15:27 GMT
-      Expires:
-      - Wed, 31 Oct 2018 06:15:27 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:28 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1o2nVWxzNIIJnu5rimrgkQZOpHtJk6eQE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 31 Oct 2018 06:15:28 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Wed, 31 Oct 2018 06:15:28 GMT
-      Date:
-      - Wed, 31 Oct 2018 06:15:28 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1o2nVWxzNIIJnu5rimrgkQZOpHtJk6eQE",
-         "name": "Test @ 2018-10-31 06:15:16 UTC",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:28 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1o2nVWxzNIIJnu5rimrgkQZOpHtJk6eQE/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 31 Oct 2018 06:15:28 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Wed, 31 Oct 2018 06:15:28 GMT
-      Expires:
-      - Wed, 31 Oct 2018 06:15:28 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:28 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271o2nVWxzNIIJnu5rimrgkQZOpHtJk6eQE%27%20in%20parents
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 31 Oct 2018 06:15:28 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Wed, 31 Oct 2018 06:15:28 GMT
-      Date:
-      - Wed, 31 Oct 2018 06:15:28 GMT
+      - Thu, 08 Nov 2018 01:44:34 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1042,12 +746,12 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1MhBo7E6tEDk5Pd3SOg99QpwD523Nif4O",
+           "id": "18HWXWET99kfPilDovx8oENyiUGge4WRJ",
            "name": "Folder",
            "mimeType": "application/vnd.google-apps.folder",
            "trashed": false,
            "parents": [
-            "1o2nVWxzNIIJnu5rimrgkQZOpHtJk6eQE"
+            "1bXDrr9l2y3AYsWeAyNHIKX0gC7xSclnU"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -1074,10 +778,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:28 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:34 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1MhBo7E6tEDk5Pd3SOg99QpwD523Nif4O/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/18HWXWET99kfPilDovx8oENyiUGge4WRJ/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1089,7 +793,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:15:28 GMT
+      - Thu, 08 Nov 2018 01:44:34 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1107,9 +811,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 31 Oct 2018 06:15:28 GMT
+      - Thu, 08 Nov 2018 01:44:34 GMT
       Expires:
-      - Wed, 31 Oct 2018 06:15:28 GMT
+      - Thu, 08 Nov 2018 01:44:34 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1141,10 +845,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:28 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:34 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271MhBo7E6tEDk5Pd3SOg99QpwD523Nif4O%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%2718HWXWET99kfPilDovx8oENyiUGge4WRJ%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -1156,7 +860,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:15:28 GMT
+      - Thu, 08 Nov 2018 01:44:34 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1167,9 +871,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 06:15:28 GMT
+      - Thu, 08 Nov 2018 01:44:35 GMT
       Date:
-      - Wed, 31 Oct 2018 06:15:28 GMT
+      - Thu, 08 Nov 2018 01:44:35 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1197,14 +901,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1u6pr1Y-y75GTAJAaFjQucQaRQsSgA5O0SsMsFEjUsgs",
+           "id": "1IGMIqZaJXafY3dIRrkKKTXZrTH0Ws21WdTP074CNffg",
            "name": "original name",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1MhBo7E6tEDk5Pd3SOg99QpwD523Nif4O"
+            "18HWXWET99kfPilDovx8oENyiUGge4WRJ"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1u6pr1Y-y75GTAJAaFjQucQaRQsSgA5O0SsMsFEjUsgs&v=1&s=AMedNnoAAAAAW9lkoH7wg3DI4-RtyGHn4Gwz-WK3YZL1&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1IGMIqZaJXafY3dIRrkKKTXZrTH0Ws21WdTP074CNffg&v=1&s=AMedNnoAAAAAW-OxI0yds8Wm1q1HocBad1wMHVrhE-S4&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -1230,10 +934,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:28 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:35 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1u6pr1Y-y75GTAJAaFjQucQaRQsSgA5O0SsMsFEjUsgs/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1IGMIqZaJXafY3dIRrkKKTXZrTH0Ws21WdTP074CNffg/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1245,7 +949,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:15:28 GMT
+      - Thu, 08 Nov 2018 01:44:35 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1256,9 +960,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 06:15:29 GMT
+      - Thu, 08 Nov 2018 01:44:35 GMT
       Date:
-      - Wed, 31 Oct 2018 06:15:29 GMT
+      - Thu, 08 Nov 2018 01:44:35 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1287,13 +991,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-31T06:15:18.345Z"
+         "modifiedTime": "2018-11-08T01:44:22.718Z"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:29 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:35 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1u6pr1Y-y75GTAJAaFjQucQaRQsSgA5O0SsMsFEjUsgs&s=AMedNnoAAAAAW9lkoH7wg3DI4-RtyGHn4Gwz-WK3YZL1&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1IGMIqZaJXafY3dIRrkKKTXZrTH0Ws21WdTP074CNffg&s=AMedNnoAAAAAW-OxI0yds8Wm1q1HocBad1wMHVrhE-S4&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1305,7 +1009,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:15:29 GMT
+      - Thu, 08 Nov 2018 01:44:35 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1336,7 +1040,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 31 Oct 2018 06:15:29 GMT
+      - Thu, 08 Nov 2018 01:44:36 GMT
       Server:
       - fife
       Content-Length:
@@ -1350,13 +1054,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:29 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:36 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1u6pr1Y-y75GTAJAaFjQucQaRQsSgA5O0SsMsFEjUsgs/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1IGMIqZaJXafY3dIRrkKKTXZrTH0Ws21WdTP074CNffg/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"original name","parents":["1XUSBgnjfyPFKO8cFyOFtm-XgpA_f4-f7"]}'
+      string: '{"name":"original name","parents":["18XhGxum-eK2HqH0TX2ynMPK4K9ibn9lZ"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1365,7 +1069,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:15:29 GMT
+      - Thu, 08 Nov 2018 01:44:36 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1382,7 +1086,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:15:31 GMT
+      - Thu, 08 Nov 2018 01:44:38 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1406,12 +1110,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "14zFdStS5wNgVqGjq2WZCs-fm5VsCURdSHF6MwMTpoFI",
+         "id": "1bqNiryINabBicSv5l-p87eWzsSaIhaTGvMbIhl3EN1Y",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1XUSBgnjfyPFKO8cFyOFtm-XgpA_f4-f7"
+          "18XhGxum-eK2HqH0TX2ynMPK4K9ibn9lZ"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1436,10 +1140,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:31 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:38 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1u6pr1Y-y75GTAJAaFjQucQaRQsSgA5O0SsMsFEjUsgs?addParents=1o2nVWxzNIIJnu5rimrgkQZOpHtJk6eQE&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1MhBo7E6tEDk5Pd3SOg99QpwD523Nif4O
+    uri: https://www.googleapis.com/drive/v3/files/1IGMIqZaJXafY3dIRrkKKTXZrTH0Ws21WdTP074CNffg?addParents=1bXDrr9l2y3AYsWeAyNHIKX0gC7xSclnU&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=18HWXWET99kfPilDovx8oENyiUGge4WRJ
     body:
       encoding: UTF-8
       string: ''
@@ -1451,7 +1155,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:15:31 GMT
+      - Thu, 08 Nov 2018 01:44:38 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1468,7 +1172,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:15:31 GMT
+      - Thu, 08 Nov 2018 01:44:39 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1492,14 +1196,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1u6pr1Y-y75GTAJAaFjQucQaRQsSgA5O0SsMsFEjUsgs",
+         "id": "1IGMIqZaJXafY3dIRrkKKTXZrTH0Ws21WdTP074CNffg",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1o2nVWxzNIIJnu5rimrgkQZOpHtJk6eQE"
+          "1bXDrr9l2y3AYsWeAyNHIKX0gC7xSclnU"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1u6pr1Y-y75GTAJAaFjQucQaRQsSgA5O0SsMsFEjUsgs&v=1&s=AMedNnoAAAAAW9lko_Aw5X43Z1UCVAZhunMeo7GwWHN0&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1IGMIqZaJXafY3dIRrkKKTXZrTH0Ws21WdTP074CNffg&v=1&s=AMedNnoAAAAAW-OxJ5ZtMZ9cjHl2UzC-kv6Li7CMjpv1&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -1523,10 +1227,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:32 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:39 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1u6pr1Y-y75GTAJAaFjQucQaRQsSgA5O0SsMsFEjUsgs?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1IGMIqZaJXafY3dIRrkKKTXZrTH0Ws21WdTP074CNffg?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"name":"new file name"}'
@@ -1538,7 +1242,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:15:32 GMT
+      - Thu, 08 Nov 2018 01:44:39 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1555,7 +1259,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:15:32 GMT
+      - Thu, 08 Nov 2018 01:44:40 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1579,14 +1283,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1u6pr1Y-y75GTAJAaFjQucQaRQsSgA5O0SsMsFEjUsgs",
+         "id": "1IGMIqZaJXafY3dIRrkKKTXZrTH0Ws21WdTP074CNffg",
          "name": "new file name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1o2nVWxzNIIJnu5rimrgkQZOpHtJk6eQE"
+          "1bXDrr9l2y3AYsWeAyNHIKX0gC7xSclnU"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1u6pr1Y-y75GTAJAaFjQucQaRQsSgA5O0SsMsFEjUsgs&v=2&s=AMedNnoAAAAAW9lkpFVGTHIrxckGThE6RdStoonV3rL-&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1IGMIqZaJXafY3dIRrkKKTXZrTH0Ws21WdTP074CNffg&v=2&s=AMedNnoAAAAAW-OxKBLgHKLw01vqfEWZ9Zk3AALKgzf5&sz=s220",
          "thumbnailVersion": "2",
          "permissions": [
           {
@@ -1610,10 +1314,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:32 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:40 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/upload/drive/v3/files/1u6pr1Y-y75GTAJAaFjQucQaRQsSgA5O0SsMsFEjUsgs
+    uri: https://www.googleapis.com/upload/drive/v3/files/1IGMIqZaJXafY3dIRrkKKTXZrTH0Ws21WdTP074CNffg
     body:
       encoding: UTF-8
       string: ''
@@ -1625,7 +1329,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:15:32 GMT
+      - Thu, 08 Nov 2018 01:44:40 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       X-Goog-Upload-Protocol:
@@ -1644,22 +1348,22 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2Uo22Qr4Emhwdb2jU9F93mY6UGHZf8Z-RjH_qe3CG8EsYAk1oZRkMLm2PiZaTRde9hCi2agWIy80uxRrUyknfcen0mvVmgU9E-tJ72PwwwhQBJJlUEQ
+      - AEnB2UqVdyrMR3saxs4oGqbUiKKPU27SmuHMTYCM_4ZweSJ3MZIi6b1E_wgLq5L9jbBWLkgzyPrggS_U1EoEDq7890r9QohEYQ
       X-Goog-Upload-Status:
       - active
       X-Goog-Upload-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1u6pr1Y-y75GTAJAaFjQucQaRQsSgA5O0SsMsFEjUsgs?upload_id=AEnB2Uo22Qr4Emhwdb2jU9F93mY6UGHZf8Z-RjH_qe3CG8EsYAk1oZRkMLm2PiZaTRde9hCi2agWIy80uxRrUyknfcen0mvVmgU9E-tJ72PwwwhQBJJlUEQ&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1IGMIqZaJXafY3dIRrkKKTXZrTH0Ws21WdTP074CNffg?upload_id=AEnB2UqVdyrMR3saxs4oGqbUiKKPU27SmuHMTYCM_4ZweSJ3MZIi6b1E_wgLq5L9jbBWLkgzyPrggS_U1EoEDq7890r9QohEYQ&upload_protocol=resumable
       X-Goog-Upload-Control-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1u6pr1Y-y75GTAJAaFjQucQaRQsSgA5O0SsMsFEjUsgs?upload_id=AEnB2Uo22Qr4Emhwdb2jU9F93mY6UGHZf8Z-RjH_qe3CG8EsYAk1oZRkMLm2PiZaTRde9hCi2agWIy80uxRrUyknfcen0mvVmgU9E-tJ72PwwwhQBJJlUEQ&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1IGMIqZaJXafY3dIRrkKKTXZrTH0Ws21WdTP074CNffg?upload_id=AEnB2UqVdyrMR3saxs4oGqbUiKKPU27SmuHMTYCM_4ZweSJ3MZIi6b1E_wgLq5L9jbBWLkgzyPrggS_U1EoEDq7890r9QohEYQ&upload_protocol=resumable
       X-Goog-Upload-Chunk-Granularity:
       - '262144'
       X-Goog-Upload-Header-Vary:
       - Origin
       - X-Origin
       X-Goog-Upload-Header-X-Google-Backends:
-      - iog26:4141
+      - oixx72:4142
       X-Goog-Upload-Header-X-Google-Session-Info:
-      - CKeBxoimHBoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x4SEJwdnZJMGdoY01jR0U4MXRKa25qZks5TkZ6bVdiNGtZSUFqazc2WGU2OXVXaHNiZDJNeWg2REFoUC1tMEtQUWtfUUlROFotcFMyS2RVLUktOTBsMlY2SmMtRlBRWld5M3Q4ZTVqM2theHVUU2Y0VVdUa0JCYklwN2NBMAQ6DTEvSWFuUWZrd3Q0TX4
+      - CKeBxoimHBoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x4T0J1aXJBeTQ0T0lHV3pXUlVhMjhFcG9FUXd0RFVTNTJKYmE3a2pXaGt2VXBjWlNQbEJWWmpKd2tFY1RlUWRRTDA0MjI4WDZwbnl0YU9QUFhBN1ZJanZ3TWZBdG4zbURQTy1ydnluRFhCVzVRZWpzV0NJd3VFbWFUUzFnMAQ6DTEvSWFuUWZrd3Q0TX4
       X-Goog-Upload-Header-Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       X-Goog-Upload-Header-Pragma:
@@ -1667,11 +1371,11 @@ http_interactions:
       X-Goog-Upload-Header-Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       X-Goog-Upload-Header-Date:
-      - Wed, 31 Oct 2018 06:15:33 GMT
+      - Thu, 08 Nov 2018 01:44:40 GMT
       Content-Length:
       - '0'
       Date:
-      - Wed, 31 Oct 2018 06:15:33 GMT
+      - Thu, 08 Nov 2018 01:44:40 GMT
       Server:
       - UploadServer
       Content-Type:
@@ -1682,10 +1386,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:33 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:40 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/upload/drive/v3/files/1u6pr1Y-y75GTAJAaFjQucQaRQsSgA5O0SsMsFEjUsgs?upload_id=AEnB2Uo22Qr4Emhwdb2jU9F93mY6UGHZf8Z-RjH_qe3CG8EsYAk1oZRkMLm2PiZaTRde9hCi2agWIy80uxRrUyknfcen0mvVmgU9E-tJ72PwwwhQBJJlUEQ&upload_protocol=resumable
+    uri: https://www.googleapis.com/upload/drive/v3/files/1IGMIqZaJXafY3dIRrkKKTXZrTH0Ws21WdTP074CNffg?upload_id=AEnB2UqVdyrMR3saxs4oGqbUiKKPU27SmuHMTYCM_4ZweSJ3MZIi6b1E_wgLq5L9jbBWLkgzyPrggS_U1EoEDq7890r9QohEYQ&upload_protocol=resumable
     body:
       encoding: UTF-8
       string: new contents!
@@ -1697,7 +1401,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:15:33 GMT
+      - Thu, 08 Nov 2018 01:44:40 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       X-Goog-Upload-Command:
@@ -1712,7 +1416,7 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2Uo22Qr4Emhwdb2jU9F93mY6UGHZf8Z-RjH_qe3CG8EsYAk1oZRkMLm2PiZaTRde9hCi2agWIy80uxRrUyknfcen0mvVmgU9E-tJ72PwwwhQBJJlUEQ
+      - AEnB2UqVdyrMR3saxs4oGqbUiKKPU27SmuHMTYCM_4ZweSJ3MZIi6b1E_wgLq5L9jbBWLkgzyPrggS_U1EoEDq7890r9QohEYQ
       X-Goog-Upload-Status:
       - final
       Vary:
@@ -1727,7 +1431,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:15:34 GMT
+      - Thu, 08 Nov 2018 01:44:41 GMT
       Content-Length:
       - '160'
       Server:
@@ -1739,15 +1443,15 @@ http_interactions:
       string: |
         {
          "kind": "drive#file",
-         "id": "1u6pr1Y-y75GTAJAaFjQucQaRQsSgA5O0SsMsFEjUsgs",
+         "id": "1IGMIqZaJXafY3dIRrkKKTXZrTH0Ws21WdTP074CNffg",
          "name": "new file name",
          "mimeType": "application/vnd.google-apps.document"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:34 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:42 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1u6pr1Y-y75GTAJAaFjQucQaRQsSgA5O0SsMsFEjUsgs?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1IGMIqZaJXafY3dIRrkKKTXZrTH0Ws21WdTP074CNffg?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1759,7 +1463,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:15:34 GMT
+      - Thu, 08 Nov 2018 01:44:42 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1770,9 +1474,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 06:15:34 GMT
+      - Thu, 08 Nov 2018 01:44:42 GMT
       Date:
-      - Wed, 31 Oct 2018 06:15:34 GMT
+      - Thu, 08 Nov 2018 01:44:42 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1798,14 +1502,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1u6pr1Y-y75GTAJAaFjQucQaRQsSgA5O0SsMsFEjUsgs",
+         "id": "1IGMIqZaJXafY3dIRrkKKTXZrTH0Ws21WdTP074CNffg",
          "name": "new file name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1o2nVWxzNIIJnu5rimrgkQZOpHtJk6eQE"
+          "1bXDrr9l2y3AYsWeAyNHIKX0gC7xSclnU"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1u6pr1Y-y75GTAJAaFjQucQaRQsSgA5O0SsMsFEjUsgs&v=2&s=AMedNnoAAAAAW9lkpiRvYX_hq_NzmlZJZJIZTve5T7KY&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1IGMIqZaJXafY3dIRrkKKTXZrTH0Ws21WdTP074CNffg&v=2&s=AMedNnoAAAAAW-OxKsKn3ChHTevZKEsl_b8KmVPpyvri&sz=s220",
          "thumbnailVersion": "2",
          "permissions": [
           {
@@ -1829,10 +1533,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:34 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:42 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1u6pr1Y-y75GTAJAaFjQucQaRQsSgA5O0SsMsFEjUsgs/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1IGMIqZaJXafY3dIRrkKKTXZrTH0Ws21WdTP074CNffg/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1844,7 +1548,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:15:34 GMT
+      - Thu, 08 Nov 2018 01:44:42 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1855,9 +1559,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 06:15:34 GMT
+      - Thu, 08 Nov 2018 01:44:42 GMT
       Date:
-      - Wed, 31 Oct 2018 06:15:34 GMT
+      - Thu, 08 Nov 2018 01:44:42 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1886,13 +1590,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "3",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-31T06:15:33.978Z"
+         "modifiedTime": "2018-11-08T01:44:41.097Z"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:34 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:42 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1u6pr1Y-y75GTAJAaFjQucQaRQsSgA5O0SsMsFEjUsgs&s=AMedNnoAAAAAW9lkpiRvYX_hq_NzmlZJZJIZTve5T7KY&sz=s350&v=2
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1IGMIqZaJXafY3dIRrkKKTXZrTH0Ws21WdTP074CNffg&s=AMedNnoAAAAAW-OxKsKn3ChHTevZKEsl_b8KmVPpyvri&sz=s350&v=2
     body:
       encoding: UTF-8
       string: ''
@@ -1904,7 +1608,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:15:35 GMT
+      - Thu, 08 Nov 2018 01:44:42 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1935,7 +1639,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 31 Oct 2018 06:15:35 GMT
+      - Thu, 08 Nov 2018 01:44:42 GMT
       Server:
       - fife
       Content-Length:
@@ -1949,13 +1653,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:35 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:42 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1u6pr1Y-y75GTAJAaFjQucQaRQsSgA5O0SsMsFEjUsgs/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1IGMIqZaJXafY3dIRrkKKTXZrTH0Ws21WdTP074CNffg/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"new file name","parents":["1XUSBgnjfyPFKO8cFyOFtm-XgpA_f4-f7"]}'
+      string: '{"name":"new file name","parents":["18XhGxum-eK2HqH0TX2ynMPK4K9ibn9lZ"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1964,7 +1668,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:15:35 GMT
+      - Thu, 08 Nov 2018 01:44:43 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1981,7 +1685,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:15:37 GMT
+      - Thu, 08 Nov 2018 01:44:44 GMT
       Vary:
       - Origin
       - X-Origin
@@ -2005,12 +1709,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "17MvxrUAg6hIpW_tXFTBcyUNBYrT79MfDhvsg8wjLov0",
+         "id": "1g--T2xpqj4_Egr0IqwBnfxZ-Zeg9WMz207AlN3jhvxg",
          "name": "new file name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1XUSBgnjfyPFKO8cFyOFtm-XgpA_f4-f7"
+          "18XhGxum-eK2HqH0TX2ynMPK4K9ibn9lZ"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -2035,13 +1739,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:37 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:44 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/14zFdStS5wNgVqGjq2WZCs-fm5VsCURdSHF6MwMTpoFI/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1bqNiryINabBicSv5l-p87eWzsSaIhaTGvMbIhl3EN1Y/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"original name","parents":["1MhBo7E6tEDk5Pd3SOg99QpwD523Nif4O"]}'
+      string: '{"name":"original name","parents":["18HWXWET99kfPilDovx8oENyiUGge4WRJ"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -2050,7 +1754,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:15:37 GMT
+      - Thu, 08 Nov 2018 01:44:45 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -2067,7 +1771,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:15:39 GMT
+      - Thu, 08 Nov 2018 01:44:47 GMT
       Vary:
       - Origin
       - X-Origin
@@ -2091,12 +1795,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1X5MZSyj_SjUc5NVCWXxSnqgjAYoJqHlCzWPUsd82jlg",
+         "id": "1t8aidZXOu9jH8joNReHJWNM7fT_NMwWO1DAwm1-TjHw",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1MhBo7E6tEDk5Pd3SOg99QpwD523Nif4O"
+          "18HWXWET99kfPilDovx8oENyiUGge4WRJ"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -2121,10 +1825,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:39 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:47 GMT
 - request:
-    method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1u6pr1Y-y75GTAJAaFjQucQaRQsSgA5O0SsMsFEjUsgs?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1o2nVWxzNIIJnu5rimrgkQZOpHtJk6eQE
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1t8aidZXOu9jH8joNReHJWNM7fT_NMwWO1DAwm1-TjHw/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -2136,68 +1840,22 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:15:39 GMT
+      - Thu, 08 Nov 2018 01:44:47 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
       - application/x-www-form-urlencoded
   response:
     status:
-      code: 204
-      message: No Content
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Wed, 31 Oct 2018 06:15:39 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:40 GMT
-- request:
-    method: post
-    uri: https://www.googleapis.com/drive/v3/files/1X5MZSyj_SjUc5NVCWXxSnqgjAYoJqHlCzWPUsd82jlg/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: '{"name":"original name","parents":["1XUSBgnjfyPFKO8cFyOFtm-XgpA_f4-f7"]}'
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 31 Oct 2018 06:15:40 GMT
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-  response:
-    status:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
       Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
+      - Thu, 08 Nov 2018 01:44:47 GMT
       Date:
-      - Wed, 31 Oct 2018 06:15:42 GMT
+      - Thu, 08 Nov 2018 01:44:47 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
       Vary:
       - Origin
       - X-Origin
@@ -2221,40 +1879,16 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1AHJ1IJGvPAoKEafk3U7yPhFSs9CnUu0yOnfhQEiXeCo",
-         "name": "original name",
+         "kind": "drive#revision",
+         "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1XUSBgnjfyPFKO8cFyOFtm-XgpA_f4-f7"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
+         "modifiedTime": "2018-11-08T01:44:46.377Z"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:42 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:47 GMT
 - request:
-    method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1o2nVWxzNIIJnu5rimrgkQZOpHtJk6eQE
+    method: patch
+    uri: https://www.googleapis.com/drive/v3/files/1IGMIqZaJXafY3dIRrkKKTXZrTH0Ws21WdTP074CNffg?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1bXDrr9l2y3AYsWeAyNHIKX0gC7xSclnU
     body:
       encoding: UTF-8
       string: ''
@@ -2266,7 +1900,51 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:15:42 GMT
+      - Thu, 08 Nov 2018 01:44:47 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 08 Nov 2018 01:44:48 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 08 Nov 2018 01:44:48 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1bXDrr9l2y3AYsWeAyNHIKX0gC7xSclnU
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 08 Nov 2018 01:44:48 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -2283,7 +1961,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:15:43 GMT
+      - Thu, 08 Nov 2018 01:44:49 GMT
       Vary:
       - Origin
       - X-Origin
@@ -2295,5 +1973,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:15:43 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:49 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Restore/restores_removed_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Restore/restores_removed_file.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Wed, 31 Oct 2018 06:06:41 GMT
+      - Thu, 08 Nov 2018 01:44:49 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:06:41 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:49 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Wed, 31 Oct 2018 06:06:41 GMT
+      - Thu, 08 Nov 2018 01:44:49 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:06:41 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:49 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-31
-        06:06:41 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-11-08
+        01:44:49 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:06:41 GMT
+      - Thu, 08 Nov 2018 01:44:49 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:06:42 GMT
+      - Thu, 08 Nov 2018 01:44:50 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1QBVZx4F_x6KzaUGOWCvMfHJy39A1xeEb",
-         "name": "Test @ 2018-10-31 06:06:41 UTC",
+         "id": "1eHvHXmATirSIm80igA_gF6E8dl3xKAyJ",
+         "name": "Test @ 2018-11-08 01:44:49 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,13 +185,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:06:42 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:51 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1QBVZx4F_x6KzaUGOWCvMfHJy39A1xeEb"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1eHvHXmATirSIm80igA_gF6E8dl3xKAyJ"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:06:42 GMT
+      - Thu, 08 Nov 2018 01:44:51 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:06:42 GMT
+      - Thu, 08 Nov 2018 01:44:52 GMT
       Vary:
       - Origin
       - X-Origin
@@ -241,12 +241,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "18SxaqEaet8-J0ZSCSrEUZSq2mTgs9Dsh",
+         "id": "1RREw6MB11Akyt-q-6IbywB-BA0TKBhf6",
          "name": "Folder",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1QBVZx4F_x6KzaUGOWCvMfHJy39A1xeEb"
+          "1eHvHXmATirSIm80igA_gF6E8dl3xKAyJ"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -262,14 +262,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:06:42 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:52 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.document","name":"original
-        name","parents":["18SxaqEaet8-J0ZSCSrEUZSq2mTgs9Dsh"]}'
+        name","parents":["1RREw6MB11Akyt-q-6IbywB-BA0TKBhf6"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -278,7 +278,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:06:42 GMT
+      - Thu, 08 Nov 2018 01:44:52 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -295,7 +295,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:06:44 GMT
+      - Thu, 08 Nov 2018 01:44:55 GMT
       Vary:
       - Origin
       - X-Origin
@@ -319,12 +319,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1V4RxQx7NEvuzIZKTj7f8x1HXpXaJNv_SfGEjoiUsxas",
+         "id": "1PgYQC-3kItRuMRdPNy3B93HiqC5k2FMkhtAqUNJ6Xr0",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "18SxaqEaet8-J0ZSCSrEUZSq2mTgs9Dsh"
+          "1RREw6MB11Akyt-q-6IbywB-BA0TKBhf6"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -340,10 +340,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:06:44 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:55 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1QBVZx4F_x6KzaUGOWCvMfHJy39A1xeEb/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1eHvHXmATirSIm80igA_gF6E8dl3xKAyJ/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -355,7 +355,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:06:44 GMT
+      - Thu, 08 Nov 2018 01:44:55 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -372,7 +372,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:06:45 GMT
+      - Thu, 08 Nov 2018 01:44:56 GMT
       Vary:
       - Origin
       - X-Origin
@@ -402,14 +402,14 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:06:45 GMT
+  recorded_at: Thu, 08 Nov 2018 01:44:56 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"1 Heart of
-        Gold (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"26 Golgafrinchan
+        Ark Fleet Ship B (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -418,7 +418,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:06:47 GMT
+      - Thu, 08 Nov 2018 01:45:01 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -435,7 +435,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:06:48 GMT
+      - Thu, 08 Nov 2018 01:45:02 GMT
       Vary:
       - Origin
       - X-Origin
@@ -459,8 +459,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1m5fepQ0RhtxoHm2ju2FbPBz7WbDVFvNS",
-         "name": "1 Heart of Gold (Archive)",
+         "id": "153XCyYghDkLP6fp2wtydCXZjUMNbcL0u",
+         "name": "26 Golgafrinchan Ark Fleet Ship B (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -480,10 +480,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:06:48 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:02 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1m5fepQ0RhtxoHm2ju2FbPBz7WbDVFvNS/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/153XCyYghDkLP6fp2wtydCXZjUMNbcL0u/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -495,7 +495,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:06:48 GMT
+      - Thu, 08 Nov 2018 01:45:02 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -512,7 +512,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:06:49 GMT
+      - Thu, 08 Nov 2018 01:45:03 GMT
       Vary:
       - Origin
       - X-Origin
@@ -542,10 +542,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:06:49 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:03 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1QBVZx4F_x6KzaUGOWCvMfHJy39A1xeEb?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1eHvHXmATirSIm80igA_gF6E8dl3xKAyJ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -557,7 +557,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:06:49 GMT
+      - Thu, 08 Nov 2018 01:45:03 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -568,9 +568,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 06:06:49 GMT
+      - Thu, 08 Nov 2018 01:45:04 GMT
       Date:
-      - Wed, 31 Oct 2018 06:06:49 GMT
+      - Thu, 08 Nov 2018 01:45:04 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -596,8 +596,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1QBVZx4F_x6KzaUGOWCvMfHJy39A1xeEb",
-         "name": "Test @ 2018-10-31 06:06:41 UTC",
+         "id": "1eHvHXmATirSIm80igA_gF6E8dl3xKAyJ",
+         "name": "Test @ 2018-11-08 01:44:49 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -623,10 +623,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:06:50 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:04 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1QBVZx4F_x6KzaUGOWCvMfHJy39A1xeEb/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1eHvHXmATirSIm80igA_gF6E8dl3xKAyJ/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -638,7 +638,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:06:50 GMT
+      - Thu, 08 Nov 2018 01:45:04 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -656,9 +656,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 31 Oct 2018 06:06:50 GMT
+      - Thu, 08 Nov 2018 01:45:04 GMT
       Expires:
-      - Wed, 31 Oct 2018 06:06:50 GMT
+      - Thu, 08 Nov 2018 01:45:04 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -690,10 +690,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:06:50 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:04 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1QBVZx4F_x6KzaUGOWCvMfHJy39A1xeEb?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271eHvHXmATirSIm80igA_gF6E8dl3xKAyJ%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -705,7 +705,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:06:50 GMT
+      - Thu, 08 Nov 2018 01:45:04 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -716,305 +716,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 06:06:50 GMT
+      - Thu, 08 Nov 2018 01:45:04 GMT
       Date:
-      - Wed, 31 Oct 2018 06:06:50 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1QBVZx4F_x6KzaUGOWCvMfHJy39A1xeEb",
-         "name": "Test @ 2018-10-31 06:06:41 UTC",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:06:50 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1QBVZx4F_x6KzaUGOWCvMfHJy39A1xeEb/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 31 Oct 2018 06:06:50 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Wed, 31 Oct 2018 06:06:50 GMT
-      Expires:
-      - Wed, 31 Oct 2018 06:06:50 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:06:50 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1QBVZx4F_x6KzaUGOWCvMfHJy39A1xeEb?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 31 Oct 2018 06:06:50 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Wed, 31 Oct 2018 06:06:50 GMT
-      Date:
-      - Wed, 31 Oct 2018 06:06:50 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1QBVZx4F_x6KzaUGOWCvMfHJy39A1xeEb",
-         "name": "Test @ 2018-10-31 06:06:41 UTC",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:06:50 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1QBVZx4F_x6KzaUGOWCvMfHJy39A1xeEb/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 31 Oct 2018 06:06:50 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Wed, 31 Oct 2018 06:06:50 GMT
-      Expires:
-      - Wed, 31 Oct 2018 06:06:50 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:06:50 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271QBVZx4F_x6KzaUGOWCvMfHJy39A1xeEb%27%20in%20parents
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 31 Oct 2018 06:06:50 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Wed, 31 Oct 2018 06:06:51 GMT
-      Date:
-      - Wed, 31 Oct 2018 06:06:51 GMT
+      - Thu, 08 Nov 2018 01:45:04 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1042,12 +746,12 @@ http_interactions:
         {
          "files": [
           {
-           "id": "18SxaqEaet8-J0ZSCSrEUZSq2mTgs9Dsh",
+           "id": "1RREw6MB11Akyt-q-6IbywB-BA0TKBhf6",
            "name": "Folder",
            "mimeType": "application/vnd.google-apps.folder",
            "trashed": false,
            "parents": [
-            "1QBVZx4F_x6KzaUGOWCvMfHJy39A1xeEb"
+            "1eHvHXmATirSIm80igA_gF6E8dl3xKAyJ"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -1074,10 +778,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:06:51 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:04 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/18SxaqEaet8-J0ZSCSrEUZSq2mTgs9Dsh/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1RREw6MB11Akyt-q-6IbywB-BA0TKBhf6/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1089,7 +793,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:06:51 GMT
+      - Thu, 08 Nov 2018 01:45:04 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1107,9 +811,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 31 Oct 2018 06:06:51 GMT
+      - Thu, 08 Nov 2018 01:45:05 GMT
       Expires:
-      - Wed, 31 Oct 2018 06:06:51 GMT
+      - Thu, 08 Nov 2018 01:45:05 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1141,10 +845,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:06:51 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:05 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%2718SxaqEaet8-J0ZSCSrEUZSq2mTgs9Dsh%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271RREw6MB11Akyt-q-6IbywB-BA0TKBhf6%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -1156,7 +860,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:06:51 GMT
+      - Thu, 08 Nov 2018 01:45:05 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1167,9 +871,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 06:06:52 GMT
+      - Thu, 08 Nov 2018 01:45:05 GMT
       Date:
-      - Wed, 31 Oct 2018 06:06:52 GMT
+      - Thu, 08 Nov 2018 01:45:05 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1197,14 +901,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1V4RxQx7NEvuzIZKTj7f8x1HXpXaJNv_SfGEjoiUsxas",
+           "id": "1PgYQC-3kItRuMRdPNy3B93HiqC5k2FMkhtAqUNJ6Xr0",
            "name": "original name",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "18SxaqEaet8-J0ZSCSrEUZSq2mTgs9Dsh"
+            "1RREw6MB11Akyt-q-6IbywB-BA0TKBhf6"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1V4RxQx7NEvuzIZKTj7f8x1HXpXaJNv_SfGEjoiUsxas&v=1&s=AMedNnoAAAAAW9linMUaQzhs8yeRg90xMJG6dUSmmdE3&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1PgYQC-3kItRuMRdPNy3B93HiqC5k2FMkhtAqUNJ6Xr0&v=1&s=AMedNnoAAAAAW-OxQfonoWdK9w6TUTYcUTqPNNNI_Z_v&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -1230,10 +934,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:06:52 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:05 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1V4RxQx7NEvuzIZKTj7f8x1HXpXaJNv_SfGEjoiUsxas/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1PgYQC-3kItRuMRdPNy3B93HiqC5k2FMkhtAqUNJ6Xr0/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1245,7 +949,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:06:52 GMT
+      - Thu, 08 Nov 2018 01:45:05 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1256,9 +960,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 06:06:52 GMT
+      - Thu, 08 Nov 2018 01:45:06 GMT
       Date:
-      - Wed, 31 Oct 2018 06:06:52 GMT
+      - Thu, 08 Nov 2018 01:45:06 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1287,13 +991,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-31T06:06:43.800Z"
+         "modifiedTime": "2018-11-08T01:44:53.310Z"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:06:52 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:06 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1V4RxQx7NEvuzIZKTj7f8x1HXpXaJNv_SfGEjoiUsxas&s=AMedNnoAAAAAW9linMUaQzhs8yeRg90xMJG6dUSmmdE3&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1PgYQC-3kItRuMRdPNy3B93HiqC5k2FMkhtAqUNJ6Xr0&s=AMedNnoAAAAAW-OxQfonoWdK9w6TUTYcUTqPNNNI_Z_v&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1305,7 +1009,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:06:52 GMT
+      - Thu, 08 Nov 2018 01:45:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1336,7 +1040,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 31 Oct 2018 06:06:53 GMT
+      - Thu, 08 Nov 2018 01:45:06 GMT
       Server:
       - fife
       Content-Length:
@@ -1350,13 +1054,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:06:53 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:06 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1V4RxQx7NEvuzIZKTj7f8x1HXpXaJNv_SfGEjoiUsxas/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1PgYQC-3kItRuMRdPNy3B93HiqC5k2FMkhtAqUNJ6Xr0/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"original name","parents":["1m5fepQ0RhtxoHm2ju2FbPBz7WbDVFvNS"]}'
+      string: '{"name":"original name","parents":["153XCyYghDkLP6fp2wtydCXZjUMNbcL0u"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1365,7 +1069,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:06:53 GMT
+      - Thu, 08 Nov 2018 01:45:06 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1382,7 +1086,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:07:00 GMT
+      - Thu, 08 Nov 2018 01:45:08 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1406,12 +1110,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1gNjMsGRvkFmDtm1yXmImCH0-TsnL8GXHy5N9Mvt-gK4",
+         "id": "1rLxhhl08KgFohifWz31CkVIWUFe1t_GNbXmeOas6iA4",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1m5fepQ0RhtxoHm2ju2FbPBz7WbDVFvNS"
+          "153XCyYghDkLP6fp2wtydCXZjUMNbcL0u"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1436,10 +1140,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:07:00 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:08 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1V4RxQx7NEvuzIZKTj7f8x1HXpXaJNv_SfGEjoiUsxas
+    uri: https://www.googleapis.com/drive/v3/files/1PgYQC-3kItRuMRdPNy3B93HiqC5k2FMkhtAqUNJ6Xr0
     body:
       encoding: UTF-8
       string: ''
@@ -1451,7 +1155,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:07:00 GMT
+      - Thu, 08 Nov 2018 01:45:08 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1468,7 +1172,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:07:01 GMT
+      - Thu, 08 Nov 2018 01:45:09 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1480,10 +1184,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:07:01 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:09 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1V4RxQx7NEvuzIZKTj7f8x1HXpXaJNv_SfGEjoiUsxas?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1PgYQC-3kItRuMRdPNy3B93HiqC5k2FMkhtAqUNJ6Xr0?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1495,7 +1199,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:07:02 GMT
+      - Thu, 08 Nov 2018 01:45:09 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1513,9 +1217,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 31 Oct 2018 06:07:02 GMT
+      - Thu, 08 Nov 2018 01:45:09 GMT
       Expires:
-      - Wed, 31 Oct 2018 06:07:02 GMT
+      - Thu, 08 Nov 2018 01:45:09 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1539,23 +1243,23 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1V4RxQx7NEvuzIZKTj7f8x1HXpXaJNv_SfGEjoiUsxas.",
+            "message": "File not found: 1PgYQC-3kItRuMRdPNy3B93HiqC5k2FMkhtAqUNJ6Xr0.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1V4RxQx7NEvuzIZKTj7f8x1HXpXaJNv_SfGEjoiUsxas."
+          "message": "File not found: 1PgYQC-3kItRuMRdPNy3B93HiqC5k2FMkhtAqUNJ6Xr0."
          }
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:07:02 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:09 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1gNjMsGRvkFmDtm1yXmImCH0-TsnL8GXHy5N9Mvt-gK4/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1rLxhhl08KgFohifWz31CkVIWUFe1t_GNbXmeOas6iA4/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"original name","parents":["18SxaqEaet8-J0ZSCSrEUZSq2mTgs9Dsh"]}'
+      string: '{"name":"original name","parents":["1RREw6MB11Akyt-q-6IbywB-BA0TKBhf6"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1564,7 +1268,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:07:02 GMT
+      - Thu, 08 Nov 2018 01:45:10 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1581,7 +1285,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:07:04 GMT
+      - Thu, 08 Nov 2018 01:45:13 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1605,12 +1309,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1nBsI3juQsEAUMUiKqbAZgaHzNTyqCBUuLwbdgdtkTOQ",
+         "id": "1QwnefEZzWhjux0ae3ZXlA_p6DPHwXlNwt0OdFoSU1SM",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "18SxaqEaet8-J0ZSCSrEUZSq2mTgs9Dsh"
+          "1RREw6MB11Akyt-q-6IbywB-BA0TKBhf6"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1635,13 +1339,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:07:05 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:13 GMT
 - request:
-    method: post
-    uri: https://www.googleapis.com/drive/v3/files/1nBsI3juQsEAUMUiKqbAZgaHzNTyqCBUuLwbdgdtkTOQ/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1QwnefEZzWhjux0ae3ZXlA_p6DPHwXlNwt0OdFoSU1SM/revisions/head
     body:
       encoding: UTF-8
-      string: '{"name":"original name","parents":["1m5fepQ0RhtxoHm2ju2FbPBz7WbDVFvNS"]}'
+      string: ''
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1650,24 +1354,22 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:07:05 GMT
-      Content-Type:
-      - application/json
+      - Thu, 08 Nov 2018 01:45:13 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
   response:
     status:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
       Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
+      - Thu, 08 Nov 2018 01:45:13 GMT
       Date:
-      - Wed, 31 Oct 2018 06:07:07 GMT
+      - Thu, 08 Nov 2018 01:45:13 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
       Vary:
       - Origin
       - X-Origin
@@ -1691,40 +1393,16 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "10_U490YQBEwyVxgSoagIR_bYLqprlQLD93cTgsOrOSw",
-         "name": "original name",
+         "kind": "drive#revision",
+         "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1m5fepQ0RhtxoHm2ju2FbPBz7WbDVFvNS"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
+         "modifiedTime": "2018-11-08T01:45:12.376Z"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:07:07 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:13 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1QBVZx4F_x6KzaUGOWCvMfHJy39A1xeEb
+    uri: https://www.googleapis.com/drive/v3/files/1eHvHXmATirSIm80igA_gF6E8dl3xKAyJ
     body:
       encoding: UTF-8
       string: ''
@@ -1736,7 +1414,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:08:33 GMT
+      - Thu, 08 Nov 2018 01:45:13 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1753,7 +1431,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:08:34 GMT
+      - Thu, 08 Nov 2018 01:45:13 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1765,5 +1443,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:34 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:14 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Restore/when_parent_of_file_to_restore_does_not_exist/restores_the_file_to_home_folder.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Restore/when_parent_of_file_to_restore_does_not_exist/restores_the_file_to_home_folder.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Wed, 31 Oct 2018 06:08:36 GMT
+      - Thu, 08 Nov 2018 01:45:14 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:36 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:14 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Wed, 31 Oct 2018 06:08:36 GMT
+      - Thu, 08 Nov 2018 01:45:14 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:37 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:14 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-31
-        06:08:37 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-11-08
+        01:45:14 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:08:37 GMT
+      - Thu, 08 Nov 2018 01:45:14 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:08:37 GMT
+      - Thu, 08 Nov 2018 01:45:15 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1NPUiJn2frlL98myQd7EiHcXQepB0fTPl",
-         "name": "Test @ 2018-10-31 06:08:37 UTC",
+         "id": "1zSYV_k67EuAqIBagK2eDil7EUY_ZFF9B",
+         "name": "Test @ 2018-11-08 01:45:14 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,13 +185,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:37 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:15 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1NPUiJn2frlL98myQd7EiHcXQepB0fTPl"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1zSYV_k67EuAqIBagK2eDil7EUY_ZFF9B"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:08:37 GMT
+      - Thu, 08 Nov 2018 01:45:15 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:08:38 GMT
+      - Thu, 08 Nov 2018 01:45:16 GMT
       Vary:
       - Origin
       - X-Origin
@@ -241,12 +241,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1asklQRadCZU9iV3iujMFcS5342A0jWVh",
+         "id": "1M4xkQkk0ULdtv2_UQUlZ8-s3-guLv5gN",
          "name": "Folder",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1NPUiJn2frlL98myQd7EiHcXQepB0fTPl"
+          "1zSYV_k67EuAqIBagK2eDil7EUY_ZFF9B"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -262,14 +262,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:38 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:16 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.document","name":"original
-        name","parents":["1asklQRadCZU9iV3iujMFcS5342A0jWVh"]}'
+        name","parents":["1M4xkQkk0ULdtv2_UQUlZ8-s3-guLv5gN"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -278,7 +278,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:08:38 GMT
+      - Thu, 08 Nov 2018 01:45:16 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -295,7 +295,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:08:40 GMT
+      - Thu, 08 Nov 2018 01:45:17 GMT
       Vary:
       - Origin
       - X-Origin
@@ -319,12 +319,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1GNSqVYs4qmLfg-PDFUT1OgRmBCHi6316LEPlZI-ENAg",
+         "id": "1k_qA3pbbDsumsl3RghZXlcSw5KJM5le5mR3iQ95udjA",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1asklQRadCZU9iV3iujMFcS5342A0jWVh"
+          "1M4xkQkk0ULdtv2_UQUlZ8-s3-guLv5gN"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -340,10 +340,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:40 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:17 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1NPUiJn2frlL98myQd7EiHcXQepB0fTPl/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1zSYV_k67EuAqIBagK2eDil7EUY_ZFF9B/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -355,7 +355,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:08:40 GMT
+      - Thu, 08 Nov 2018 01:45:17 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -372,7 +372,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:08:40 GMT
+      - Thu, 08 Nov 2018 01:45:18 GMT
       Vary:
       - Origin
       - X-Origin
@@ -402,13 +402,14 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:41 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:18 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"3 RW6 (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"27 Bistromath
+        (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -417,7 +418,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:08:41 GMT
+      - Thu, 08 Nov 2018 01:45:23 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -434,7 +435,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:08:42 GMT
+      - Thu, 08 Nov 2018 01:45:23 GMT
       Vary:
       - Origin
       - X-Origin
@@ -458,8 +459,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1rceOH-78iGZ59QUbwAZlla86M-Xj5ImF",
-         "name": "3 RW6 (Archive)",
+         "id": "1b_OAh33v9CKwWAPf2wsrJBaLyg1EWfJ3",
+         "name": "27 Bistromath (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -479,10 +480,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:42 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:24 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1rceOH-78iGZ59QUbwAZlla86M-Xj5ImF/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1b_OAh33v9CKwWAPf2wsrJBaLyg1EWfJ3/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -494,7 +495,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:08:42 GMT
+      - Thu, 08 Nov 2018 01:45:24 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -511,7 +512,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:08:43 GMT
+      - Thu, 08 Nov 2018 01:45:24 GMT
       Vary:
       - Origin
       - X-Origin
@@ -541,10 +542,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:43 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:25 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1NPUiJn2frlL98myQd7EiHcXQepB0fTPl?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1zSYV_k67EuAqIBagK2eDil7EUY_ZFF9B?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -556,7 +557,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:08:43 GMT
+      - Thu, 08 Nov 2018 01:45:25 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -567,9 +568,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 06:08:43 GMT
+      - Thu, 08 Nov 2018 01:45:25 GMT
       Date:
-      - Wed, 31 Oct 2018 06:08:43 GMT
+      - Thu, 08 Nov 2018 01:45:25 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -595,8 +596,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1NPUiJn2frlL98myQd7EiHcXQepB0fTPl",
-         "name": "Test @ 2018-10-31 06:08:37 UTC",
+         "id": "1zSYV_k67EuAqIBagK2eDil7EUY_ZFF9B",
+         "name": "Test @ 2018-11-08 01:45:14 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -622,10 +623,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:43 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:25 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1NPUiJn2frlL98myQd7EiHcXQepB0fTPl/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1zSYV_k67EuAqIBagK2eDil7EUY_ZFF9B/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -637,7 +638,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:08:43 GMT
+      - Thu, 08 Nov 2018 01:45:25 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -655,9 +656,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 31 Oct 2018 06:08:44 GMT
+      - Thu, 08 Nov 2018 01:45:26 GMT
       Expires:
-      - Wed, 31 Oct 2018 06:08:44 GMT
+      - Thu, 08 Nov 2018 01:45:26 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -689,10 +690,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:44 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:26 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1NPUiJn2frlL98myQd7EiHcXQepB0fTPl?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271zSYV_k67EuAqIBagK2eDil7EUY_ZFF9B%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -704,7 +705,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:08:44 GMT
+      - Thu, 08 Nov 2018 01:45:26 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -715,305 +716,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 06:08:44 GMT
+      - Thu, 08 Nov 2018 01:45:26 GMT
       Date:
-      - Wed, 31 Oct 2018 06:08:44 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1NPUiJn2frlL98myQd7EiHcXQepB0fTPl",
-         "name": "Test @ 2018-10-31 06:08:37 UTC",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:44 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1NPUiJn2frlL98myQd7EiHcXQepB0fTPl/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 31 Oct 2018 06:08:44 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Wed, 31 Oct 2018 06:08:44 GMT
-      Expires:
-      - Wed, 31 Oct 2018 06:08:44 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:44 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1NPUiJn2frlL98myQd7EiHcXQepB0fTPl?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 31 Oct 2018 06:08:44 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Wed, 31 Oct 2018 06:08:44 GMT
-      Date:
-      - Wed, 31 Oct 2018 06:08:44 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1NPUiJn2frlL98myQd7EiHcXQepB0fTPl",
-         "name": "Test @ 2018-10-31 06:08:37 UTC",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:45 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1NPUiJn2frlL98myQd7EiHcXQepB0fTPl/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 31 Oct 2018 06:08:45 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Wed, 31 Oct 2018 06:08:45 GMT
-      Expires:
-      - Wed, 31 Oct 2018 06:08:45 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:45 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271NPUiJn2frlL98myQd7EiHcXQepB0fTPl%27%20in%20parents
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 31 Oct 2018 06:08:45 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Wed, 31 Oct 2018 06:08:45 GMT
-      Date:
-      - Wed, 31 Oct 2018 06:08:45 GMT
+      - Thu, 08 Nov 2018 01:45:26 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1041,12 +746,12 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1asklQRadCZU9iV3iujMFcS5342A0jWVh",
+           "id": "1M4xkQkk0ULdtv2_UQUlZ8-s3-guLv5gN",
            "name": "Folder",
            "mimeType": "application/vnd.google-apps.folder",
            "trashed": false,
            "parents": [
-            "1NPUiJn2frlL98myQd7EiHcXQepB0fTPl"
+            "1zSYV_k67EuAqIBagK2eDil7EUY_ZFF9B"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -1073,10 +778,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:45 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:26 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1asklQRadCZU9iV3iujMFcS5342A0jWVh/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1M4xkQkk0ULdtv2_UQUlZ8-s3-guLv5gN/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1088,7 +793,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:08:45 GMT
+      - Thu, 08 Nov 2018 01:45:26 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1106,9 +811,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 31 Oct 2018 06:08:46 GMT
+      - Thu, 08 Nov 2018 01:45:26 GMT
       Expires:
-      - Wed, 31 Oct 2018 06:08:46 GMT
+      - Thu, 08 Nov 2018 01:45:26 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1140,10 +845,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:46 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:26 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271asklQRadCZU9iV3iujMFcS5342A0jWVh%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271M4xkQkk0ULdtv2_UQUlZ8-s3-guLv5gN%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -1155,7 +860,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:08:46 GMT
+      - Thu, 08 Nov 2018 01:45:26 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1166,9 +871,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 06:08:46 GMT
+      - Thu, 08 Nov 2018 01:45:27 GMT
       Date:
-      - Wed, 31 Oct 2018 06:08:46 GMT
+      - Thu, 08 Nov 2018 01:45:27 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1196,14 +901,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1GNSqVYs4qmLfg-PDFUT1OgRmBCHi6316LEPlZI-ENAg",
+           "id": "1k_qA3pbbDsumsl3RghZXlcSw5KJM5le5mR3iQ95udjA",
            "name": "original name",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1asklQRadCZU9iV3iujMFcS5342A0jWVh"
+            "1M4xkQkk0ULdtv2_UQUlZ8-s3-guLv5gN"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1GNSqVYs4qmLfg-PDFUT1OgRmBCHi6316LEPlZI-ENAg&v=1&s=AMedNnoAAAAAW9ljDj_pEAtKypFjUSxEKeczYagobAet&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1k_qA3pbbDsumsl3RghZXlcSw5KJM5le5mR3iQ95udjA&v=1&s=AMedNnoAAAAAW-OxV8_ScuMPeaYpWY4NBYpa0s5xNlWp&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -1229,10 +934,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:46 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:27 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1GNSqVYs4qmLfg-PDFUT1OgRmBCHi6316LEPlZI-ENAg/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1k_qA3pbbDsumsl3RghZXlcSw5KJM5le5mR3iQ95udjA/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1244,7 +949,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:08:46 GMT
+      - Thu, 08 Nov 2018 01:45:27 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1255,9 +960,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 06:08:46 GMT
+      - Thu, 08 Nov 2018 01:45:27 GMT
       Date:
-      - Wed, 31 Oct 2018 06:08:46 GMT
+      - Thu, 08 Nov 2018 01:45:27 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1286,13 +991,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-31T06:08:38.988Z"
+         "modifiedTime": "2018-11-08T01:45:16.583Z"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:46 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:27 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1GNSqVYs4qmLfg-PDFUT1OgRmBCHi6316LEPlZI-ENAg&s=AMedNnoAAAAAW9ljDj_pEAtKypFjUSxEKeczYagobAet&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1k_qA3pbbDsumsl3RghZXlcSw5KJM5le5mR3iQ95udjA&s=AMedNnoAAAAAW-OxV8_ScuMPeaYpWY4NBYpa0s5xNlWp&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1304,7 +1009,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:08:46 GMT
+      - Thu, 08 Nov 2018 01:45:27 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1335,7 +1040,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 31 Oct 2018 06:08:47 GMT
+      - Thu, 08 Nov 2018 01:45:28 GMT
       Server:
       - fife
       Content-Length:
@@ -1349,13 +1054,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:47 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:28 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1GNSqVYs4qmLfg-PDFUT1OgRmBCHi6316LEPlZI-ENAg/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1k_qA3pbbDsumsl3RghZXlcSw5KJM5le5mR3iQ95udjA/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"original name","parents":["1rceOH-78iGZ59QUbwAZlla86M-Xj5ImF"]}'
+      string: '{"name":"original name","parents":["1b_OAh33v9CKwWAPf2wsrJBaLyg1EWfJ3"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1364,7 +1069,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:08:47 GMT
+      - Thu, 08 Nov 2018 01:45:28 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1381,7 +1086,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:08:49 GMT
+      - Thu, 08 Nov 2018 01:45:30 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1405,12 +1110,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1wXwL_SskBbyERLcYpN_7tjH6rP7F9i66NnwKssXcFeU",
+         "id": "1e7pN-0mCp8KqHVYwYxk5JrhxPaiGurGMOC6TBX0Eh_8",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1rceOH-78iGZ59QUbwAZlla86M-Xj5ImF"
+          "1b_OAh33v9CKwWAPf2wsrJBaLyg1EWfJ3"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1435,10 +1140,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:49 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:30 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1GNSqVYs4qmLfg-PDFUT1OgRmBCHi6316LEPlZI-ENAg
+    uri: https://www.googleapis.com/drive/v3/files/1k_qA3pbbDsumsl3RghZXlcSw5KJM5le5mR3iQ95udjA
     body:
       encoding: UTF-8
       string: ''
@@ -1450,7 +1155,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:08:49 GMT
+      - Thu, 08 Nov 2018 01:45:30 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1467,7 +1172,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:08:49 GMT
+      - Thu, 08 Nov 2018 01:45:30 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1479,10 +1184,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:49 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:30 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1asklQRadCZU9iV3iujMFcS5342A0jWVh
+    uri: https://www.googleapis.com/drive/v3/files/1M4xkQkk0ULdtv2_UQUlZ8-s3-guLv5gN
     body:
       encoding: UTF-8
       string: ''
@@ -1494,7 +1199,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:08:49 GMT
+      - Thu, 08 Nov 2018 01:45:30 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1511,7 +1216,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:08:50 GMT
+      - Thu, 08 Nov 2018 01:45:31 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1523,10 +1228,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:50 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:31 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1asklQRadCZU9iV3iujMFcS5342A0jWVh?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1M4xkQkk0ULdtv2_UQUlZ8-s3-guLv5gN?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1538,7 +1243,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:08:50 GMT
+      - Thu, 08 Nov 2018 01:45:31 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1556,9 +1261,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 31 Oct 2018 06:08:50 GMT
+      - Thu, 08 Nov 2018 01:45:32 GMT
       Expires:
-      - Wed, 31 Oct 2018 06:08:50 GMT
+      - Thu, 08 Nov 2018 01:45:32 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1582,20 +1287,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1asklQRadCZU9iV3iujMFcS5342A0jWVh.",
+            "message": "File not found: 1M4xkQkk0ULdtv2_UQUlZ8-s3-guLv5gN.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1asklQRadCZU9iV3iujMFcS5342A0jWVh."
+          "message": "File not found: 1M4xkQkk0ULdtv2_UQUlZ8-s3-guLv5gN."
          }
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:50 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:32 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271asklQRadCZU9iV3iujMFcS5342A0jWVh%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271M4xkQkk0ULdtv2_UQUlZ8-s3-guLv5gN%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -1607,7 +1312,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:08:50 GMT
+      - Thu, 08 Nov 2018 01:45:32 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1618,9 +1323,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 06:08:50 GMT
+      - Thu, 08 Nov 2018 01:45:32 GMT
       Date:
-      - Wed, 31 Oct 2018 06:08:50 GMT
+      - Thu, 08 Nov 2018 01:45:32 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1649,10 +1354,10 @@ http_interactions:
          "files": []
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:50 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:32 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1GNSqVYs4qmLfg-PDFUT1OgRmBCHi6316LEPlZI-ENAg?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1k_qA3pbbDsumsl3RghZXlcSw5KJM5le5mR3iQ95udjA?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1664,7 +1369,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:08:50 GMT
+      - Thu, 08 Nov 2018 01:45:32 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1682,9 +1387,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 31 Oct 2018 06:08:51 GMT
+      - Thu, 08 Nov 2018 01:45:32 GMT
       Expires:
-      - Wed, 31 Oct 2018 06:08:51 GMT
+      - Thu, 08 Nov 2018 01:45:32 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1708,23 +1413,23 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1GNSqVYs4qmLfg-PDFUT1OgRmBCHi6316LEPlZI-ENAg.",
+            "message": "File not found: 1k_qA3pbbDsumsl3RghZXlcSw5KJM5le5mR3iQ95udjA.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1GNSqVYs4qmLfg-PDFUT1OgRmBCHi6316LEPlZI-ENAg."
+          "message": "File not found: 1k_qA3pbbDsumsl3RghZXlcSw5KJM5le5mR3iQ95udjA."
          }
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:51 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:32 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1wXwL_SskBbyERLcYpN_7tjH6rP7F9i66NnwKssXcFeU/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1e7pN-0mCp8KqHVYwYxk5JrhxPaiGurGMOC6TBX0Eh_8/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"original name","parents":["1NPUiJn2frlL98myQd7EiHcXQepB0fTPl"]}'
+      string: '{"name":"original name","parents":["1zSYV_k67EuAqIBagK2eDil7EUY_ZFF9B"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1733,7 +1438,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:08:51 GMT
+      - Thu, 08 Nov 2018 01:45:33 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1750,7 +1455,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:08:53 GMT
+      - Thu, 08 Nov 2018 01:45:36 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1774,12 +1479,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "12N8W2LUZ2MaJ6f_AnFP7rrWDXhmGeKrWkVvylzj_rZk",
+         "id": "1RaC7yOXlbzg8v7RuKLpoXZsKDUoeymMKdLcPiKJn54I",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1NPUiJn2frlL98myQd7EiHcXQepB0fTPl"
+          "1zSYV_k67EuAqIBagK2eDil7EUY_ZFF9B"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1804,13 +1509,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:53 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:36 GMT
 - request:
-    method: post
-    uri: https://www.googleapis.com/drive/v3/files/12N8W2LUZ2MaJ6f_AnFP7rrWDXhmGeKrWkVvylzj_rZk/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1RaC7yOXlbzg8v7RuKLpoXZsKDUoeymMKdLcPiKJn54I/revisions/head
     body:
       encoding: UTF-8
-      string: '{"name":"original name","parents":["1rceOH-78iGZ59QUbwAZlla86M-Xj5ImF"]}'
+      string: ''
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1819,24 +1524,22 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:08:53 GMT
-      Content-Type:
-      - application/json
+      - Thu, 08 Nov 2018 01:45:36 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
   response:
     status:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
       Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
+      - Thu, 08 Nov 2018 01:45:36 GMT
       Date:
-      - Wed, 31 Oct 2018 06:08:55 GMT
+      - Thu, 08 Nov 2018 01:45:36 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
       Vary:
       - Origin
       - X-Origin
@@ -1860,12 +1563,74 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1fnPElS2OZ8DiVsvcGXUK6v-yuqsBPWh8aNOEsqRI3b4",
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-11-08T01:45:35.361Z"
+        }
+    http_version: 
+  recorded_at: Thu, 08 Nov 2018 01:45:36 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1RaC7yOXlbzg8v7RuKLpoXZsKDUoeymMKdLcPiKJn54I/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"original name","parents":["1b_OAh33v9CKwWAPf2wsrJBaLyg1EWfJ3"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 08 Nov 2018 01:45:36 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 08 Nov 2018 01:45:38 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1Dlkzbw6Uuye877XBlJeiXjeUSUD-I8ojMHhGVMmD_js",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1rceOH-78iGZ59QUbwAZlla86M-Xj5ImF"
+          "1b_OAh33v9CKwWAPf2wsrJBaLyg1EWfJ3"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1890,10 +1655,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:55 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:38 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1NPUiJn2frlL98myQd7EiHcXQepB0fTPl
+    uri: https://www.googleapis.com/drive/v3/files/1zSYV_k67EuAqIBagK2eDil7EUY_ZFF9B
     body:
       encoding: UTF-8
       string: ''
@@ -1905,7 +1670,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 06:08:55 GMT
+      - Thu, 08 Nov 2018 01:45:38 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1922,7 +1687,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 06:08:56 GMT
+      - Thu, 08 Nov 2018 01:45:38 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1934,5 +1699,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 06:08:56 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:39 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Restore/when_remote_file_is_a_folder/it_restores_the_folder.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Restore/when_remote_file_is_a_folder/it_restores_the_folder.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Wed, 31 Oct 2018 07:24:29 GMT
+      - Thu, 08 Nov 2018 01:45:39 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:24:29 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:39 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Wed, 31 Oct 2018 07:24:29 GMT
+      - Thu, 08 Nov 2018 01:45:40 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:24:29 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:40 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-31
-        07:24:29 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-11-08
+        01:45:40 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:24:29 GMT
+      - Thu, 08 Nov 2018 01:45:40 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:24:30 GMT
+      - Thu, 08 Nov 2018 01:45:40 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1iYsYwq0fAEvojVc_Meva9bhdJm0SpmsE",
-         "name": "Test @ 2018-10-31 07:24:29 UTC",
+         "id": "1AIkjie58BQCHZToCYhtebzovH5QZu-XI",
+         "name": "Test @ 2018-11-08 01:45:40 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,13 +185,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:24:30 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:41 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1iYsYwq0fAEvojVc_Meva9bhdJm0SpmsE"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1AIkjie58BQCHZToCYhtebzovH5QZu-XI"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:24:30 GMT
+      - Thu, 08 Nov 2018 01:45:41 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:24:31 GMT
+      - Thu, 08 Nov 2018 01:45:41 GMT
       Vary:
       - Origin
       - X-Origin
@@ -241,12 +241,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1CMP7nX2s9OhScIjZgLSbAlbO3uSSnQMr",
+         "id": "1I8DngRaGS4fwJ-BWtAVSowu5ifRbsWz7",
          "name": "Folder",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1iYsYwq0fAEvojVc_Meva9bhdJm0SpmsE"
+          "1AIkjie58BQCHZToCYhtebzovH5QZu-XI"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -262,14 +262,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:24:31 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:42 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.document","name":"original
-        name","parents":["1CMP7nX2s9OhScIjZgLSbAlbO3uSSnQMr"]}'
+        name","parents":["1I8DngRaGS4fwJ-BWtAVSowu5ifRbsWz7"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -278,7 +278,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:24:31 GMT
+      - Thu, 08 Nov 2018 01:45:42 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -295,7 +295,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:24:32 GMT
+      - Thu, 08 Nov 2018 01:45:43 GMT
       Vary:
       - Origin
       - X-Origin
@@ -319,12 +319,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1D08l1n7ZZbVvqQlBomx60bT6UROSmhC5HDZE9mbDdmA",
+         "id": "1i-faym3P8H9zmZqlRnB_qhg1WMn2VsXpJ_wX5ZNJwPE",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1CMP7nX2s9OhScIjZgLSbAlbO3uSSnQMr"
+          "1I8DngRaGS4fwJ-BWtAVSowu5ifRbsWz7"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -340,10 +340,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:24:32 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:43 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1iYsYwq0fAEvojVc_Meva9bhdJm0SpmsE/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1AIkjie58BQCHZToCYhtebzovH5QZu-XI/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -355,7 +355,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:24:32 GMT
+      - Thu, 08 Nov 2018 01:45:43 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -372,7 +372,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:24:33 GMT
+      - Thu, 08 Nov 2018 01:45:44 GMT
       Vary:
       - Origin
       - X-Origin
@@ -402,14 +402,14 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:24:33 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:44 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"4 Starship
-        Titanic (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"28 Bistromath
+        (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -418,7 +418,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:24:38 GMT
+      - Thu, 08 Nov 2018 01:45:49 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -435,7 +435,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:24:39 GMT
+      - Thu, 08 Nov 2018 01:45:50 GMT
       Vary:
       - Origin
       - X-Origin
@@ -459,8 +459,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "14vmRy5gIx9TQfAGn8YbHdLG9pa_DDz4p",
-         "name": "4 Starship Titanic (Archive)",
+         "id": "16a5FGv8c0ILPZ_TPKS07q9jRG-nzkQ5b",
+         "name": "28 Bistromath (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -480,10 +480,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:24:39 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:50 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/14vmRy5gIx9TQfAGn8YbHdLG9pa_DDz4p/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/16a5FGv8c0ILPZ_TPKS07q9jRG-nzkQ5b/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -495,7 +495,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:24:39 GMT
+      - Thu, 08 Nov 2018 01:45:50 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -512,7 +512,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:24:40 GMT
+      - Thu, 08 Nov 2018 01:45:50 GMT
       Vary:
       - Origin
       - X-Origin
@@ -542,10 +542,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:24:40 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:51 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1iYsYwq0fAEvojVc_Meva9bhdJm0SpmsE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1AIkjie58BQCHZToCYhtebzovH5QZu-XI?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -557,7 +557,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:24:40 GMT
+      - Thu, 08 Nov 2018 01:45:51 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -568,9 +568,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 07:24:40 GMT
+      - Thu, 08 Nov 2018 01:45:51 GMT
       Date:
-      - Wed, 31 Oct 2018 07:24:40 GMT
+      - Thu, 08 Nov 2018 01:45:51 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -596,8 +596,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1iYsYwq0fAEvojVc_Meva9bhdJm0SpmsE",
-         "name": "Test @ 2018-10-31 07:24:29 UTC",
+         "id": "1AIkjie58BQCHZToCYhtebzovH5QZu-XI",
+         "name": "Test @ 2018-11-08 01:45:40 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -623,10 +623,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:24:40 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:51 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1iYsYwq0fAEvojVc_Meva9bhdJm0SpmsE/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1AIkjie58BQCHZToCYhtebzovH5QZu-XI/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -638,7 +638,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:24:40 GMT
+      - Thu, 08 Nov 2018 01:45:51 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -656,9 +656,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 31 Oct 2018 07:24:41 GMT
+      - Thu, 08 Nov 2018 01:45:51 GMT
       Expires:
-      - Wed, 31 Oct 2018 07:24:41 GMT
+      - Thu, 08 Nov 2018 01:45:51 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -690,10 +690,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:24:41 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:51 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1iYsYwq0fAEvojVc_Meva9bhdJm0SpmsE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271AIkjie58BQCHZToCYhtebzovH5QZu-XI%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -705,7 +705,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:24:41 GMT
+      - Thu, 08 Nov 2018 01:45:51 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -716,305 +716,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 07:24:41 GMT
+      - Thu, 08 Nov 2018 01:45:51 GMT
       Date:
-      - Wed, 31 Oct 2018 07:24:41 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1iYsYwq0fAEvojVc_Meva9bhdJm0SpmsE",
-         "name": "Test @ 2018-10-31 07:24:29 UTC",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:24:41 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1iYsYwq0fAEvojVc_Meva9bhdJm0SpmsE/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 31 Oct 2018 07:24:41 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Wed, 31 Oct 2018 07:24:41 GMT
-      Expires:
-      - Wed, 31 Oct 2018 07:24:41 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:24:41 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1iYsYwq0fAEvojVc_Meva9bhdJm0SpmsE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 31 Oct 2018 07:24:41 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Wed, 31 Oct 2018 07:24:41 GMT
-      Date:
-      - Wed, 31 Oct 2018 07:24:41 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1iYsYwq0fAEvojVc_Meva9bhdJm0SpmsE",
-         "name": "Test @ 2018-10-31 07:24:29 UTC",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:24:41 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1iYsYwq0fAEvojVc_Meva9bhdJm0SpmsE/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 31 Oct 2018 07:24:41 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Wed, 31 Oct 2018 07:24:41 GMT
-      Expires:
-      - Wed, 31 Oct 2018 07:24:41 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:24:41 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271iYsYwq0fAEvojVc_Meva9bhdJm0SpmsE%27%20in%20parents
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 31 Oct 2018 07:24:41 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Wed, 31 Oct 2018 07:24:41 GMT
-      Date:
-      - Wed, 31 Oct 2018 07:24:41 GMT
+      - Thu, 08 Nov 2018 01:45:51 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1042,12 +746,12 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1CMP7nX2s9OhScIjZgLSbAlbO3uSSnQMr",
+           "id": "1I8DngRaGS4fwJ-BWtAVSowu5ifRbsWz7",
            "name": "Folder",
            "mimeType": "application/vnd.google-apps.folder",
            "trashed": false,
            "parents": [
-            "1iYsYwq0fAEvojVc_Meva9bhdJm0SpmsE"
+            "1AIkjie58BQCHZToCYhtebzovH5QZu-XI"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -1074,10 +778,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:24:41 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:51 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1CMP7nX2s9OhScIjZgLSbAlbO3uSSnQMr/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1I8DngRaGS4fwJ-BWtAVSowu5ifRbsWz7/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1089,7 +793,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:24:41 GMT
+      - Thu, 08 Nov 2018 01:45:51 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1107,9 +811,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 31 Oct 2018 07:24:41 GMT
+      - Thu, 08 Nov 2018 01:45:52 GMT
       Expires:
-      - Wed, 31 Oct 2018 07:24:41 GMT
+      - Thu, 08 Nov 2018 01:45:52 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1141,10 +845,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:24:41 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:52 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271CMP7nX2s9OhScIjZgLSbAlbO3uSSnQMr%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271I8DngRaGS4fwJ-BWtAVSowu5ifRbsWz7%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -1156,7 +860,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:24:42 GMT
+      - Thu, 08 Nov 2018 01:45:52 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1167,9 +871,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 07:24:42 GMT
+      - Thu, 08 Nov 2018 01:45:52 GMT
       Date:
-      - Wed, 31 Oct 2018 07:24:42 GMT
+      - Thu, 08 Nov 2018 01:45:52 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1197,14 +901,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1D08l1n7ZZbVvqQlBomx60bT6UROSmhC5HDZE9mbDdmA",
+           "id": "1i-faym3P8H9zmZqlRnB_qhg1WMn2VsXpJ_wX5ZNJwPE",
            "name": "original name",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1CMP7nX2s9OhScIjZgLSbAlbO3uSSnQMr"
+            "1I8DngRaGS4fwJ-BWtAVSowu5ifRbsWz7"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1D08l1n7ZZbVvqQlBomx60bT6UROSmhC5HDZE9mbDdmA&v=1&s=AMedNnoAAAAAW9l02hxBrEVv0P-f5XaXbWikF9zBCkqI&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1i-faym3P8H9zmZqlRnB_qhg1WMn2VsXpJ_wX5ZNJwPE&v=1&s=AMedNnoAAAAAW-OxcEIpaBoG0xlBJGL7PUa6-5QysUWA&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -1230,10 +934,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:24:42 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:52 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1D08l1n7ZZbVvqQlBomx60bT6UROSmhC5HDZE9mbDdmA/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1i-faym3P8H9zmZqlRnB_qhg1WMn2VsXpJ_wX5ZNJwPE/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1245,7 +949,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:24:42 GMT
+      - Thu, 08 Nov 2018 01:45:52 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1256,9 +960,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 07:24:42 GMT
+      - Thu, 08 Nov 2018 01:45:52 GMT
       Date:
-      - Wed, 31 Oct 2018 07:24:42 GMT
+      - Thu, 08 Nov 2018 01:45:52 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1287,13 +991,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-31T07:24:31.520Z"
+         "modifiedTime": "2018-11-08T01:45:42.331Z"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:24:42 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:52 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1D08l1n7ZZbVvqQlBomx60bT6UROSmhC5HDZE9mbDdmA&s=AMedNnoAAAAAW9l02hxBrEVv0P-f5XaXbWikF9zBCkqI&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1i-faym3P8H9zmZqlRnB_qhg1WMn2VsXpJ_wX5ZNJwPE&s=AMedNnoAAAAAW-OxcEIpaBoG0xlBJGL7PUa6-5QysUWA&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1305,7 +1009,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:24:42 GMT
+      - Thu, 08 Nov 2018 01:45:52 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1336,7 +1040,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 31 Oct 2018 07:24:42 GMT
+      - Thu, 08 Nov 2018 01:45:53 GMT
       Server:
       - fife
       Content-Length:
@@ -1350,13 +1054,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:24:42 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:53 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1D08l1n7ZZbVvqQlBomx60bT6UROSmhC5HDZE9mbDdmA/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1i-faym3P8H9zmZqlRnB_qhg1WMn2VsXpJ_wX5ZNJwPE/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"original name","parents":["14vmRy5gIx9TQfAGn8YbHdLG9pa_DDz4p"]}'
+      string: '{"name":"original name","parents":["16a5FGv8c0ILPZ_TPKS07q9jRG-nzkQ5b"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1365,7 +1069,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:24:42 GMT
+      - Thu, 08 Nov 2018 01:45:53 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1382,7 +1086,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:24:44 GMT
+      - Thu, 08 Nov 2018 01:45:54 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1406,12 +1110,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1slOCjQmIb-J8tfYcUa__ivTSsSSGz5MKr2ktTAvR2PU",
+         "id": "1uR55SxqHsP-tm3EJj9bf6pRLKiBwQBIW1ZUJO1U64cE",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "14vmRy5gIx9TQfAGn8YbHdLG9pa_DDz4p"
+          "16a5FGv8c0ILPZ_TPKS07q9jRG-nzkQ5b"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1436,10 +1140,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:24:44 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:54 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1D08l1n7ZZbVvqQlBomx60bT6UROSmhC5HDZE9mbDdmA
+    uri: https://www.googleapis.com/drive/v3/files/1i-faym3P8H9zmZqlRnB_qhg1WMn2VsXpJ_wX5ZNJwPE
     body:
       encoding: UTF-8
       string: ''
@@ -1451,7 +1155,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:24:44 GMT
+      - Thu, 08 Nov 2018 01:45:55 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1468,7 +1172,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:24:45 GMT
+      - Thu, 08 Nov 2018 01:45:55 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1480,10 +1184,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:24:45 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:55 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1D08l1n7ZZbVvqQlBomx60bT6UROSmhC5HDZE9mbDdmA?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1i-faym3P8H9zmZqlRnB_qhg1WMn2VsXpJ_wX5ZNJwPE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1495,7 +1199,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:24:45 GMT
+      - Thu, 08 Nov 2018 01:45:55 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1513,9 +1217,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 31 Oct 2018 07:24:45 GMT
+      - Thu, 08 Nov 2018 01:45:55 GMT
       Expires:
-      - Wed, 31 Oct 2018 07:24:45 GMT
+      - Thu, 08 Nov 2018 01:45:55 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1539,23 +1243,23 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1D08l1n7ZZbVvqQlBomx60bT6UROSmhC5HDZE9mbDdmA.",
+            "message": "File not found: 1i-faym3P8H9zmZqlRnB_qhg1WMn2VsXpJ_wX5ZNJwPE.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1D08l1n7ZZbVvqQlBomx60bT6UROSmhC5HDZE9mbDdmA."
+          "message": "File not found: 1i-faym3P8H9zmZqlRnB_qhg1WMn2VsXpJ_wX5ZNJwPE."
          }
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:24:45 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:55 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1slOCjQmIb-J8tfYcUa__ivTSsSSGz5MKr2ktTAvR2PU/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1uR55SxqHsP-tm3EJj9bf6pRLKiBwQBIW1ZUJO1U64cE/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"original name","parents":["1CMP7nX2s9OhScIjZgLSbAlbO3uSSnQMr"]}'
+      string: '{"name":"original name","parents":["1I8DngRaGS4fwJ-BWtAVSowu5ifRbsWz7"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1564,7 +1268,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:24:46 GMT
+      - Thu, 08 Nov 2018 01:45:56 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1581,7 +1285,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:24:48 GMT
+      - Thu, 08 Nov 2018 01:45:58 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1605,12 +1309,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1nR17BpBH-qTupgt3jxVNI7nsy9etBVUxjTeDGXBQOLQ",
+         "id": "1YMutuFYPBFuM8fScptqAMryq9KbL2BQgarWBfb57rfg",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1CMP7nX2s9OhScIjZgLSbAlbO3uSSnQMr"
+          "1I8DngRaGS4fwJ-BWtAVSowu5ifRbsWz7"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1635,13 +1339,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:24:48 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:58 GMT
 - request:
-    method: post
-    uri: https://www.googleapis.com/drive/v3/files/1nR17BpBH-qTupgt3jxVNI7nsy9etBVUxjTeDGXBQOLQ/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1YMutuFYPBFuM8fScptqAMryq9KbL2BQgarWBfb57rfg/revisions/head
     body:
       encoding: UTF-8
-      string: '{"name":"original name","parents":["14vmRy5gIx9TQfAGn8YbHdLG9pa_DDz4p"]}'
+      string: ''
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1650,24 +1354,22 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:24:48 GMT
-      Content-Type:
-      - application/json
+      - Thu, 08 Nov 2018 01:45:58 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
   response:
     status:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
       Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
+      - Thu, 08 Nov 2018 01:45:59 GMT
       Date:
-      - Wed, 31 Oct 2018 07:24:50 GMT
+      - Thu, 08 Nov 2018 01:45:59 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
       Vary:
       - Origin
       - X-Origin
@@ -1691,40 +1393,16 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1c2t0Rgml-Fqd88y5hDHG3YsxCXkuQYp3NeDlB3HAmv0",
-         "name": "original name",
+         "kind": "drive#revision",
+         "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "14vmRy5gIx9TQfAGn8YbHdLG9pa_DDz4p"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
+         "modifiedTime": "2018-11-08T01:45:57.522Z"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:24:50 GMT
+  recorded_at: Thu, 08 Nov 2018 01:45:59 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1iYsYwq0fAEvojVc_Meva9bhdJm0SpmsE
+    uri: https://www.googleapis.com/drive/v3/files/1AIkjie58BQCHZToCYhtebzovH5QZu-XI
     body:
       encoding: UTF-8
       string: ''
@@ -1736,7 +1414,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:24:51 GMT
+      - Thu, 08 Nov 2018 01:45:59 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1753,7 +1431,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:24:51 GMT
+      - Thu, 08 Nov 2018 01:45:59 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1765,5 +1443,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:24:51 GMT
+  recorded_at: Thu, 08 Nov 2018 01:46:00 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Revision_Restore/restores_a_prior_revision.yml
+++ b/spec/support/fixtures/vcr_cassettes/Revision_Restore/restores_a_prior_revision.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Wed, 07 Nov 2018 06:12:30 GMT
+      - Thu, 08 Nov 2018 01:32:58 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:12:30 GMT
+  recorded_at: Thu, 08 Nov 2018 01:32:58 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Wed, 07 Nov 2018 06:12:30 GMT
+      - Thu, 08 Nov 2018 01:32:59 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:12:30 GMT
+  recorded_at: Thu, 08 Nov 2018 01:32:59 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-11-07
-        06:12:30 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-11-08
+        01:32:59 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:12:30 GMT
+      - Thu, 08 Nov 2018 01:32:59 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:12:30 GMT
+      - Thu, 08 Nov 2018 01:33:00 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ",
-         "name": "Test @ 2018-11-07 06:12:30 UTC",
+         "id": "1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1",
+         "name": "Test @ 2018-11-08 01:32:59 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,13 +185,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:12:31 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:01 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Fol 1","parents":["1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Fol 1","parents":["1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:12:31 GMT
+      - Thu, 08 Nov 2018 01:33:01 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:12:31 GMT
+      - Thu, 08 Nov 2018 01:33:01 GMT
       Vary:
       - Origin
       - X-Origin
@@ -241,12 +241,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY",
+         "id": "1pJKmPVsDi4sj27umEonP4hisTAshnwWs",
          "name": "Fol 1",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ"
+          "1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -262,13 +262,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:12:31 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:01 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Fol 2","parents":["1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Fol 2","parents":["1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -277,7 +277,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:12:31 GMT
+      - Thu, 08 Nov 2018 01:33:01 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -294,7 +294,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:12:32 GMT
+      - Thu, 08 Nov 2018 01:33:05 GMT
       Vary:
       - Origin
       - X-Origin
@@ -318,12 +318,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5",
+         "id": "1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT",
          "name": "Fol 2",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ"
+          "1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -339,13 +339,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:12:32 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:05 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Fol 3","parents":["1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Fol 3","parents":["1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -354,7 +354,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:12:32 GMT
+      - Thu, 08 Nov 2018 01:33:05 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -371,7 +371,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:12:52 GMT
+      - Thu, 08 Nov 2018 01:33:06 GMT
       Vary:
       - Origin
       - X-Origin
@@ -395,12 +395,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1RlbBN3mWAJGpwNFwtVju1z6bEm0XerIz",
+         "id": "19Qnn6jjVnzD-lh8HvNEQFktFBF2qQyBn",
          "name": "Fol 3",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ"
+          "1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -416,13 +416,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:12:52 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:06 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File A","parents":["1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File A","parents":["1pJKmPVsDi4sj27umEonP4hisTAshnwWs"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -431,7 +431,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:12:52 GMT
+      - Thu, 08 Nov 2018 01:33:06 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -448,7 +448,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:12:54 GMT
+      - Thu, 08 Nov 2018 01:33:11 GMT
       Vary:
       - Origin
       - X-Origin
@@ -472,12 +472,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1lulyWfmP9ai1nkAmJBi76Bd0mu63j4LcA-HBfL3xqP4",
+         "id": "1oN7GehbKvGZe-kpoCdFQXl3DroCoL-n6NYQu5szrGd0",
          "name": "File A",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY"
+          "1pJKmPVsDi4sj27umEonP4hisTAshnwWs"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -493,10 +493,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:12:54 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:11 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/upload/drive/v3/files/1lulyWfmP9ai1nkAmJBi76Bd0mu63j4LcA-HBfL3xqP4
+    uri: https://www.googleapis.com/upload/drive/v3/files/1oN7GehbKvGZe-kpoCdFQXl3DroCoL-n6NYQu5szrGd0
     body:
       encoding: UTF-8
       string: ''
@@ -508,7 +508,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:12:54 GMT
+      - Thu, 08 Nov 2018 01:33:11 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       X-Goog-Upload-Protocol:
@@ -527,22 +527,22 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2UqOkEsQed6mxMhUY8RbGzYp5h6ntlnjSB99hDnqauDgU8gA1yL9h7EG_ubmShPX6MbFQbG46mmKPPOu4GRsVBX1RTp0Sg
+      - AEnB2UoxcDfGF8xcW1quCat6grVWENDYjrSzcc41i9r5DJS6ih7jb-igo8mPC5qvScBVVMlYpqM_sTJmCInLSHwGelojacCFBg
       X-Goog-Upload-Status:
       - active
       X-Goog-Upload-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1lulyWfmP9ai1nkAmJBi76Bd0mu63j4LcA-HBfL3xqP4?upload_id=AEnB2UqOkEsQed6mxMhUY8RbGzYp5h6ntlnjSB99hDnqauDgU8gA1yL9h7EG_ubmShPX6MbFQbG46mmKPPOu4GRsVBX1RTp0Sg&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1oN7GehbKvGZe-kpoCdFQXl3DroCoL-n6NYQu5szrGd0?upload_id=AEnB2UoxcDfGF8xcW1quCat6grVWENDYjrSzcc41i9r5DJS6ih7jb-igo8mPC5qvScBVVMlYpqM_sTJmCInLSHwGelojacCFBg&upload_protocol=resumable
       X-Goog-Upload-Control-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1lulyWfmP9ai1nkAmJBi76Bd0mu63j4LcA-HBfL3xqP4?upload_id=AEnB2UqOkEsQed6mxMhUY8RbGzYp5h6ntlnjSB99hDnqauDgU8gA1yL9h7EG_ubmShPX6MbFQbG46mmKPPOu4GRsVBX1RTp0Sg&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1oN7GehbKvGZe-kpoCdFQXl3DroCoL-n6NYQu5szrGd0?upload_id=AEnB2UoxcDfGF8xcW1quCat6grVWENDYjrSzcc41i9r5DJS6ih7jb-igo8mPC5qvScBVVMlYpqM_sTJmCInLSHwGelojacCFBg&upload_protocol=resumable
       X-Goog-Upload-Chunk-Granularity:
       - '262144'
       X-Goog-Upload-Header-Vary:
       - Origin
       - X-Origin
       X-Goog-Upload-Header-X-Google-Backends:
-      - iopn3:4399
+      - oiau135:4307
       X-Goog-Upload-Header-X-Google-Session-Info:
-      - CKeBxoimHBoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x4TkJtaWxHUTlNS2p6QjQ0OW9EdUFwLXNuUWktcVVCYk1UeVhaRVVaT1d4LXYtX3VZcWFQUl9jS1RRSEF3TkRTcUkxR2VGd3Y2WWYzMnVSSTd0bkRZR2YxdGRXdUVWT3RPUDRuWUJNTkktUGtMcGFLUk4xYWI5b2g4QlFBMAQ6DTEvSWFuUWZrd3Q0TX4
+      - CKeBxoimHBoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x4T0J1OXZkNERSa2VlZkxoclNLOW9TQUNkU0pORGp3cTN3XzhhMUtrSTQzVWE2djlQS3BDaDJiZG53SUx3Nk5HVTBfNmhFWGMtaHpycEtWRHl3ZXA5V29LNjV6RUwzZFJ1SlowX01scGYtNTNHcU9KTlRBZEMwU1lRdFlRMAQ6DTEvSWFuUWZrd3Q0TX4
       X-Goog-Upload-Header-Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       X-Goog-Upload-Header-Pragma:
@@ -550,11 +550,11 @@ http_interactions:
       X-Goog-Upload-Header-Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       X-Goog-Upload-Header-Date:
-      - Wed, 07 Nov 2018 06:12:54 GMT
+      - Thu, 08 Nov 2018 01:33:11 GMT
       Content-Length:
       - '0'
       Date:
-      - Wed, 07 Nov 2018 06:12:54 GMT
+      - Thu, 08 Nov 2018 01:33:12 GMT
       Server:
       - UploadServer
       Content-Type:
@@ -565,10 +565,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:12:54 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:12 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/upload/drive/v3/files/1lulyWfmP9ai1nkAmJBi76Bd0mu63j4LcA-HBfL3xqP4?upload_id=AEnB2UqOkEsQed6mxMhUY8RbGzYp5h6ntlnjSB99hDnqauDgU8gA1yL9h7EG_ubmShPX6MbFQbG46mmKPPOu4GRsVBX1RTp0Sg&upload_protocol=resumable
+    uri: https://www.googleapis.com/upload/drive/v3/files/1oN7GehbKvGZe-kpoCdFQXl3DroCoL-n6NYQu5szrGd0?upload_id=AEnB2UoxcDfGF8xcW1quCat6grVWENDYjrSzcc41i9r5DJS6ih7jb-igo8mPC5qvScBVVMlYpqM_sTJmCInLSHwGelojacCFBg&upload_protocol=resumable
     body:
       encoding: UTF-8
       string: awesome
@@ -580,7 +580,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:12:54 GMT
+      - Thu, 08 Nov 2018 01:33:12 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       X-Goog-Upload-Command:
@@ -595,7 +595,7 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2UqOkEsQed6mxMhUY8RbGzYp5h6ntlnjSB99hDnqauDgU8gA1yL9h7EG_ubmShPX6MbFQbG46mmKPPOu4GRsVBX1RTp0Sg
+      - AEnB2UoxcDfGF8xcW1quCat6grVWENDYjrSzcc41i9r5DJS6ih7jb-igo8mPC5qvScBVVMlYpqM_sTJmCInLSHwGelojacCFBg
       X-Goog-Upload-Status:
       - final
       Vary:
@@ -610,7 +610,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:12:55 GMT
+      - Thu, 08 Nov 2018 01:33:13 GMT
       Content-Length:
       - '153'
       Server:
@@ -622,18 +622,18 @@ http_interactions:
       string: |
         {
          "kind": "drive#file",
-         "id": "1lulyWfmP9ai1nkAmJBi76Bd0mu63j4LcA-HBfL3xqP4",
+         "id": "1oN7GehbKvGZe-kpoCdFQXl3DroCoL-n6NYQu5szrGd0",
          "name": "File A",
          "mimeType": "application/vnd.google-apps.document"
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:12:55 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:13 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File B","parents":["1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File B","parents":["1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -642,7 +642,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:12:55 GMT
+      - Thu, 08 Nov 2018 01:33:13 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -659,7 +659,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:12:57 GMT
+      - Thu, 08 Nov 2018 01:33:14 GMT
       Vary:
       - Origin
       - X-Origin
@@ -683,12 +683,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1lEs97BZenN-NQZBt0Mp7xnib6RuEmHFCVBiVDA7lalA",
+         "id": "1BGrUK7SgNwPfKGKpUvAey86uF2-ayBpKHzUze3IN3k0",
          "name": "File B",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5"
+          "1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -704,10 +704,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:12:57 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:14 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/upload/drive/v3/files/1lEs97BZenN-NQZBt0Mp7xnib6RuEmHFCVBiVDA7lalA
+    uri: https://www.googleapis.com/upload/drive/v3/files/1BGrUK7SgNwPfKGKpUvAey86uF2-ayBpKHzUze3IN3k0
     body:
       encoding: UTF-8
       string: ''
@@ -719,7 +719,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:12:57 GMT
+      - Thu, 08 Nov 2018 01:33:14 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       X-Goog-Upload-Protocol:
@@ -738,22 +738,22 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2Uo5OgYl2EH405sn4ocRYinmYtqjECxzSdA3OspPP-EFnlGFm0zCkDlOyj5XozoL1XKd3N1y3YUg4_oAfWIDW8mCfQzJ3g
+      - AEnB2UqswnhRwPYx688WixFruZzZozqXgJoLQ-0S-xCQIjcvrvtLAESmf9fYrJlLE25yOh73uLt-0mA6U7CiZIegYIZr_ht78g
       X-Goog-Upload-Status:
       - active
       X-Goog-Upload-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1lEs97BZenN-NQZBt0Mp7xnib6RuEmHFCVBiVDA7lalA?upload_id=AEnB2Uo5OgYl2EH405sn4ocRYinmYtqjECxzSdA3OspPP-EFnlGFm0zCkDlOyj5XozoL1XKd3N1y3YUg4_oAfWIDW8mCfQzJ3g&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1BGrUK7SgNwPfKGKpUvAey86uF2-ayBpKHzUze3IN3k0?upload_id=AEnB2UqswnhRwPYx688WixFruZzZozqXgJoLQ-0S-xCQIjcvrvtLAESmf9fYrJlLE25yOh73uLt-0mA6U7CiZIegYIZr_ht78g&upload_protocol=resumable
       X-Goog-Upload-Control-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1lEs97BZenN-NQZBt0Mp7xnib6RuEmHFCVBiVDA7lalA?upload_id=AEnB2Uo5OgYl2EH405sn4ocRYinmYtqjECxzSdA3OspPP-EFnlGFm0zCkDlOyj5XozoL1XKd3N1y3YUg4_oAfWIDW8mCfQzJ3g&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1BGrUK7SgNwPfKGKpUvAey86uF2-ayBpKHzUze3IN3k0?upload_id=AEnB2UqswnhRwPYx688WixFruZzZozqXgJoLQ-0S-xCQIjcvrvtLAESmf9fYrJlLE25yOh73uLt-0mA6U7CiZIegYIZr_ht78g&upload_protocol=resumable
       X-Goog-Upload-Chunk-Granularity:
       - '262144'
       X-Goog-Upload-Header-Vary:
       - Origin
       - X-Origin
       X-Goog-Upload-Header-X-Google-Backends:
-      - iopn3:4399
+      - oibk201:4234
       X-Goog-Upload-Header-X-Google-Session-Info:
-      - CKeBxoimHBoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x4TkJtaWxHUTlNS2p6QjQ0OW9EdUFwLXNuUWktcVVCYk1UeVhaRVVaT1d4LXYtX3VZcWFQUl9jS1RRSEF3TkRTcUkxR2VGd3Y2WWYzMnVSSTd0bkRZR2YxdGRXdUVWT3RPUDRuWUJNTkktUGtMcGFLUk4xYWI5b2g4QlFBMAQ6DTEvSWFuUWZrd3Q0TX4
+      - CKeBxoimHBoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x4T0J1OXZkNERSa2VlZkxoclNLOW9TQUNkU0pORGp3cTN3XzhhMUtrSTQzVWE2djlQS3BDaDJiZG53SUx3Nk5HVTBfNmhFWGMtaHpycEtWRHl3ZXA5V29LNjV6RUwzZFJ1SlowX01scGYtNTNHcU9KTlRBZEMwU1lRdFlRMAQ6DTEvSWFuUWZrd3Q0TX4
       X-Goog-Upload-Header-Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       X-Goog-Upload-Header-Pragma:
@@ -761,11 +761,11 @@ http_interactions:
       X-Goog-Upload-Header-Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       X-Goog-Upload-Header-Date:
-      - Wed, 07 Nov 2018 06:12:57 GMT
+      - Thu, 08 Nov 2018 01:33:15 GMT
       Content-Length:
       - '0'
       Date:
-      - Wed, 07 Nov 2018 06:12:57 GMT
+      - Thu, 08 Nov 2018 01:33:15 GMT
       Server:
       - UploadServer
       Content-Type:
@@ -776,10 +776,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:12:57 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:15 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/upload/drive/v3/files/1lEs97BZenN-NQZBt0Mp7xnib6RuEmHFCVBiVDA7lalA?upload_id=AEnB2Uo5OgYl2EH405sn4ocRYinmYtqjECxzSdA3OspPP-EFnlGFm0zCkDlOyj5XozoL1XKd3N1y3YUg4_oAfWIDW8mCfQzJ3g&upload_protocol=resumable
+    uri: https://www.googleapis.com/upload/drive/v3/files/1BGrUK7SgNwPfKGKpUvAey86uF2-ayBpKHzUze3IN3k0?upload_id=AEnB2UqswnhRwPYx688WixFruZzZozqXgJoLQ-0S-xCQIjcvrvtLAESmf9fYrJlLE25yOh73uLt-0mA6U7CiZIegYIZr_ht78g&upload_protocol=resumable
     body:
       encoding: UTF-8
       string: great
@@ -791,7 +791,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:12:57 GMT
+      - Thu, 08 Nov 2018 01:33:15 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       X-Goog-Upload-Command:
@@ -806,7 +806,7 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2Uo5OgYl2EH405sn4ocRYinmYtqjECxzSdA3OspPP-EFnlGFm0zCkDlOyj5XozoL1XKd3N1y3YUg4_oAfWIDW8mCfQzJ3g
+      - AEnB2UqswnhRwPYx688WixFruZzZozqXgJoLQ-0S-xCQIjcvrvtLAESmf9fYrJlLE25yOh73uLt-0mA6U7CiZIegYIZr_ht78g
       X-Goog-Upload-Status:
       - final
       Vary:
@@ -821,7 +821,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:12:58 GMT
+      - Thu, 08 Nov 2018 01:33:16 GMT
       Content-Length:
       - '153'
       Server:
@@ -833,18 +833,18 @@ http_interactions:
       string: |
         {
          "kind": "drive#file",
-         "id": "1lEs97BZenN-NQZBt0Mp7xnib6RuEmHFCVBiVDA7lalA",
+         "id": "1BGrUK7SgNwPfKGKpUvAey86uF2-ayBpKHzUze3IN3k0",
          "name": "File B",
          "mimeType": "application/vnd.google-apps.document"
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:12:58 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:17 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File C","parents":["1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File C","parents":["1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -853,7 +853,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:12:58 GMT
+      - Thu, 08 Nov 2018 01:33:17 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -870,7 +870,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:00 GMT
+      - Thu, 08 Nov 2018 01:33:20 GMT
       Vary:
       - Origin
       - X-Origin
@@ -894,12 +894,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1ebr5Wp_oSjfqsNT_AYkPlsIkTZ2Hmg1TtqTeCN_Btiw",
+         "id": "1h8hoCjL1fXLkPu0drS4FIJLZSUEXKj7o_GerEVkoUQ4",
          "name": "File C",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5"
+          "1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -915,13 +915,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:01 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:20 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File D","parents":["1RlbBN3mWAJGpwNFwtVju1z6bEm0XerIz"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File D","parents":["19Qnn6jjVnzD-lh8HvNEQFktFBF2qQyBn"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -930,7 +930,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:01 GMT
+      - Thu, 08 Nov 2018 01:33:20 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -947,7 +947,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:02 GMT
+      - Thu, 08 Nov 2018 01:33:22 GMT
       Vary:
       - Origin
       - X-Origin
@@ -971,12 +971,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "12N0OSpQ1HUwztJiCfZagE3Mp9fB7GTeBp8SampYRsuM",
+         "id": "1ShrevNfMsRy3Go6JQf6ipqsWdEpb7St406n0ZZHkTo0",
          "name": "File D",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1RlbBN3mWAJGpwNFwtVju1z6bEm0XerIz"
+          "19Qnn6jjVnzD-lh8HvNEQFktFBF2qQyBn"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -992,10 +992,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:02 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:22 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -1007,7 +1007,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:02 GMT
+      - Thu, 08 Nov 2018 01:33:22 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1024,7 +1024,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:03 GMT
+      - Thu, 08 Nov 2018 01:33:26 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1054,14 +1054,14 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:03 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:27 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"34 Vogon Constructor
-        Fleet (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"1 Golgafrinchan
+        Ark Fleet Ship B (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1070,7 +1070,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:08 GMT
+      - Thu, 08 Nov 2018 01:33:32 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1087,7 +1087,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:09 GMT
+      - Thu, 08 Nov 2018 01:33:33 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1111,8 +1111,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1Fbo5u06J4KOCs7nhXvcTwEZ1OdKW4j7W",
-         "name": "34 Vogon Constructor Fleet (Archive)",
+         "id": "1I3SZFNG9B2x60Wzc6YQe8zDdwJIQxeP5",
+         "name": "1 Golgafrinchan Ark Fleet Ship B (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -1132,10 +1132,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:09 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:33 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1Fbo5u06J4KOCs7nhXvcTwEZ1OdKW4j7W/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1I3SZFNG9B2x60Wzc6YQe8zDdwJIQxeP5/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -1147,7 +1147,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:09 GMT
+      - Thu, 08 Nov 2018 01:33:33 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1164,7 +1164,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:11 GMT
+      - Thu, 08 Nov 2018 01:33:34 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1194,10 +1194,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:11 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:35 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1209,7 +1209,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:11 GMT
+      - Thu, 08 Nov 2018 01:33:35 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1220,9 +1220,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:13:12 GMT
+      - Thu, 08 Nov 2018 01:33:35 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:12 GMT
+      - Thu, 08 Nov 2018 01:33:35 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1248,8 +1248,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ",
-         "name": "Test @ 2018-11-07 06:12:30 UTC",
+         "id": "1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1",
+         "name": "Test @ 2018-11-08 01:32:59 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -1275,10 +1275,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:12 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:35 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1290,7 +1290,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:12 GMT
+      - Thu, 08 Nov 2018 01:33:35 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1308,9 +1308,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 07 Nov 2018 06:13:12 GMT
+      - Thu, 08 Nov 2018 01:33:35 GMT
       Expires:
-      - Wed, 07 Nov 2018 06:13:12 GMT
+      - Thu, 08 Nov 2018 01:33:35 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1342,10 +1342,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:12 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:36 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271NTe1qMlosZUPFjPrPa2IvsznfsDecDF1%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -1357,7 +1357,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:12 GMT
+      - Thu, 08 Nov 2018 01:33:36 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1368,9 +1368,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:13:14 GMT
+      - Thu, 08 Nov 2018 01:33:36 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:14 GMT
+      - Thu, 08 Nov 2018 01:33:36 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1398,12 +1398,12 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1RlbBN3mWAJGpwNFwtVju1z6bEm0XerIz",
+           "id": "19Qnn6jjVnzD-lh8HvNEQFktFBF2qQyBn",
            "name": "Fol 3",
            "mimeType": "application/vnd.google-apps.folder",
            "trashed": false,
            "parents": [
-            "1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ"
+            "1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -1428,12 +1428,12 @@ http_interactions:
            ]
           },
           {
-           "id": "1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5",
+           "id": "1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT",
            "name": "Fol 2",
            "mimeType": "application/vnd.google-apps.folder",
            "trashed": false,
            "parents": [
-            "1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ"
+            "1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -1458,12 +1458,12 @@ http_interactions:
            ]
           },
           {
-           "id": "1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY",
+           "id": "1pJKmPVsDi4sj27umEonP4hisTAshnwWs",
            "name": "Fol 1",
            "mimeType": "application/vnd.google-apps.folder",
            "trashed": false,
            "parents": [
-            "1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ"
+            "1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -1490,10 +1490,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:14 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:36 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1RlbBN3mWAJGpwNFwtVju1z6bEm0XerIz/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/19Qnn6jjVnzD-lh8HvNEQFktFBF2qQyBn/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1505,7 +1505,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:14 GMT
+      - Thu, 08 Nov 2018 01:33:36 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1523,9 +1523,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 07 Nov 2018 06:13:14 GMT
+      - Thu, 08 Nov 2018 01:33:36 GMT
       Expires:
-      - Wed, 07 Nov 2018 06:13:14 GMT
+      - Thu, 08 Nov 2018 01:33:36 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1557,10 +1557,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:14 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:36 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1572,7 +1572,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:14 GMT
+      - Thu, 08 Nov 2018 01:33:36 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1590,9 +1590,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 07 Nov 2018 06:13:14 GMT
+      - Thu, 08 Nov 2018 01:33:36 GMT
       Expires:
-      - Wed, 07 Nov 2018 06:13:14 GMT
+      - Thu, 08 Nov 2018 01:33:36 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1624,10 +1624,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:14 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:36 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1pJKmPVsDi4sj27umEonP4hisTAshnwWs/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1639,7 +1639,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:14 GMT
+      - Thu, 08 Nov 2018 01:33:36 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1657,9 +1657,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 07 Nov 2018 06:13:15 GMT
+      - Thu, 08 Nov 2018 01:33:37 GMT
       Expires:
-      - Wed, 07 Nov 2018 06:13:15 GMT
+      - Thu, 08 Nov 2018 01:33:37 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1691,10 +1691,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:15 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:37 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271RlbBN3mWAJGpwNFwtVju1z6bEm0XerIz%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%2719Qnn6jjVnzD-lh8HvNEQFktFBF2qQyBn%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -1706,7 +1706,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:15 GMT
+      - Thu, 08 Nov 2018 01:33:37 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1717,9 +1717,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:13:15 GMT
+      - Thu, 08 Nov 2018 01:33:37 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:15 GMT
+      - Thu, 08 Nov 2018 01:33:37 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1747,14 +1747,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "12N0OSpQ1HUwztJiCfZagE3Mp9fB7GTeBp8SampYRsuM",
+           "id": "1ShrevNfMsRy3Go6JQf6ipqsWdEpb7St406n0ZZHkTo0",
            "name": "File D",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1RlbBN3mWAJGpwNFwtVju1z6bEm0XerIz"
+            "19Qnn6jjVnzD-lh8HvNEQFktFBF2qQyBn"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=12N0OSpQ1HUwztJiCfZagE3Mp9fB7GTeBp8SampYRsuM&v=1&s=AMedNnoAAAAAW-Kem1A7uTYLgEDWpfjne3wvibK-Lk35&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1ShrevNfMsRy3Go6JQf6ipqsWdEpb7St406n0ZZHkTo0&v=1&s=AMedNnoAAAAAW-OukZQuDHAQDAOdXmj730nsP7sR5vvX&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -1780,10 +1780,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:15 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:37 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/12N0OSpQ1HUwztJiCfZagE3Mp9fB7GTeBp8SampYRsuM/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1ShrevNfMsRy3Go6JQf6ipqsWdEpb7St406n0ZZHkTo0/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1795,7 +1795,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:15 GMT
+      - Thu, 08 Nov 2018 01:33:37 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1806,9 +1806,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:13:15 GMT
+      - Thu, 08 Nov 2018 01:33:37 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:15 GMT
+      - Thu, 08 Nov 2018 01:33:37 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1837,13 +1837,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-11-07T06:13:01.561Z"
+         "modifiedTime": "2018-11-08T01:33:21.114Z"
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:15 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:38 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=12N0OSpQ1HUwztJiCfZagE3Mp9fB7GTeBp8SampYRsuM&s=AMedNnoAAAAAW-Kem1A7uTYLgEDWpfjne3wvibK-Lk35&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1ShrevNfMsRy3Go6JQf6ipqsWdEpb7St406n0ZZHkTo0&s=AMedNnoAAAAAW-OukZQuDHAQDAOdXmj730nsP7sR5vvX&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1855,7 +1855,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:15 GMT
+      - Thu, 08 Nov 2018 01:33:38 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1886,7 +1886,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Nov 2018 06:13:16 GMT
+      - Thu, 08 Nov 2018 01:33:38 GMT
       Server:
       - fife
       Content-Length:
@@ -1900,13 +1900,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:16 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:38 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/12N0OSpQ1HUwztJiCfZagE3Mp9fB7GTeBp8SampYRsuM/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ShrevNfMsRy3Go6JQf6ipqsWdEpb7St406n0ZZHkTo0/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"File D","parents":["1Fbo5u06J4KOCs7nhXvcTwEZ1OdKW4j7W"]}'
+      string: '{"name":"File D","parents":["1I3SZFNG9B2x60Wzc6YQe8zDdwJIQxeP5"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1915,7 +1915,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:16 GMT
+      - Thu, 08 Nov 2018 01:33:38 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1932,7 +1932,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:19 GMT
+      - Thu, 08 Nov 2018 01:33:40 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1956,12 +1956,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1YXU00_vmFqhqaPoJBWXYtg0BhGkdD7qSv28O9e7DTB0",
+         "id": "1LkR9hxKBG8y8h4qezRskKaO9xOFR206VZuSjFbXng8I",
          "name": "File D",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1Fbo5u06J4KOCs7nhXvcTwEZ1OdKW4j7W"
+          "1I3SZFNG9B2x60Wzc6YQe8zDdwJIQxeP5"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1986,10 +1986,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:19 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:41 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -2001,7 +2001,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:19 GMT
+      - Thu, 08 Nov 2018 01:33:41 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2012,9 +2012,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:13:20 GMT
+      - Thu, 08 Nov 2018 01:33:41 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:20 GMT
+      - Thu, 08 Nov 2018 01:33:41 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -2042,14 +2042,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1ebr5Wp_oSjfqsNT_AYkPlsIkTZ2Hmg1TtqTeCN_Btiw",
+           "id": "1h8hoCjL1fXLkPu0drS4FIJLZSUEXKj7o_GerEVkoUQ4",
            "name": "File C",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5"
+            "1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1ebr5Wp_oSjfqsNT_AYkPlsIkTZ2Hmg1TtqTeCN_Btiw&v=1&s=AMedNnoAAAAAW-KeoLc6M6S69iVJZHv8tuIOTL_ahu3L&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1h8hoCjL1fXLkPu0drS4FIJLZSUEXKj7o_GerEVkoUQ4&v=1&s=AMedNnoAAAAAW-OulbeBedtEru__rEh_VP31hdtDWbf2&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -2073,14 +2073,14 @@ http_interactions:
            ]
           },
           {
-           "id": "1lEs97BZenN-NQZBt0Mp7xnib6RuEmHFCVBiVDA7lalA",
+           "id": "1BGrUK7SgNwPfKGKpUvAey86uF2-ayBpKHzUze3IN3k0",
            "name": "File B",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5"
+            "1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1lEs97BZenN-NQZBt0Mp7xnib6RuEmHFCVBiVDA7lalA&v=1&s=AMedNnoAAAAAW-KeoOu_OTk0-5iedtlmOmzhl-pv4ki8&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1BGrUK7SgNwPfKGKpUvAey86uF2-ayBpKHzUze3IN3k0&v=1&s=AMedNnoAAAAAW-OulRN_-M-ZxS-WE_GDfLgyLWDD_i2m&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -2106,10 +2106,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:20 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:41 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1ebr5Wp_oSjfqsNT_AYkPlsIkTZ2Hmg1TtqTeCN_Btiw/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1h8hoCjL1fXLkPu0drS4FIJLZSUEXKj7o_GerEVkoUQ4/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -2121,7 +2121,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:20 GMT
+      - Thu, 08 Nov 2018 01:33:41 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2132,9 +2132,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:13:21 GMT
+      - Thu, 08 Nov 2018 01:33:42 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:21 GMT
+      - Thu, 08 Nov 2018 01:33:42 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -2163,13 +2163,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-11-07T06:12:59.297Z"
+         "modifiedTime": "2018-11-08T01:33:19.213Z"
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:21 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:43 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1ebr5Wp_oSjfqsNT_AYkPlsIkTZ2Hmg1TtqTeCN_Btiw&s=AMedNnoAAAAAW-KeoLc6M6S69iVJZHv8tuIOTL_ahu3L&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1h8hoCjL1fXLkPu0drS4FIJLZSUEXKj7o_GerEVkoUQ4&s=AMedNnoAAAAAW-OulbeBedtEru__rEh_VP31hdtDWbf2&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -2181,7 +2181,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:21 GMT
+      - Thu, 08 Nov 2018 01:33:43 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2212,7 +2212,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Nov 2018 06:13:21 GMT
+      - Thu, 08 Nov 2018 01:33:43 GMT
       Server:
       - fife
       Content-Length:
@@ -2226,13 +2226,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:21 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:43 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1ebr5Wp_oSjfqsNT_AYkPlsIkTZ2Hmg1TtqTeCN_Btiw/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1h8hoCjL1fXLkPu0drS4FIJLZSUEXKj7o_GerEVkoUQ4/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"File C","parents":["1Fbo5u06J4KOCs7nhXvcTwEZ1OdKW4j7W"]}'
+      string: '{"name":"File C","parents":["1I3SZFNG9B2x60Wzc6YQe8zDdwJIQxeP5"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -2241,7 +2241,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:21 GMT
+      - Thu, 08 Nov 2018 01:33:43 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -2258,7 +2258,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:23 GMT
+      - Thu, 08 Nov 2018 01:33:45 GMT
       Vary:
       - Origin
       - X-Origin
@@ -2282,12 +2282,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "19L0Bae1V3k_3dmapfl7y0SJo6CAqfKkxY8DEs_xHY80",
+         "id": "1sv6bgOu6L-h94kObfettsSTQxKc6KYVLk3nMClRafNg",
          "name": "File C",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1Fbo5u06J4KOCs7nhXvcTwEZ1OdKW4j7W"
+          "1I3SZFNG9B2x60Wzc6YQe8zDdwJIQxeP5"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -2312,10 +2312,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:23 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:46 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1lEs97BZenN-NQZBt0Mp7xnib6RuEmHFCVBiVDA7lalA/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1BGrUK7SgNwPfKGKpUvAey86uF2-ayBpKHzUze3IN3k0/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -2327,7 +2327,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:23 GMT
+      - Thu, 08 Nov 2018 01:33:46 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2338,9 +2338,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:13:24 GMT
+      - Thu, 08 Nov 2018 01:33:46 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:24 GMT
+      - Thu, 08 Nov 2018 01:33:46 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -2369,13 +2369,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "3",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-11-07T06:12:58.309Z"
+         "modifiedTime": "2018-11-08T01:33:16.006Z"
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:24 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:46 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1lEs97BZenN-NQZBt0Mp7xnib6RuEmHFCVBiVDA7lalA&s=AMedNnoAAAAAW-KeoOu_OTk0-5iedtlmOmzhl-pv4ki8&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1BGrUK7SgNwPfKGKpUvAey86uF2-ayBpKHzUze3IN3k0&s=AMedNnoAAAAAW-OulRN_-M-ZxS-WE_GDfLgyLWDD_i2m&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -2387,7 +2387,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:24 GMT
+      - Thu, 08 Nov 2018 01:33:46 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2418,7 +2418,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Nov 2018 06:13:24 GMT
+      - Thu, 08 Nov 2018 01:33:46 GMT
       Server:
       - fife
       Content-Length:
@@ -2432,13 +2432,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:24 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:46 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1lEs97BZenN-NQZBt0Mp7xnib6RuEmHFCVBiVDA7lalA/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1BGrUK7SgNwPfKGKpUvAey86uF2-ayBpKHzUze3IN3k0/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"File B","parents":["1Fbo5u06J4KOCs7nhXvcTwEZ1OdKW4j7W"]}'
+      string: '{"name":"File B","parents":["1I3SZFNG9B2x60Wzc6YQe8zDdwJIQxeP5"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -2447,7 +2447,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:24 GMT
+      - Thu, 08 Nov 2018 01:33:46 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -2464,7 +2464,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:26 GMT
+      - Thu, 08 Nov 2018 01:33:48 GMT
       Vary:
       - Origin
       - X-Origin
@@ -2488,12 +2488,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "10AIrGMbCUiTcLQ5U3KZlzTstdUrIla4tqAxnAvxD6gM",
+         "id": "1RbQFM3MoNsKrw2EYVhDT10NyPi2zgO1g5Yb7PjMwoDY",
          "name": "File B",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1Fbo5u06J4KOCs7nhXvcTwEZ1OdKW4j7W"
+          "1I3SZFNG9B2x60Wzc6YQe8zDdwJIQxeP5"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -2518,10 +2518,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:26 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:48 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271pJKmPVsDi4sj27umEonP4hisTAshnwWs%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -2533,7 +2533,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:26 GMT
+      - Thu, 08 Nov 2018 01:33:48 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2544,9 +2544,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:13:26 GMT
+      - Thu, 08 Nov 2018 01:33:49 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:26 GMT
+      - Thu, 08 Nov 2018 01:33:49 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -2574,14 +2574,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1lulyWfmP9ai1nkAmJBi76Bd0mu63j4LcA-HBfL3xqP4",
+           "id": "1oN7GehbKvGZe-kpoCdFQXl3DroCoL-n6NYQu5szrGd0",
            "name": "File A",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY"
+            "1pJKmPVsDi4sj27umEonP4hisTAshnwWs"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1lulyWfmP9ai1nkAmJBi76Bd0mu63j4LcA-HBfL3xqP4&v=1&s=AMedNnoAAAAAW-KepiDf7qN7y3JBJe9a5IYTVJuKjk0c&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1oN7GehbKvGZe-kpoCdFQXl3DroCoL-n6NYQu5szrGd0&v=1&s=AMedNnoAAAAAW-OunS2NF3la2EkUPNcc0E-akTQzoXTK&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -2607,10 +2607,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:26 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:49 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1lulyWfmP9ai1nkAmJBi76Bd0mu63j4LcA-HBfL3xqP4/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1oN7GehbKvGZe-kpoCdFQXl3DroCoL-n6NYQu5szrGd0/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -2622,7 +2622,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:26 GMT
+      - Thu, 08 Nov 2018 01:33:49 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2633,9 +2633,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:13:27 GMT
+      - Thu, 08 Nov 2018 01:33:49 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:27 GMT
+      - Thu, 08 Nov 2018 01:33:49 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -2664,13 +2664,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "3",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-11-07T06:12:55.262Z"
+         "modifiedTime": "2018-11-08T01:33:12.615Z"
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:27 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:49 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1lulyWfmP9ai1nkAmJBi76Bd0mu63j4LcA-HBfL3xqP4&s=AMedNnoAAAAAW-KepiDf7qN7y3JBJe9a5IYTVJuKjk0c&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1oN7GehbKvGZe-kpoCdFQXl3DroCoL-n6NYQu5szrGd0&s=AMedNnoAAAAAW-OunS2NF3la2EkUPNcc0E-akTQzoXTK&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -2682,7 +2682,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:27 GMT
+      - Thu, 08 Nov 2018 01:33:49 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2713,7 +2713,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Nov 2018 06:13:27 GMT
+      - Thu, 08 Nov 2018 01:33:49 GMT
       Server:
       - fife
       Content-Length:
@@ -2727,13 +2727,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:27 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:49 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1lulyWfmP9ai1nkAmJBi76Bd0mu63j4LcA-HBfL3xqP4/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1oN7GehbKvGZe-kpoCdFQXl3DroCoL-n6NYQu5szrGd0/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"File A","parents":["1Fbo5u06J4KOCs7nhXvcTwEZ1OdKW4j7W"]}'
+      string: '{"name":"File A","parents":["1I3SZFNG9B2x60Wzc6YQe8zDdwJIQxeP5"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -2742,7 +2742,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:27 GMT
+      - Thu, 08 Nov 2018 01:33:49 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -2759,7 +2759,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:29 GMT
+      - Thu, 08 Nov 2018 01:33:52 GMT
       Vary:
       - Origin
       - X-Origin
@@ -2783,12 +2783,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1VDJD2W1LBHNtUZKtwH8dUsuO9IC9D0JwEgRiKE4LsMc",
+         "id": "1je9z4JaWVIRFlTtNEjKiO5nDr2PKRb8h5yd-nRJdgqw",
          "name": "File A",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1Fbo5u06J4KOCs7nhXvcTwEZ1OdKW4j7W"
+          "1I3SZFNG9B2x60Wzc6YQe8zDdwJIQxeP5"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -2813,10 +2813,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:30 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:52 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5?addParents=1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ
+    uri: https://www.googleapis.com/drive/v3/files/1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT?addParents=1pJKmPVsDi4sj27umEonP4hisTAshnwWs&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1
     body:
       encoding: UTF-8
       string: ''
@@ -2828,7 +2828,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:30 GMT
+      - Thu, 08 Nov 2018 01:33:52 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -2845,7 +2845,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:31 GMT
+      - Thu, 08 Nov 2018 01:33:55 GMT
       Vary:
       - Origin
       - X-Origin
@@ -2869,12 +2869,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5",
+         "id": "1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT",
          "name": "Fol 2",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY"
+          "1pJKmPVsDi4sj27umEonP4hisTAshnwWs"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -2899,10 +2899,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:31 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:55 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1RlbBN3mWAJGpwNFwtVju1z6bEm0XerIz?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ
+    uri: https://www.googleapis.com/drive/v3/files/19Qnn6jjVnzD-lh8HvNEQFktFBF2qQyBn?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1
     body:
       encoding: UTF-8
       string: ''
@@ -2914,7 +2914,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:31 GMT
+      - Thu, 08 Nov 2018 01:33:55 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -2931,7 +2931,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:31 GMT
+      - Thu, 08 Nov 2018 01:33:56 GMT
       Vary:
       - Origin
       - X-Origin
@@ -2955,7 +2955,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1RlbBN3mWAJGpwNFwtVju1z6bEm0XerIz",
+         "id": "19Qnn6jjVnzD-lh8HvNEQFktFBF2qQyBn",
          "name": "Fol 3",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
@@ -2973,10 +2973,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:31 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:56 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/12N0OSpQ1HUwztJiCfZagE3Mp9fB7GTeBp8SampYRsuM?addParents=1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1RlbBN3mWAJGpwNFwtVju1z6bEm0XerIz
+    uri: https://www.googleapis.com/drive/v3/files/1ShrevNfMsRy3Go6JQf6ipqsWdEpb7St406n0ZZHkTo0?addParents=1pJKmPVsDi4sj27umEonP4hisTAshnwWs&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=19Qnn6jjVnzD-lh8HvNEQFktFBF2qQyBn
     body:
       encoding: UTF-8
       string: ''
@@ -2988,7 +2988,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:31 GMT
+      - Thu, 08 Nov 2018 01:33:56 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -3005,7 +3005,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:32 GMT
+      - Thu, 08 Nov 2018 01:33:57 GMT
       Vary:
       - Origin
       - X-Origin
@@ -3029,14 +3029,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "12N0OSpQ1HUwztJiCfZagE3Mp9fB7GTeBp8SampYRsuM",
+         "id": "1ShrevNfMsRy3Go6JQf6ipqsWdEpb7St406n0ZZHkTo0",
          "name": "File D",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY"
+          "1pJKmPVsDi4sj27umEonP4hisTAshnwWs"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=12N0OSpQ1HUwztJiCfZagE3Mp9fB7GTeBp8SampYRsuM&v=1&s=AMedNnoAAAAAW-KerOFbELfMBWAnWUM7ijoWJhXzuDcG&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1ShrevNfMsRy3Go6JQf6ipqsWdEpb7St406n0ZZHkTo0&v=1&s=AMedNnoAAAAAW-OupbFdJ5zeMQ_oxrvnhZxUIUVYWbvm&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -3060,10 +3060,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:32 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:57 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1lEs97BZenN-NQZBt0Mp7xnib6RuEmHFCVBiVDA7lalA
+    uri: https://www.googleapis.com/drive/v3/files/1BGrUK7SgNwPfKGKpUvAey86uF2-ayBpKHzUze3IN3k0
     body:
       encoding: UTF-8
       string: ''
@@ -3075,7 +3075,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:32 GMT
+      - Thu, 08 Nov 2018 01:33:57 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -3092,7 +3092,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:33 GMT
+      - Thu, 08 Nov 2018 01:33:58 GMT
       Vary:
       - Origin
       - X-Origin
@@ -3104,10 +3104,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:33 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:58 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1pJKmPVsDi4sj27umEonP4hisTAshnwWs?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"name":"new folder name"}'
@@ -3119,7 +3119,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:33 GMT
+      - Thu, 08 Nov 2018 01:33:58 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -3136,7 +3136,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:33 GMT
+      - Thu, 08 Nov 2018 01:33:59 GMT
       Vary:
       - Origin
       - X-Origin
@@ -3160,12 +3160,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY",
+         "id": "1pJKmPVsDi4sj27umEonP4hisTAshnwWs",
          "name": "new folder name",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ"
+          "1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -3190,10 +3190,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:33 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:59 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/upload/drive/v3/files/1lulyWfmP9ai1nkAmJBi76Bd0mu63j4LcA-HBfL3xqP4
+    uri: https://www.googleapis.com/upload/drive/v3/files/1oN7GehbKvGZe-kpoCdFQXl3DroCoL-n6NYQu5szrGd0
     body:
       encoding: UTF-8
       string: ''
@@ -3205,7 +3205,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:33 GMT
+      - Thu, 08 Nov 2018 01:33:59 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       X-Goog-Upload-Protocol:
@@ -3224,22 +3224,22 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2UoCXuJlxW3VVLbddK9030F4fwiifZTcVoFrdIhzshVv8nw0MHTzBhYmy96QQxtuP0bkI2eIpGtbZtzx2W2qtDttPcJgRQ
+      - AEnB2UomZZHVjPPIl1gLWxmZiKxApQYOG3FM6NaEa8mUqN4IcRX_BIVLOIDTBzWMFMRph-fEPcpIHRhkBBS2s_nYR2cmJ6PsyA
       X-Goog-Upload-Status:
       - active
       X-Goog-Upload-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1lulyWfmP9ai1nkAmJBi76Bd0mu63j4LcA-HBfL3xqP4?upload_id=AEnB2UoCXuJlxW3VVLbddK9030F4fwiifZTcVoFrdIhzshVv8nw0MHTzBhYmy96QQxtuP0bkI2eIpGtbZtzx2W2qtDttPcJgRQ&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1oN7GehbKvGZe-kpoCdFQXl3DroCoL-n6NYQu5szrGd0?upload_id=AEnB2UomZZHVjPPIl1gLWxmZiKxApQYOG3FM6NaEa8mUqN4IcRX_BIVLOIDTBzWMFMRph-fEPcpIHRhkBBS2s_nYR2cmJ6PsyA&upload_protocol=resumable
       X-Goog-Upload-Control-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1lulyWfmP9ai1nkAmJBi76Bd0mu63j4LcA-HBfL3xqP4?upload_id=AEnB2UoCXuJlxW3VVLbddK9030F4fwiifZTcVoFrdIhzshVv8nw0MHTzBhYmy96QQxtuP0bkI2eIpGtbZtzx2W2qtDttPcJgRQ&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1oN7GehbKvGZe-kpoCdFQXl3DroCoL-n6NYQu5szrGd0?upload_id=AEnB2UomZZHVjPPIl1gLWxmZiKxApQYOG3FM6NaEa8mUqN4IcRX_BIVLOIDTBzWMFMRph-fEPcpIHRhkBBS2s_nYR2cmJ6PsyA&upload_protocol=resumable
       X-Goog-Upload-Chunk-Granularity:
       - '262144'
       X-Goog-Upload-Header-Vary:
       - Origin
       - X-Origin
       X-Goog-Upload-Header-X-Google-Backends:
-      - iocw23:4398
+      - iogk2:4384
       X-Goog-Upload-Header-X-Google-Session-Info:
-      - CKeBxoimHBoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x4TkJtaWxHUTlNS2p6QjQ0OW9EdUFwLXNuUWktcVVCYk1UeVhaRVVaT1d4LXYtX3VZcWFQUl9jS1RRSEF3TkRTcUkxR2VGd3Y2WWYzMnVSSTd0bkRZR2YxdGRXdUVWT3RPUDRuWUJNTkktUGtMcGFLUk4xYWI5b2g4QlFBMAQ6DTEvSWFuUWZrd3Q0TX4
+      - CKeBxoimHBoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x4T0J1OXZkNERSa2VlZkxoclNLOW9TQUNkU0pORGp3cTN3XzhhMUtrSTQzVWE2djlQS3BDaDJiZG53SUx3Nk5HVTBfNmhFWGMtaHpycEtWRHl3ZXA5V29LNjV6RUwzZFJ1SlowX01scGYtNTNHcU9KTlRBZEMwU1lRdFlRMAQ6DTEvSWFuUWZrd3Q0TX4
       X-Goog-Upload-Header-Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       X-Goog-Upload-Header-Pragma:
@@ -3247,11 +3247,11 @@ http_interactions:
       X-Goog-Upload-Header-Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       X-Goog-Upload-Header-Date:
-      - Wed, 07 Nov 2018 06:13:34 GMT
+      - Thu, 08 Nov 2018 01:33:59 GMT
       Content-Length:
       - '0'
       Date:
-      - Wed, 07 Nov 2018 06:13:34 GMT
+      - Thu, 08 Nov 2018 01:33:59 GMT
       Server:
       - UploadServer
       Content-Type:
@@ -3262,10 +3262,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:34 GMT
+  recorded_at: Thu, 08 Nov 2018 01:33:59 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/upload/drive/v3/files/1lulyWfmP9ai1nkAmJBi76Bd0mu63j4LcA-HBfL3xqP4?upload_id=AEnB2UoCXuJlxW3VVLbddK9030F4fwiifZTcVoFrdIhzshVv8nw0MHTzBhYmy96QQxtuP0bkI2eIpGtbZtzx2W2qtDttPcJgRQ&upload_protocol=resumable
+    uri: https://www.googleapis.com/upload/drive/v3/files/1oN7GehbKvGZe-kpoCdFQXl3DroCoL-n6NYQu5szrGd0?upload_id=AEnB2UomZZHVjPPIl1gLWxmZiKxApQYOG3FM6NaEa8mUqN4IcRX_BIVLOIDTBzWMFMRph-fEPcpIHRhkBBS2s_nYR2cmJ6PsyA&upload_protocol=resumable
     body:
       encoding: UTF-8
       string: super awesome!
@@ -3277,7 +3277,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:34 GMT
+      - Thu, 08 Nov 2018 01:33:59 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       X-Goog-Upload-Command:
@@ -3292,7 +3292,7 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2UoCXuJlxW3VVLbddK9030F4fwiifZTcVoFrdIhzshVv8nw0MHTzBhYmy96QQxtuP0bkI2eIpGtbZtzx2W2qtDttPcJgRQ
+      - AEnB2UomZZHVjPPIl1gLWxmZiKxApQYOG3FM6NaEa8mUqN4IcRX_BIVLOIDTBzWMFMRph-fEPcpIHRhkBBS2s_nYR2cmJ6PsyA
       X-Goog-Upload-Status:
       - final
       Vary:
@@ -3307,7 +3307,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:35 GMT
+      - Thu, 08 Nov 2018 01:34:03 GMT
       Content-Length:
       - '153'
       Server:
@@ -3319,18 +3319,18 @@ http_interactions:
       string: |
         {
          "kind": "drive#file",
-         "id": "1lulyWfmP9ai1nkAmJBi76Bd0mu63j4LcA-HBfL3xqP4",
+         "id": "1oN7GehbKvGZe-kpoCdFQXl3DroCoL-n6NYQu5szrGd0",
          "name": "File A",
          "mimeType": "application/vnd.google-apps.document"
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:35 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:03 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File E","parents":["1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File E","parents":["1pJKmPVsDi4sj27umEonP4hisTAshnwWs"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -3339,7 +3339,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:35 GMT
+      - Thu, 08 Nov 2018 01:34:03 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -3356,7 +3356,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:37 GMT
+      - Thu, 08 Nov 2018 01:34:04 GMT
       Vary:
       - Origin
       - X-Origin
@@ -3380,12 +3380,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1lGzjqMvzraScFNLWxfdHkbLrtbw7AK8BFliLhkVJSII",
+         "id": "1N3z8E7p3ICKbuKY3ax4XqCyhDVlxwuL1ik7bHitoSeA",
          "name": "File E",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY"
+          "1pJKmPVsDi4sj27umEonP4hisTAshnwWs"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -3410,13 +3410,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:37 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:04 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File F","parents":["1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File F","parents":["1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -3425,7 +3425,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:37 GMT
+      - Thu, 08 Nov 2018 01:34:04 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -3442,7 +3442,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:38 GMT
+      - Thu, 08 Nov 2018 01:34:05 GMT
       Vary:
       - Origin
       - X-Origin
@@ -3466,12 +3466,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1vc8bE4K4KLTCOZEqW4Gn-vlKYS-ojGp91wN4t5KpvKM",
+         "id": "1NuOu6EfHFmVEkmscjdSP_Tgcua-0-9MZnkvIv1rnsk8",
          "name": "File F",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ"
+          "1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -3496,10 +3496,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:38 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:05 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -3511,7 +3511,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:38 GMT
+      - Thu, 08 Nov 2018 01:34:05 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -3522,9 +3522,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:13:39 GMT
+      - Thu, 08 Nov 2018 01:34:06 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:39 GMT
+      - Thu, 08 Nov 2018 01:34:06 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -3550,8 +3550,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ",
-         "name": "Test @ 2018-11-07 06:12:30 UTC",
+         "id": "1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1",
+         "name": "Test @ 2018-11-08 01:32:59 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -3577,10 +3577,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:39 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:06 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -3592,7 +3592,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:39 GMT
+      - Thu, 08 Nov 2018 01:34:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -3610,9 +3610,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 07 Nov 2018 06:13:39 GMT
+      - Thu, 08 Nov 2018 01:34:06 GMT
       Expires:
-      - Wed, 07 Nov 2018 06:13:39 GMT
+      - Thu, 08 Nov 2018 01:34:06 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -3644,10 +3644,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:39 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:06 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1RlbBN3mWAJGpwNFwtVju1z6bEm0XerIz?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/19Qnn6jjVnzD-lh8HvNEQFktFBF2qQyBn?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -3659,7 +3659,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:39 GMT
+      - Thu, 08 Nov 2018 01:34:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -3677,9 +3677,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 07 Nov 2018 06:13:39 GMT
+      - Thu, 08 Nov 2018 01:34:06 GMT
       Expires:
-      - Wed, 07 Nov 2018 06:13:39 GMT
+      - Thu, 08 Nov 2018 01:34:06 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -3703,20 +3703,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1RlbBN3mWAJGpwNFwtVju1z6bEm0XerIz.",
+            "message": "File not found: 19Qnn6jjVnzD-lh8HvNEQFktFBF2qQyBn.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1RlbBN3mWAJGpwNFwtVju1z6bEm0XerIz."
+          "message": "File not found: 19Qnn6jjVnzD-lh8HvNEQFktFBF2qQyBn."
          }
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:39 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:06 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -3728,7 +3728,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:39 GMT
+      - Thu, 08 Nov 2018 01:34:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -3739,9 +3739,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:13:39 GMT
+      - Thu, 08 Nov 2018 01:34:07 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:39 GMT
+      - Thu, 08 Nov 2018 01:34:07 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -3767,12 +3767,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5",
+         "id": "1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT",
          "name": "Fol 2",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY"
+          "1pJKmPVsDi4sj27umEonP4hisTAshnwWs"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -3797,10 +3797,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:39 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:07 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -3812,7 +3812,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:39 GMT
+      - Thu, 08 Nov 2018 01:34:07 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -3830,9 +3830,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 07 Nov 2018 06:13:39 GMT
+      - Thu, 08 Nov 2018 01:34:07 GMT
       Expires:
-      - Wed, 07 Nov 2018 06:13:39 GMT
+      - Thu, 08 Nov 2018 01:34:07 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -3864,10 +3864,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:39 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:07 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1pJKmPVsDi4sj27umEonP4hisTAshnwWs?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -3879,7 +3879,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:39 GMT
+      - Thu, 08 Nov 2018 01:34:07 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -3890,9 +3890,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:13:39 GMT
+      - Thu, 08 Nov 2018 01:34:07 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:39 GMT
+      - Thu, 08 Nov 2018 01:34:07 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -3918,12 +3918,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY",
+         "id": "1pJKmPVsDi4sj27umEonP4hisTAshnwWs",
          "name": "new folder name",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ"
+          "1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -3948,10 +3948,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:39 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:07 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1pJKmPVsDi4sj27umEonP4hisTAshnwWs/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -3963,7 +3963,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:39 GMT
+      - Thu, 08 Nov 2018 01:34:07 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -3981,9 +3981,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 07 Nov 2018 06:13:40 GMT
+      - Thu, 08 Nov 2018 01:34:07 GMT
       Expires:
-      - Wed, 07 Nov 2018 06:13:40 GMT
+      - Thu, 08 Nov 2018 01:34:07 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -4015,10 +4015,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:40 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:07 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/12N0OSpQ1HUwztJiCfZagE3Mp9fB7GTeBp8SampYRsuM?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ShrevNfMsRy3Go6JQf6ipqsWdEpb7St406n0ZZHkTo0?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -4030,7 +4030,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:40 GMT
+      - Thu, 08 Nov 2018 01:34:07 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -4041,9 +4041,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:13:40 GMT
+      - Thu, 08 Nov 2018 01:34:08 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:40 GMT
+      - Thu, 08 Nov 2018 01:34:08 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -4069,14 +4069,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "12N0OSpQ1HUwztJiCfZagE3Mp9fB7GTeBp8SampYRsuM",
+         "id": "1ShrevNfMsRy3Go6JQf6ipqsWdEpb7St406n0ZZHkTo0",
          "name": "File D",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY"
+          "1pJKmPVsDi4sj27umEonP4hisTAshnwWs"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=12N0OSpQ1HUwztJiCfZagE3Mp9fB7GTeBp8SampYRsuM&v=1&s=AMedNnoAAAAAW-KetBHd3yXvFMytAZWHhlypon2tleMy&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1ShrevNfMsRy3Go6JQf6ipqsWdEpb7St406n0ZZHkTo0&v=1&s=AMedNnoAAAAAW-OusHpW_Ur2qRwoZ2EZrJd1cuI_ZQWB&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -4100,10 +4100,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:40 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:08 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/12N0OSpQ1HUwztJiCfZagE3Mp9fB7GTeBp8SampYRsuM/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1ShrevNfMsRy3Go6JQf6ipqsWdEpb7St406n0ZZHkTo0/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -4115,7 +4115,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:40 GMT
+      - Thu, 08 Nov 2018 01:34:08 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -4126,9 +4126,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:13:40 GMT
+      - Thu, 08 Nov 2018 01:34:08 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:40 GMT
+      - Thu, 08 Nov 2018 01:34:08 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -4157,13 +4157,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-11-07T06:13:01.561Z"
+         "modifiedTime": "2018-11-08T01:33:21.114Z"
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:40 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:08 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=12N0OSpQ1HUwztJiCfZagE3Mp9fB7GTeBp8SampYRsuM&s=AMedNnoAAAAAW-KetBHd3yXvFMytAZWHhlypon2tleMy&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1ShrevNfMsRy3Go6JQf6ipqsWdEpb7St406n0ZZHkTo0&s=AMedNnoAAAAAW-OusHpW_Ur2qRwoZ2EZrJd1cuI_ZQWB&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -4175,7 +4175,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:40 GMT
+      - Thu, 08 Nov 2018 01:34:08 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -4206,7 +4206,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Nov 2018 06:13:40 GMT
+      - Thu, 08 Nov 2018 01:34:08 GMT
       Server:
       - fife
       Content-Length:
@@ -4220,13 +4220,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:40 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:09 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/12N0OSpQ1HUwztJiCfZagE3Mp9fB7GTeBp8SampYRsuM/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ShrevNfMsRy3Go6JQf6ipqsWdEpb7St406n0ZZHkTo0/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"File D","parents":["1Fbo5u06J4KOCs7nhXvcTwEZ1OdKW4j7W"]}'
+      string: '{"name":"File D","parents":["1I3SZFNG9B2x60Wzc6YQe8zDdwJIQxeP5"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -4235,7 +4235,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:40 GMT
+      - Thu, 08 Nov 2018 01:34:09 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -4252,7 +4252,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:42 GMT
+      - Thu, 08 Nov 2018 01:34:11 GMT
       Vary:
       - Origin
       - X-Origin
@@ -4276,12 +4276,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1rVmd9-yLFb-jQj70nhX68NWPVCCsX3FEdIgrwjix4tw",
+         "id": "1uI7C_jsNdriH09H-l2WMOTg8bwfiblS5yFww4R5hsq8",
          "name": "File D",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1Fbo5u06J4KOCs7nhXvcTwEZ1OdKW4j7W"
+          "1I3SZFNG9B2x60Wzc6YQe8zDdwJIQxeP5"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -4306,10 +4306,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:42 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:11 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1ebr5Wp_oSjfqsNT_AYkPlsIkTZ2Hmg1TtqTeCN_Btiw?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1h8hoCjL1fXLkPu0drS4FIJLZSUEXKj7o_GerEVkoUQ4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -4321,7 +4321,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:42 GMT
+      - Thu, 08 Nov 2018 01:34:11 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -4332,9 +4332,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:13:42 GMT
+      - Thu, 08 Nov 2018 01:34:11 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:42 GMT
+      - Thu, 08 Nov 2018 01:34:11 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -4360,14 +4360,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1ebr5Wp_oSjfqsNT_AYkPlsIkTZ2Hmg1TtqTeCN_Btiw",
+         "id": "1h8hoCjL1fXLkPu0drS4FIJLZSUEXKj7o_GerEVkoUQ4",
          "name": "File C",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5"
+          "1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1ebr5Wp_oSjfqsNT_AYkPlsIkTZ2Hmg1TtqTeCN_Btiw&v=1&s=AMedNnoAAAAAW-Ketlp9rAsqzDPS8r8AfeWlKhQtVxox&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1h8hoCjL1fXLkPu0drS4FIJLZSUEXKj7o_GerEVkoUQ4&v=1&s=AMedNnoAAAAAW-Ous5Dd3se1_83U7pwzpMjLRrRxBRTT&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -4391,10 +4391,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:42 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:11 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1ebr5Wp_oSjfqsNT_AYkPlsIkTZ2Hmg1TtqTeCN_Btiw/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1h8hoCjL1fXLkPu0drS4FIJLZSUEXKj7o_GerEVkoUQ4/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -4406,7 +4406,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:42 GMT
+      - Thu, 08 Nov 2018 01:34:11 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -4417,9 +4417,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:13:42 GMT
+      - Thu, 08 Nov 2018 01:34:12 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:42 GMT
+      - Thu, 08 Nov 2018 01:34:12 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -4448,13 +4448,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-11-07T06:12:59.297Z"
+         "modifiedTime": "2018-11-08T01:33:19.213Z"
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:42 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:12 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1ebr5Wp_oSjfqsNT_AYkPlsIkTZ2Hmg1TtqTeCN_Btiw&s=AMedNnoAAAAAW-Ketlp9rAsqzDPS8r8AfeWlKhQtVxox&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1h8hoCjL1fXLkPu0drS4FIJLZSUEXKj7o_GerEVkoUQ4&s=AMedNnoAAAAAW-Ous5Dd3se1_83U7pwzpMjLRrRxBRTT&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -4466,7 +4466,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:42 GMT
+      - Thu, 08 Nov 2018 01:34:12 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -4497,7 +4497,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Nov 2018 06:13:43 GMT
+      - Thu, 08 Nov 2018 01:34:12 GMT
       Server:
       - fife
       Content-Length:
@@ -4511,10 +4511,10 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:43 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:12 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1lEs97BZenN-NQZBt0Mp7xnib6RuEmHFCVBiVDA7lalA?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1BGrUK7SgNwPfKGKpUvAey86uF2-ayBpKHzUze3IN3k0?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -4526,7 +4526,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:43 GMT
+      - Thu, 08 Nov 2018 01:34:12 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -4544,9 +4544,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 07 Nov 2018 06:13:43 GMT
+      - Thu, 08 Nov 2018 01:34:12 GMT
       Expires:
-      - Wed, 07 Nov 2018 06:13:43 GMT
+      - Thu, 08 Nov 2018 01:34:12 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -4570,20 +4570,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1lEs97BZenN-NQZBt0Mp7xnib6RuEmHFCVBiVDA7lalA.",
+            "message": "File not found: 1BGrUK7SgNwPfKGKpUvAey86uF2-ayBpKHzUze3IN3k0.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1lEs97BZenN-NQZBt0Mp7xnib6RuEmHFCVBiVDA7lalA."
+          "message": "File not found: 1BGrUK7SgNwPfKGKpUvAey86uF2-ayBpKHzUze3IN3k0."
          }
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:43 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:12 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1lulyWfmP9ai1nkAmJBi76Bd0mu63j4LcA-HBfL3xqP4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1oN7GehbKvGZe-kpoCdFQXl3DroCoL-n6NYQu5szrGd0?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -4595,7 +4595,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:43 GMT
+      - Thu, 08 Nov 2018 01:34:12 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -4606,9 +4606,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:13:43 GMT
+      - Thu, 08 Nov 2018 01:34:12 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:43 GMT
+      - Thu, 08 Nov 2018 01:34:12 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -4634,14 +4634,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1lulyWfmP9ai1nkAmJBi76Bd0mu63j4LcA-HBfL3xqP4",
+         "id": "1oN7GehbKvGZe-kpoCdFQXl3DroCoL-n6NYQu5szrGd0",
          "name": "File A",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY"
+          "1pJKmPVsDi4sj27umEonP4hisTAshnwWs"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1lulyWfmP9ai1nkAmJBi76Bd0mu63j4LcA-HBfL3xqP4&v=1&s=AMedNnoAAAAAW-Ket2wXj9QZisT6CAKXWBmJ3OpcGQA5&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1oN7GehbKvGZe-kpoCdFQXl3DroCoL-n6NYQu5szrGd0&v=1&s=AMedNnoAAAAAW-OutKa6nsfJ4s_ay6KmSbhBHJHeKw2R&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -4665,10 +4665,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:43 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:13 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1lulyWfmP9ai1nkAmJBi76Bd0mu63j4LcA-HBfL3xqP4/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1oN7GehbKvGZe-kpoCdFQXl3DroCoL-n6NYQu5szrGd0/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -4680,7 +4680,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:43 GMT
+      - Thu, 08 Nov 2018 01:34:13 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -4691,9 +4691,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:13:43 GMT
+      - Thu, 08 Nov 2018 01:34:13 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:43 GMT
+      - Thu, 08 Nov 2018 01:34:13 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -4722,13 +4722,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "4",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-11-07T06:13:34.794Z"
+         "modifiedTime": "2018-11-08T01:34:00.335Z"
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:43 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:13 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1lulyWfmP9ai1nkAmJBi76Bd0mu63j4LcA-HBfL3xqP4&s=AMedNnoAAAAAW-Ket2wXj9QZisT6CAKXWBmJ3OpcGQA5&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1oN7GehbKvGZe-kpoCdFQXl3DroCoL-n6NYQu5szrGd0&s=AMedNnoAAAAAW-OutKa6nsfJ4s_ay6KmSbhBHJHeKw2R&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -4740,7 +4740,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:43 GMT
+      - Thu, 08 Nov 2018 01:34:13 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -4771,7 +4771,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Nov 2018 06:13:43 GMT
+      - Thu, 08 Nov 2018 01:34:13 GMT
       Server:
       - fife
       Content-Length:
@@ -4785,13 +4785,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:43 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:13 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1lulyWfmP9ai1nkAmJBi76Bd0mu63j4LcA-HBfL3xqP4/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1oN7GehbKvGZe-kpoCdFQXl3DroCoL-n6NYQu5szrGd0/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"File A","parents":["1Fbo5u06J4KOCs7nhXvcTwEZ1OdKW4j7W"]}'
+      string: '{"name":"File A","parents":["1I3SZFNG9B2x60Wzc6YQe8zDdwJIQxeP5"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -4800,7 +4800,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:43 GMT
+      - Thu, 08 Nov 2018 01:34:13 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -4817,7 +4817,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:45 GMT
+      - Thu, 08 Nov 2018 01:34:15 GMT
       Vary:
       - Origin
       - X-Origin
@@ -4841,12 +4841,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1dYWpowEDeG0e3CRbX0K9QoSjMQArcfVoep1UgSNg5FY",
+         "id": "1oAHiCqkYrCO8388TWUKN5Vml9EFGsm1lR8FN-wIqBJ8",
          "name": "File A",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1Fbo5u06J4KOCs7nhXvcTwEZ1OdKW4j7W"
+          "1I3SZFNG9B2x60Wzc6YQe8zDdwJIQxeP5"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -4871,10 +4871,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:45 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:15 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271NTe1qMlosZUPFjPrPa2IvsznfsDecDF1%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -4886,7 +4886,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:45 GMT
+      - Thu, 08 Nov 2018 01:34:15 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -4897,9 +4897,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:13:45 GMT
+      - Thu, 08 Nov 2018 01:34:15 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:45 GMT
+      - Thu, 08 Nov 2018 01:34:15 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -4927,14 +4927,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1vc8bE4K4KLTCOZEqW4Gn-vlKYS-ojGp91wN4t5KpvKM",
+           "id": "1NuOu6EfHFmVEkmscjdSP_Tgcua-0-9MZnkvIv1rnsk8",
            "name": "File F",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ"
+            "1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1vc8bE4K4KLTCOZEqW4Gn-vlKYS-ojGp91wN4t5KpvKM&v=1&s=AMedNnoAAAAAW-KeuTOOMo-ek1Umv_2Mna9CmXqc49Gw&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1NuOu6EfHFmVEkmscjdSP_Tgcua-0-9MZnkvIv1rnsk8&v=1&s=AMedNnoAAAAAW-OutyIIMqpM079KxNl4veKrmLaRJH35&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -4958,12 +4958,12 @@ http_interactions:
            ]
           },
           {
-           "id": "1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY",
+           "id": "1pJKmPVsDi4sj27umEonP4hisTAshnwWs",
            "name": "new folder name",
            "mimeType": "application/vnd.google-apps.folder",
            "trashed": false,
            "parents": [
-            "1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ"
+            "1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -4990,10 +4990,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:45 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:15 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1vc8bE4K4KLTCOZEqW4Gn-vlKYS-ojGp91wN4t5KpvKM/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1NuOu6EfHFmVEkmscjdSP_Tgcua-0-9MZnkvIv1rnsk8/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -5005,7 +5005,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:45 GMT
+      - Thu, 08 Nov 2018 01:34:15 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -5016,9 +5016,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:13:45 GMT
+      - Thu, 08 Nov 2018 01:34:15 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:45 GMT
+      - Thu, 08 Nov 2018 01:34:15 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -5047,13 +5047,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-11-07T06:13:37.673Z"
+         "modifiedTime": "2018-11-08T01:34:04.906Z"
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:45 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:15 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1vc8bE4K4KLTCOZEqW4Gn-vlKYS-ojGp91wN4t5KpvKM&s=AMedNnoAAAAAW-KeuTOOMo-ek1Umv_2Mna9CmXqc49Gw&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1NuOu6EfHFmVEkmscjdSP_Tgcua-0-9MZnkvIv1rnsk8&s=AMedNnoAAAAAW-OutyIIMqpM079KxNl4veKrmLaRJH35&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -5065,7 +5065,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:45 GMT
+      - Thu, 08 Nov 2018 01:34:15 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -5096,7 +5096,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Nov 2018 06:13:45 GMT
+      - Thu, 08 Nov 2018 01:34:16 GMT
       Server:
       - fife
       Content-Length:
@@ -5110,13 +5110,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:45 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:16 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1vc8bE4K4KLTCOZEqW4Gn-vlKYS-ojGp91wN4t5KpvKM/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1NuOu6EfHFmVEkmscjdSP_Tgcua-0-9MZnkvIv1rnsk8/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"File F","parents":["1Fbo5u06J4KOCs7nhXvcTwEZ1OdKW4j7W"]}'
+      string: '{"name":"File F","parents":["1I3SZFNG9B2x60Wzc6YQe8zDdwJIQxeP5"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -5125,7 +5125,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:46 GMT
+      - Thu, 08 Nov 2018 01:34:16 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -5142,7 +5142,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:47 GMT
+      - Thu, 08 Nov 2018 01:34:18 GMT
       Vary:
       - Origin
       - X-Origin
@@ -5166,12 +5166,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1ncgejJHamtgJivhqwKCO_UnZPQmCUEm38UEsB4TM5zw",
+         "id": "1XqPyuVhUedhEa_Os1DZ-01VqCAWp02qHzyjRbb3zJEo",
          "name": "File F",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1Fbo5u06J4KOCs7nhXvcTwEZ1OdKW4j7W"
+          "1I3SZFNG9B2x60Wzc6YQe8zDdwJIQxeP5"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -5196,10 +5196,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:47 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:18 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271RlbBN3mWAJGpwNFwtVju1z6bEm0XerIz%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%2719Qnn6jjVnzD-lh8HvNEQFktFBF2qQyBn%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -5211,7 +5211,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:47 GMT
+      - Thu, 08 Nov 2018 01:34:18 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -5222,9 +5222,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:13:47 GMT
+      - Thu, 08 Nov 2018 01:34:18 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:47 GMT
+      - Thu, 08 Nov 2018 01:34:18 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -5253,10 +5253,10 @@ http_interactions:
          "files": []
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:47 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:18 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -5268,7 +5268,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:47 GMT
+      - Thu, 08 Nov 2018 01:34:18 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -5279,9 +5279,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:13:48 GMT
+      - Thu, 08 Nov 2018 01:34:18 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:48 GMT
+      - Thu, 08 Nov 2018 01:34:18 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -5309,14 +5309,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1ebr5Wp_oSjfqsNT_AYkPlsIkTZ2Hmg1TtqTeCN_Btiw",
+           "id": "1h8hoCjL1fXLkPu0drS4FIJLZSUEXKj7o_GerEVkoUQ4",
            "name": "File C",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5"
+            "1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1ebr5Wp_oSjfqsNT_AYkPlsIkTZ2Hmg1TtqTeCN_Btiw&v=1&s=AMedNnoAAAAAW-KevOvd4lkybdQ3BhgfLw65aEVs8OhO&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1h8hoCjL1fXLkPu0drS4FIJLZSUEXKj7o_GerEVkoUQ4&v=1&s=AMedNnoAAAAAW-OuutpCIySrcPUq6kPChF9XAiSAnw_s&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -5342,10 +5342,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:48 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:18 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271pJKmPVsDi4sj27umEonP4hisTAshnwWs%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -5357,7 +5357,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:48 GMT
+      - Thu, 08 Nov 2018 01:34:18 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -5368,9 +5368,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:13:48 GMT
+      - Thu, 08 Nov 2018 01:34:19 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:48 GMT
+      - Thu, 08 Nov 2018 01:34:19 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -5398,14 +5398,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1lGzjqMvzraScFNLWxfdHkbLrtbw7AK8BFliLhkVJSII",
+           "id": "1N3z8E7p3ICKbuKY3ax4XqCyhDVlxwuL1ik7bHitoSeA",
            "name": "File E",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY"
+            "1pJKmPVsDi4sj27umEonP4hisTAshnwWs"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1lGzjqMvzraScFNLWxfdHkbLrtbw7AK8BFliLhkVJSII&v=1&s=AMedNnoAAAAAW-KevB2R9bd2jlb7Q_fEVhQWDIIna3PH&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1N3z8E7p3ICKbuKY3ax4XqCyhDVlxwuL1ik7bHitoSeA&v=1&s=AMedNnoAAAAAW-Ouu8Q9KbKhuYGK3YoL9zUimPlncxoB&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -5429,14 +5429,14 @@ http_interactions:
            ]
           },
           {
-           "id": "1lulyWfmP9ai1nkAmJBi76Bd0mu63j4LcA-HBfL3xqP4",
+           "id": "1oN7GehbKvGZe-kpoCdFQXl3DroCoL-n6NYQu5szrGd0",
            "name": "File A",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY"
+            "1pJKmPVsDi4sj27umEonP4hisTAshnwWs"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1lulyWfmP9ai1nkAmJBi76Bd0mu63j4LcA-HBfL3xqP4&v=1&s=AMedNnoAAAAAW-KevKqtK5-NVemYBKnKOKM581O57Aox&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1oN7GehbKvGZe-kpoCdFQXl3DroCoL-n6NYQu5szrGd0&v=1&s=AMedNnoAAAAAW-Ouu6I8XSJ4CMWkOkOzlEqZaHzFcbFU&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -5460,14 +5460,14 @@ http_interactions:
            ]
           },
           {
-           "id": "12N0OSpQ1HUwztJiCfZagE3Mp9fB7GTeBp8SampYRsuM",
+           "id": "1ShrevNfMsRy3Go6JQf6ipqsWdEpb7St406n0ZZHkTo0",
            "name": "File D",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY"
+            "1pJKmPVsDi4sj27umEonP4hisTAshnwWs"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=12N0OSpQ1HUwztJiCfZagE3Mp9fB7GTeBp8SampYRsuM&v=1&s=AMedNnoAAAAAW-KevBiSz0MXP7hfWVpnNKTUsG69t3pp&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1ShrevNfMsRy3Go6JQf6ipqsWdEpb7St406n0ZZHkTo0&v=1&s=AMedNnoAAAAAW-Ouu1AOKoy44MFDHeu1_wJ5pPhvJExB&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -5491,12 +5491,12 @@ http_interactions:
            ]
           },
           {
-           "id": "1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5",
+           "id": "1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT",
            "name": "Fol 2",
            "mimeType": "application/vnd.google-apps.folder",
            "trashed": false,
            "parents": [
-            "1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY"
+            "1pJKmPVsDi4sj27umEonP4hisTAshnwWs"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -5523,10 +5523,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:48 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:19 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1lGzjqMvzraScFNLWxfdHkbLrtbw7AK8BFliLhkVJSII/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1N3z8E7p3ICKbuKY3ax4XqCyhDVlxwuL1ik7bHitoSeA/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -5538,7 +5538,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:48 GMT
+      - Thu, 08 Nov 2018 01:34:19 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -5549,9 +5549,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:13:48 GMT
+      - Thu, 08 Nov 2018 01:34:19 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:48 GMT
+      - Thu, 08 Nov 2018 01:34:19 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -5580,13 +5580,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-11-07T06:13:36.268Z"
+         "modifiedTime": "2018-11-08T01:34:03.553Z"
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:48 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:19 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1lGzjqMvzraScFNLWxfdHkbLrtbw7AK8BFliLhkVJSII&s=AMedNnoAAAAAW-KevB2R9bd2jlb7Q_fEVhQWDIIna3PH&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1N3z8E7p3ICKbuKY3ax4XqCyhDVlxwuL1ik7bHitoSeA&s=AMedNnoAAAAAW-Ouu8Q9KbKhuYGK3YoL9zUimPlncxoB&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -5598,7 +5598,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:48 GMT
+      - Thu, 08 Nov 2018 01:34:19 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -5629,7 +5629,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Nov 2018 06:13:48 GMT
+      - Thu, 08 Nov 2018 01:34:19 GMT
       Server:
       - fife
       Content-Length:
@@ -5643,13 +5643,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:48 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:19 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1lGzjqMvzraScFNLWxfdHkbLrtbw7AK8BFliLhkVJSII/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1N3z8E7p3ICKbuKY3ax4XqCyhDVlxwuL1ik7bHitoSeA/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"File E","parents":["1Fbo5u06J4KOCs7nhXvcTwEZ1OdKW4j7W"]}'
+      string: '{"name":"File E","parents":["1I3SZFNG9B2x60Wzc6YQe8zDdwJIQxeP5"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -5658,7 +5658,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:48 GMT
+      - Thu, 08 Nov 2018 01:34:19 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -5675,7 +5675,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:50 GMT
+      - Thu, 08 Nov 2018 01:34:21 GMT
       Vary:
       - Origin
       - X-Origin
@@ -5699,12 +5699,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1JXeqYSdDhD9gI6BVDHet4hB8J_vpzi1Or4SnEeB8d4k",
+         "id": "1-GiDUX4URMWxn9hUh5zWR0WtluNmGe9yN85wzG78eK4",
          "name": "File E",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1Fbo5u06J4KOCs7nhXvcTwEZ1OdKW4j7W"
+          "1I3SZFNG9B2x60Wzc6YQe8zDdwJIQxeP5"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -5729,13 +5729,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:50 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:21 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Fol 3","parents":["1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Fol 3","parents":["1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -5744,7 +5744,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:51 GMT
+      - Thu, 08 Nov 2018 01:34:23 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -5761,7 +5761,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:52 GMT
+      - Thu, 08 Nov 2018 01:34:24 GMT
       Vary:
       - Origin
       - X-Origin
@@ -5785,12 +5785,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1avp5m0mME29n1ztKk82n1PuyEXuB4sKV",
+         "id": "1ln1xSI27jmVn3dJIE2Jwx7EVHMeet6zo",
          "name": "Fol 3",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ"
+          "1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -5815,10 +5815,77 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:52 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:24 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1ln1xSI27jmVn3dJIE2Jwx7EVHMeet6zo/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 08 Nov 2018 01:34:24 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 08 Nov 2018 01:34:24 GMT
+      Expires:
+      - Thu, 08 Nov 2018 01:34:24 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 08 Nov 2018 01:34:24 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1pJKmPVsDi4sj27umEonP4hisTAshnwWs?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"name":"Fol 1"}'
@@ -5830,7 +5897,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:52 GMT
+      - Thu, 08 Nov 2018 01:34:24 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -5847,7 +5914,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:52 GMT
+      - Thu, 08 Nov 2018 01:34:25 GMT
       Vary:
       - Origin
       - X-Origin
@@ -5871,12 +5938,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY",
+         "id": "1pJKmPVsDi4sj27umEonP4hisTAshnwWs",
          "name": "Fol 1",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ"
+          "1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -5901,13 +5968,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:52 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:25 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1VDJD2W1LBHNtUZKtwH8dUsuO9IC9D0JwEgRiKE4LsMc/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1je9z4JaWVIRFlTtNEjKiO5nDr2PKRb8h5yd-nRJdgqw/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"File A","parents":["1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY"]}'
+      string: '{"name":"File A","parents":["1pJKmPVsDi4sj27umEonP4hisTAshnwWs"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -5916,7 +5983,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:52 GMT
+      - Thu, 08 Nov 2018 01:34:25 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -5933,7 +6000,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:55 GMT
+      - Thu, 08 Nov 2018 01:34:31 GMT
       Vary:
       - Origin
       - X-Origin
@@ -5957,12 +6024,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "14GP3SFnuu9zv4qDM-G4XFGGPkQva7yaM1Ib-YlEU5-0",
+         "id": "1j7r4zrEdQa4b4yf_trlB8OJgl4vOuUCZrzzwUFTaL0A",
          "name": "File A",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY"
+          "1pJKmPVsDi4sj27umEonP4hisTAshnwWs"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -5987,10 +6054,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:55 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:31 GMT
 - request:
-    method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1lulyWfmP9ai1nkAmJBi76Bd0mu63j4LcA-HBfL3xqP4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1j7r4zrEdQa4b4yf_trlB8OJgl4vOuUCZrzzwUFTaL0A/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -6002,68 +6069,22 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:55 GMT
+      - Thu, 08 Nov 2018 01:34:31 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
       - application/x-www-form-urlencoded
   response:
     status:
-      code: 204
-      message: No Content
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Wed, 07 Nov 2018 06:13:56 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:56 GMT
-- request:
-    method: post
-    uri: https://www.googleapis.com/drive/v3/files/14GP3SFnuu9zv4qDM-G4XFGGPkQva7yaM1Ib-YlEU5-0/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: '{"name":"File A","parents":["1Fbo5u06J4KOCs7nhXvcTwEZ1OdKW4j7W"]}'
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 07 Nov 2018 06:13:56 GMT
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-  response:
-    status:
       code: 200
       message: OK
     headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
       Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
+      - Thu, 08 Nov 2018 01:34:31 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:58 GMT
+      - Thu, 08 Nov 2018 01:34:31 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
       Vary:
       - Origin
       - X-Origin
@@ -6087,40 +6108,16 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1IAZu2mj5XJmgxS6hIQe36K-xozJ2jefPDfIYt9qcRTw",
-         "name": "File A",
+         "kind": "drive#revision",
+         "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1Fbo5u06J4KOCs7nhXvcTwEZ1OdKW4j7W"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
+         "modifiedTime": "2018-11-08T01:34:30.287Z"
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:58 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:31 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1lGzjqMvzraScFNLWxfdHkbLrtbw7AK8BFliLhkVJSII?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY
+    uri: https://www.googleapis.com/drive/v3/files/1oN7GehbKvGZe-kpoCdFQXl3DroCoL-n6NYQu5szrGd0?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1pJKmPVsDi4sj27umEonP4hisTAshnwWs
     body:
       encoding: UTF-8
       string: ''
@@ -6132,7 +6129,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:58 GMT
+      - Thu, 08 Nov 2018 01:34:31 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -6149,7 +6146,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:58 GMT
+      - Thu, 08 Nov 2018 01:34:32 GMT
       Vary:
       - Origin
       - X-Origin
@@ -6161,10 +6158,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:59 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:32 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5?addParents=1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY
+    uri: https://www.googleapis.com/drive/v3/files/1N3z8E7p3ICKbuKY3ax4XqCyhDVlxwuL1ik7bHitoSeA?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1pJKmPVsDi4sj27umEonP4hisTAshnwWs
     body:
       encoding: UTF-8
       string: ''
@@ -6176,7 +6173,51 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:59 GMT
+      - Thu, 08 Nov 2018 01:34:32 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 08 Nov 2018 01:34:32 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 08 Nov 2018 01:34:32 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/drive/v3/files/1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT?addParents=1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1pJKmPVsDi4sj27umEonP4hisTAshnwWs
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 08 Nov 2018 01:34:32 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -6193,7 +6234,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:13:59 GMT
+      - Thu, 08 Nov 2018 01:34:33 GMT
       Vary:
       - Origin
       - X-Origin
@@ -6217,12 +6258,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5",
+         "id": "1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT",
          "name": "Fol 2",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ"
+          "1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -6247,13 +6288,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:13:59 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:33 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/10AIrGMbCUiTcLQ5U3KZlzTstdUrIla4tqAxnAvxD6gM/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1RbQFM3MoNsKrw2EYVhDT10NyPi2zgO1g5Yb7PjMwoDY/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"File B","parents":["1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5"]}'
+      string: '{"name":"File B","parents":["1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -6262,7 +6303,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:13:59 GMT
+      - Thu, 08 Nov 2018 01:34:33 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -6279,7 +6320,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:14:01 GMT
+      - Thu, 08 Nov 2018 01:34:36 GMT
       Vary:
       - Origin
       - X-Origin
@@ -6303,12 +6344,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1OGygyBPY3jNqW2BXToQdQA3x-djD_jaKDUp_oHpsy4M",
+         "id": "1XDDsny4mnHbmJ5xiuZv4lpGFf3IMHGdipRMqhOEy4lg",
          "name": "File B",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5"
+          "1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -6333,96 +6374,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:01 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:36 GMT
 - request:
-    method: post
-    uri: https://www.googleapis.com/drive/v3/files/1OGygyBPY3jNqW2BXToQdQA3x-djD_jaKDUp_oHpsy4M/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: '{"name":"File B","parents":["1Fbo5u06J4KOCs7nhXvcTwEZ1OdKW4j7W"]}'
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 07 Nov 2018 06:14:01 GMT
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Wed, 07 Nov 2018 06:14:03 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "16bCD_IOU4xQkq0nMk-gb7s9A0Laht-BccKh9oTMrqJ8",
-         "name": "File B",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1Fbo5u06J4KOCs7nhXvcTwEZ1OdKW4j7W"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:04 GMT
-- request:
-    method: patch
-    uri: https://www.googleapis.com/drive/v3/files/12N0OSpQ1HUwztJiCfZagE3Mp9fB7GTeBp8SampYRsuM?addParents=1avp5m0mME29n1ztKk82n1PuyEXuB4sKV&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1XDDsny4mnHbmJ5xiuZv4lpGFf3IMHGdipRMqhOEy4lg/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -6434,7 +6389,67 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:04 GMT
+      - Thu, 08 Nov 2018 01:34:36 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 08 Nov 2018 01:34:36 GMT
+      Date:
+      - Thu, 08 Nov 2018 01:34:36 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-11-08T01:34:35.434Z"
+        }
+    http_version: 
+  recorded_at: Thu, 08 Nov 2018 01:34:36 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/drive/v3/files/1ShrevNfMsRy3Go6JQf6ipqsWdEpb7St406n0ZZHkTo0?addParents=1ln1xSI27jmVn3dJIE2Jwx7EVHMeet6zo&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1pJKmPVsDi4sj27umEonP4hisTAshnwWs
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 08 Nov 2018 01:34:36 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -6451,7 +6466,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:14:04 GMT
+      - Thu, 08 Nov 2018 01:34:37 GMT
       Vary:
       - Origin
       - X-Origin
@@ -6475,14 +6490,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "12N0OSpQ1HUwztJiCfZagE3Mp9fB7GTeBp8SampYRsuM",
+         "id": "1ShrevNfMsRy3Go6JQf6ipqsWdEpb7St406n0ZZHkTo0",
          "name": "File D",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1avp5m0mME29n1ztKk82n1PuyEXuB4sKV"
+          "1ln1xSI27jmVn3dJIE2Jwx7EVHMeet6zo"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=12N0OSpQ1HUwztJiCfZagE3Mp9fB7GTeBp8SampYRsuM&v=1&s=AMedNnoAAAAAW-KezNqTbxBaQFh8Nl4RyPz3Bf_-rTSd&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1ShrevNfMsRy3Go6JQf6ipqsWdEpb7St406n0ZZHkTo0&v=1&s=AMedNnoAAAAAW-OuzXsgrT-5Vk2nj0R0GjwUKkVpVe13&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -6506,10 +6521,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:04 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:37 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1vc8bE4K4KLTCOZEqW4Gn-vlKYS-ojGp91wN4t5KpvKM?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ
+    uri: https://www.googleapis.com/drive/v3/files/1NuOu6EfHFmVEkmscjdSP_Tgcua-0-9MZnkvIv1rnsk8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1
     body:
       encoding: UTF-8
       string: ''
@@ -6521,7 +6536,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:04 GMT
+      - Thu, 08 Nov 2018 01:34:37 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -6538,7 +6553,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:14:05 GMT
+      - Thu, 08 Nov 2018 01:34:38 GMT
       Vary:
       - Origin
       - X-Origin
@@ -6550,10 +6565,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:05 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:38 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -6565,7 +6580,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:05 GMT
+      - Thu, 08 Nov 2018 01:34:38 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -6576,9 +6591,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:14:05 GMT
+      - Thu, 08 Nov 2018 01:34:38 GMT
       Date:
-      - Wed, 07 Nov 2018 06:14:05 GMT
+      - Thu, 08 Nov 2018 01:34:38 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -6604,8 +6619,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ",
-         "name": "Test @ 2018-11-07 06:12:30 UTC",
+         "id": "1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1",
+         "name": "Test @ 2018-11-08 01:32:59 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -6631,10 +6646,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:05 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:38 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -6646,7 +6661,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:05 GMT
+      - Thu, 08 Nov 2018 01:34:38 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -6664,9 +6679,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 07 Nov 2018 06:14:05 GMT
+      - Thu, 08 Nov 2018 01:34:38 GMT
       Expires:
-      - Wed, 07 Nov 2018 06:14:05 GMT
+      - Thu, 08 Nov 2018 01:34:38 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -6698,10 +6713,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:05 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:39 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1ebr5Wp_oSjfqsNT_AYkPlsIkTZ2Hmg1TtqTeCN_Btiw?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1h8hoCjL1fXLkPu0drS4FIJLZSUEXKj7o_GerEVkoUQ4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -6713,7 +6728,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:05 GMT
+      - Thu, 08 Nov 2018 01:34:39 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -6724,9 +6739,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:14:05 GMT
+      - Thu, 08 Nov 2018 01:34:39 GMT
       Date:
-      - Wed, 07 Nov 2018 06:14:05 GMT
+      - Thu, 08 Nov 2018 01:34:39 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -6752,14 +6767,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1ebr5Wp_oSjfqsNT_AYkPlsIkTZ2Hmg1TtqTeCN_Btiw",
+         "id": "1h8hoCjL1fXLkPu0drS4FIJLZSUEXKj7o_GerEVkoUQ4",
          "name": "File C",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5"
+          "1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1ebr5Wp_oSjfqsNT_AYkPlsIkTZ2Hmg1TtqTeCN_Btiw&v=1&s=AMedNnoAAAAAW-KezcMJ6v6OzPkCIavg5BDaOz09gHMe&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1h8hoCjL1fXLkPu0drS4FIJLZSUEXKj7o_GerEVkoUQ4&v=1&s=AMedNnoAAAAAW-OuzzZ6DFl_-lQ2VF30UOiYyUfrSMNc&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -6783,10 +6798,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:05 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:39 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1ebr5Wp_oSjfqsNT_AYkPlsIkTZ2Hmg1TtqTeCN_Btiw/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1h8hoCjL1fXLkPu0drS4FIJLZSUEXKj7o_GerEVkoUQ4/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -6798,7 +6813,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:05 GMT
+      - Thu, 08 Nov 2018 01:34:39 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -6809,9 +6824,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:14:06 GMT
+      - Thu, 08 Nov 2018 01:34:40 GMT
       Date:
-      - Wed, 07 Nov 2018 06:14:06 GMT
+      - Thu, 08 Nov 2018 01:34:40 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -6840,13 +6855,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-11-07T06:12:59.297Z"
+         "modifiedTime": "2018-11-08T01:33:19.213Z"
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:06 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:40 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1avp5m0mME29n1ztKk82n1PuyEXuB4sKV?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ln1xSI27jmVn3dJIE2Jwx7EVHMeet6zo?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -6858,7 +6873,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:06 GMT
+      - Thu, 08 Nov 2018 01:34:40 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -6869,9 +6884,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:14:06 GMT
+      - Thu, 08 Nov 2018 01:34:40 GMT
       Date:
-      - Wed, 07 Nov 2018 06:14:06 GMT
+      - Thu, 08 Nov 2018 01:34:40 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -6897,12 +6912,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1avp5m0mME29n1ztKk82n1PuyEXuB4sKV",
+         "id": "1ln1xSI27jmVn3dJIE2Jwx7EVHMeet6zo",
          "name": "Fol 3",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ"
+          "1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -6927,10 +6942,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:06 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:40 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1avp5m0mME29n1ztKk82n1PuyEXuB4sKV/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1ln1xSI27jmVn3dJIE2Jwx7EVHMeet6zo/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -6942,7 +6957,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:06 GMT
+      - Thu, 08 Nov 2018 01:34:40 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -6960,9 +6975,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 07 Nov 2018 06:14:06 GMT
+      - Thu, 08 Nov 2018 01:34:40 GMT
       Expires:
-      - Wed, 07 Nov 2018 06:14:06 GMT
+      - Thu, 08 Nov 2018 01:34:40 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -6994,10 +7009,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:06 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:40 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1pJKmPVsDi4sj27umEonP4hisTAshnwWs?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -7009,7 +7024,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:06 GMT
+      - Thu, 08 Nov 2018 01:34:40 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -7020,9 +7035,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:14:06 GMT
+      - Thu, 08 Nov 2018 01:34:40 GMT
       Date:
-      - Wed, 07 Nov 2018 06:14:06 GMT
+      - Thu, 08 Nov 2018 01:34:40 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -7048,12 +7063,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY",
+         "id": "1pJKmPVsDi4sj27umEonP4hisTAshnwWs",
          "name": "Fol 1",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ"
+          "1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -7078,10 +7093,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:06 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:40 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1pJKmPVsDi4sj27umEonP4hisTAshnwWs/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -7093,7 +7108,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:06 GMT
+      - Thu, 08 Nov 2018 01:34:40 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -7111,9 +7126,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 07 Nov 2018 06:14:06 GMT
+      - Thu, 08 Nov 2018 01:34:41 GMT
       Expires:
-      - Wed, 07 Nov 2018 06:14:06 GMT
+      - Thu, 08 Nov 2018 01:34:41 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -7145,10 +7160,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:06 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:41 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/14GP3SFnuu9zv4qDM-G4XFGGPkQva7yaM1Ib-YlEU5-0?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1j7r4zrEdQa4b4yf_trlB8OJgl4vOuUCZrzzwUFTaL0A?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -7160,7 +7175,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:06 GMT
+      - Thu, 08 Nov 2018 01:34:41 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -7171,9 +7186,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:14:07 GMT
+      - Thu, 08 Nov 2018 01:34:41 GMT
       Date:
-      - Wed, 07 Nov 2018 06:14:07 GMT
+      - Thu, 08 Nov 2018 01:34:41 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -7199,14 +7214,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "14GP3SFnuu9zv4qDM-G4XFGGPkQva7yaM1Ib-YlEU5-0",
+         "id": "1j7r4zrEdQa4b4yf_trlB8OJgl4vOuUCZrzzwUFTaL0A",
          "name": "File A",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY"
+          "1pJKmPVsDi4sj27umEonP4hisTAshnwWs"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=14GP3SFnuu9zv4qDM-G4XFGGPkQva7yaM1Ib-YlEU5-0&v=1&s=AMedNnoAAAAAW-Kez5whVHz6H45hCFL6xmDdQrIMRegY&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1j7r4zrEdQa4b4yf_trlB8OJgl4vOuUCZrzzwUFTaL0A&v=1&s=AMedNnoAAAAAW-Ou0XYWtip0Fi2Y-ixYbO9uGZJGrNiZ&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -7230,10 +7245,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:07 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:41 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/14GP3SFnuu9zv4qDM-G4XFGGPkQva7yaM1Ib-YlEU5-0/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1j7r4zrEdQa4b4yf_trlB8OJgl4vOuUCZrzzwUFTaL0A/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -7245,7 +7260,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:07 GMT
+      - Thu, 08 Nov 2018 01:34:41 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -7256,9 +7271,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:14:07 GMT
+      - Thu, 08 Nov 2018 01:34:41 GMT
       Date:
-      - Wed, 07 Nov 2018 06:14:07 GMT
+      - Thu, 08 Nov 2018 01:34:41 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -7287,13 +7302,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-11-07T06:13:54.167Z"
+         "modifiedTime": "2018-11-08T01:34:30.287Z"
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:07 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:41 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=14GP3SFnuu9zv4qDM-G4XFGGPkQva7yaM1Ib-YlEU5-0&s=AMedNnoAAAAAW-Kez5whVHz6H45hCFL6xmDdQrIMRegY&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1j7r4zrEdQa4b4yf_trlB8OJgl4vOuUCZrzzwUFTaL0A&s=AMedNnoAAAAAW-Ou0XYWtip0Fi2Y-ixYbO9uGZJGrNiZ&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -7305,7 +7320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:07 GMT
+      - Thu, 08 Nov 2018 01:34:41 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -7336,7 +7351,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Nov 2018 06:14:07 GMT
+      - Thu, 08 Nov 2018 01:34:42 GMT
       Server:
       - fife
       Content-Length:
@@ -7350,96 +7365,10 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAAE/ElEQVR4nO3dvUocWACG4cmS2JhIEEQEwWpqRQwkoJ2X4LWlzUWkTmWTZiBlCouIgjA6YUDwZ3ScLfYG3hTDssvzdKf7mpcDpzmvFovFAAj++rcHwH+GWqBSC1RqgUotUKkFKrVApRao1AKVWqBSC1RqgUotUKkFKrVApRao1AKVWqBSC1RqgUotUKkFKrVApRao1AKVWqBSC1RqgUotUKkFKrVApRaoll7L4+PjZDJ5enpaLBaz2ez5+fnl5WU8Hg8Gg7u7u9vb28Fg8M/x/v5+Op3e3t4+Pz8vFovJZLLsbfBHXi37b7CvX79eXFwMh8ONjY3Pnz+fnJxcX1+vrKy8f//+27dvBwcH6+vrr1+/Ho/HP378GA6Ha2trDw8P8/n86elpd3d3f39/qfOgW+7dMp/Pb25u3rx5s729/eXLl0+fPo3H48vLy42Njfl8fnx8/OvXr9FodHh4eH19vbW1dXBwcHR09Pj4eHZ2trW1NZvNljoP/sjS75bv37+/vLwMh8Orq6udnZ3pdLq6ujoajT58+HB2djabzXZ3d09PT/f29n7//r25ubm6unp+fv727dufP39+/Pjx3bt3S50H3dJrgf8Nb2JQqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqB6m8cT6OKpreeCQAAAABJRU5ErkJggg==
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:07 GMT
-- request:
-    method: post
-    uri: https://www.googleapis.com/drive/v3/files/14GP3SFnuu9zv4qDM-G4XFGGPkQva7yaM1Ib-YlEU5-0/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: '{"name":"File A","parents":["1Fbo5u06J4KOCs7nhXvcTwEZ1OdKW4j7W"]}'
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 07 Nov 2018 06:14:07 GMT
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Wed, 07 Nov 2018 06:14:09 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1WTjTycvqTKchfLuL3k35TtbqctPBkGRHS0eYjO7en-c",
-         "name": "File A",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1Fbo5u06J4KOCs7nhXvcTwEZ1OdKW4j7W"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:09 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:42 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1lGzjqMvzraScFNLWxfdHkbLrtbw7AK8BFliLhkVJSII?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1N3z8E7p3ICKbuKY3ax4XqCyhDVlxwuL1ik7bHitoSeA?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -7451,7 +7380,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:09 GMT
+      - Thu, 08 Nov 2018 01:34:42 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -7469,9 +7398,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 07 Nov 2018 06:14:10 GMT
+      - Thu, 08 Nov 2018 01:34:42 GMT
       Expires:
-      - Wed, 07 Nov 2018 06:14:10 GMT
+      - Thu, 08 Nov 2018 01:34:42 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -7495,20 +7424,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1lGzjqMvzraScFNLWxfdHkbLrtbw7AK8BFliLhkVJSII.",
+            "message": "File not found: 1N3z8E7p3ICKbuKY3ax4XqCyhDVlxwuL1ik7bHitoSeA.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1lGzjqMvzraScFNLWxfdHkbLrtbw7AK8BFliLhkVJSII."
+          "message": "File not found: 1N3z8E7p3ICKbuKY3ax4XqCyhDVlxwuL1ik7bHitoSeA."
          }
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:10 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:42 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -7520,7 +7449,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:10 GMT
+      - Thu, 08 Nov 2018 01:34:42 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -7531,9 +7460,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:14:10 GMT
+      - Thu, 08 Nov 2018 01:34:42 GMT
       Date:
-      - Wed, 07 Nov 2018 06:14:10 GMT
+      - Thu, 08 Nov 2018 01:34:42 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -7559,12 +7488,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5",
+         "id": "1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT",
          "name": "Fol 2",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ"
+          "1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -7589,10 +7518,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:10 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:42 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -7604,7 +7533,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:10 GMT
+      - Thu, 08 Nov 2018 01:34:42 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -7622,9 +7551,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 07 Nov 2018 06:14:10 GMT
+      - Thu, 08 Nov 2018 01:34:42 GMT
       Expires:
-      - Wed, 07 Nov 2018 06:14:10 GMT
+      - Thu, 08 Nov 2018 01:34:42 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -7656,10 +7585,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:10 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:43 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1OGygyBPY3jNqW2BXToQdQA3x-djD_jaKDUp_oHpsy4M?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1XDDsny4mnHbmJ5xiuZv4lpGFf3IMHGdipRMqhOEy4lg?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -7671,7 +7600,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:10 GMT
+      - Thu, 08 Nov 2018 01:34:43 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -7682,9 +7611,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:14:10 GMT
+      - Thu, 08 Nov 2018 01:34:43 GMT
       Date:
-      - Wed, 07 Nov 2018 06:14:10 GMT
+      - Thu, 08 Nov 2018 01:34:43 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -7710,14 +7639,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1OGygyBPY3jNqW2BXToQdQA3x-djD_jaKDUp_oHpsy4M",
+         "id": "1XDDsny4mnHbmJ5xiuZv4lpGFf3IMHGdipRMqhOEy4lg",
          "name": "File B",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5"
+          "1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1OGygyBPY3jNqW2BXToQdQA3x-djD_jaKDUp_oHpsy4M&v=1&s=AMedNnoAAAAAW-Ke0p6V8u0RVq46nM3hzYdq8wfrTXEZ&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1XDDsny4mnHbmJ5xiuZv4lpGFf3IMHGdipRMqhOEy4lg&v=1&s=AMedNnoAAAAAW-Ou04ZIGtKf0eSPDhlVEGVE2bPqCP-z&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -7741,10 +7670,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:10 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:43 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1OGygyBPY3jNqW2BXToQdQA3x-djD_jaKDUp_oHpsy4M/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1XDDsny4mnHbmJ5xiuZv4lpGFf3IMHGdipRMqhOEy4lg/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -7756,7 +7685,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:10 GMT
+      - Thu, 08 Nov 2018 01:34:43 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -7767,9 +7696,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:14:11 GMT
+      - Thu, 08 Nov 2018 01:34:43 GMT
       Date:
-      - Wed, 07 Nov 2018 06:14:11 GMT
+      - Thu, 08 Nov 2018 01:34:43 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -7798,13 +7727,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-11-07T06:14:00.679Z"
+         "modifiedTime": "2018-11-08T01:34:35.434Z"
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:11 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:43 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1OGygyBPY3jNqW2BXToQdQA3x-djD_jaKDUp_oHpsy4M&s=AMedNnoAAAAAW-Ke0p6V8u0RVq46nM3hzYdq8wfrTXEZ&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1XDDsny4mnHbmJ5xiuZv4lpGFf3IMHGdipRMqhOEy4lg&s=AMedNnoAAAAAW-Ou04ZIGtKf0eSPDhlVEGVE2bPqCP-z&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -7816,7 +7745,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:11 GMT
+      - Thu, 08 Nov 2018 01:34:43 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -7847,7 +7776,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 07 Nov 2018 06:14:11 GMT
+      - Thu, 08 Nov 2018 01:34:43 GMT
       Server:
       - fife
       Content-Length:
@@ -7861,96 +7790,10 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAAEiUlEQVR4nO3dPUprUQBG0eQRRUIgndiI2FsJ6QUdqmBv4xQsHYOF4A+oaYSrRqewi1we77HWAO75ms2B09zpz8/PBAj+/O0B8M9QC1RqgUotUKkFKrVApRao1AKVWqBSC1RqgUotUKkFKrVApRao1AKVWqBSC1RqgUotUKkFKrVApRao1AKVWqBSC1RqgUotUKkFKrVApRao1ALV6LUMw/D29vb19fX+/v79/f38/DyZTD4/P19eXtbr9dXV1dgDYFtmo359s9lcXl4uFovDw8Obm5uTk5PNZrO7uzufz+/v74+Pjx8fH0cdAFs07t0yDMNisVitVsMwnJ+fr9frg4OD2Wz29PQ0n88nk8n+/v6oA2CLxr1b9vb2lsvl9fX1xcXFcrk8PT29vb1drVYPDw8fHx9HR0c7OzujDoAtmo79l9a7u7vX19ezs7PpdDrqQTC20WuB/4YXZKjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQUqtUClFqjUApVaoFILVGqBSi1QqQWqX/2XWP6W93tFAAAAAElFTkSuQmCC
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:11 GMT
-- request:
-    method: post
-    uri: https://www.googleapis.com/drive/v3/files/1OGygyBPY3jNqW2BXToQdQA3x-djD_jaKDUp_oHpsy4M/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: '{"name":"File B","parents":["1Fbo5u06J4KOCs7nhXvcTwEZ1OdKW4j7W"]}'
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 07 Nov 2018 06:14:11 GMT
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Wed, 07 Nov 2018 06:14:13 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1B8mG4kDobHjJavBXpbT3K9GrQOPdAz5G4Tphh-QLS1M",
-         "name": "File B",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1Fbo5u06J4KOCs7nhXvcTwEZ1OdKW4j7W"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:13 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:43 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/12N0OSpQ1HUwztJiCfZagE3Mp9fB7GTeBp8SampYRsuM?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ShrevNfMsRy3Go6JQf6ipqsWdEpb7St406n0ZZHkTo0?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -7962,7 +7805,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:13 GMT
+      - Thu, 08 Nov 2018 01:34:44 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -7973,9 +7816,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:14:13 GMT
+      - Thu, 08 Nov 2018 01:34:44 GMT
       Date:
-      - Wed, 07 Nov 2018 06:14:13 GMT
+      - Thu, 08 Nov 2018 01:34:44 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -8001,14 +7844,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "12N0OSpQ1HUwztJiCfZagE3Mp9fB7GTeBp8SampYRsuM",
+         "id": "1ShrevNfMsRy3Go6JQf6ipqsWdEpb7St406n0ZZHkTo0",
          "name": "File D",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1avp5m0mME29n1ztKk82n1PuyEXuB4sKV"
+          "1ln1xSI27jmVn3dJIE2Jwx7EVHMeet6zo"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=12N0OSpQ1HUwztJiCfZagE3Mp9fB7GTeBp8SampYRsuM&v=1&s=AMedNnoAAAAAW-Ke1XO7mBtHr-i7pu78ByG-f3qz0Kz7&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1ShrevNfMsRy3Go6JQf6ipqsWdEpb7St406n0ZZHkTo0&v=1&s=AMedNnoAAAAAW-Ou1DKHgKqUc5If12W8KjTK5FvytW9Y&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -8032,10 +7875,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:13 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:44 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/12N0OSpQ1HUwztJiCfZagE3Mp9fB7GTeBp8SampYRsuM/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1ShrevNfMsRy3Go6JQf6ipqsWdEpb7St406n0ZZHkTo0/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -8047,7 +7890,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:13 GMT
+      - Thu, 08 Nov 2018 01:34:44 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -8058,9 +7901,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:14:13 GMT
+      - Thu, 08 Nov 2018 01:34:44 GMT
       Date:
-      - Wed, 07 Nov 2018 06:14:13 GMT
+      - Thu, 08 Nov 2018 01:34:44 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -8089,13 +7932,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-11-07T06:13:01.561Z"
+         "modifiedTime": "2018-11-08T01:33:21.114Z"
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:13 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:44 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1vc8bE4K4KLTCOZEqW4Gn-vlKYS-ojGp91wN4t5KpvKM?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1NuOu6EfHFmVEkmscjdSP_Tgcua-0-9MZnkvIv1rnsk8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -8107,7 +7950,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:13 GMT
+      - Thu, 08 Nov 2018 01:34:44 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -8125,9 +7968,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 07 Nov 2018 06:14:13 GMT
+      - Thu, 08 Nov 2018 01:34:45 GMT
       Expires:
-      - Wed, 07 Nov 2018 06:14:13 GMT
+      - Thu, 08 Nov 2018 01:34:45 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -8151,20 +7994,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1vc8bE4K4KLTCOZEqW4Gn-vlKYS-ojGp91wN4t5KpvKM.",
+            "message": "File not found: 1NuOu6EfHFmVEkmscjdSP_Tgcua-0-9MZnkvIv1rnsk8.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1vc8bE4K4KLTCOZEqW4Gn-vlKYS-ojGp91wN4t5KpvKM."
+          "message": "File not found: 1NuOu6EfHFmVEkmscjdSP_Tgcua-0-9MZnkvIv1rnsk8."
          }
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:13 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:45 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271avp5m0mME29n1ztKk82n1PuyEXuB4sKV%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271ln1xSI27jmVn3dJIE2Jwx7EVHMeet6zo%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -8176,7 +8019,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:13 GMT
+      - Thu, 08 Nov 2018 01:34:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -8187,9 +8030,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:14:13 GMT
+      - Thu, 08 Nov 2018 01:34:45 GMT
       Date:
-      - Wed, 07 Nov 2018 06:14:13 GMT
+      - Thu, 08 Nov 2018 01:34:45 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -8217,14 +8060,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "12N0OSpQ1HUwztJiCfZagE3Mp9fB7GTeBp8SampYRsuM",
+           "id": "1ShrevNfMsRy3Go6JQf6ipqsWdEpb7St406n0ZZHkTo0",
            "name": "File D",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1avp5m0mME29n1ztKk82n1PuyEXuB4sKV"
+            "1ln1xSI27jmVn3dJIE2Jwx7EVHMeet6zo"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=12N0OSpQ1HUwztJiCfZagE3Mp9fB7GTeBp8SampYRsuM&v=1&s=AMedNnoAAAAAW-Ke1XO7mBtHr-i7pu78ByG-f3qz0Kz7&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1ShrevNfMsRy3Go6JQf6ipqsWdEpb7St406n0ZZHkTo0&v=1&s=AMedNnoAAAAAW-Ou1VPye2l5qDiYqbOEltA-OkmRarMu&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -8250,10 +8093,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:13 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:45 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271pJKmPVsDi4sj27umEonP4hisTAshnwWs%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -8265,7 +8108,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:13 GMT
+      - Thu, 08 Nov 2018 01:34:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -8276,9 +8119,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:14:13 GMT
+      - Thu, 08 Nov 2018 01:34:45 GMT
       Date:
-      - Wed, 07 Nov 2018 06:14:13 GMT
+      - Thu, 08 Nov 2018 01:34:45 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -8306,14 +8149,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "14GP3SFnuu9zv4qDM-G4XFGGPkQva7yaM1Ib-YlEU5-0",
+           "id": "1j7r4zrEdQa4b4yf_trlB8OJgl4vOuUCZrzzwUFTaL0A",
            "name": "File A",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY"
+            "1pJKmPVsDi4sj27umEonP4hisTAshnwWs"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=14GP3SFnuu9zv4qDM-G4XFGGPkQva7yaM1Ib-YlEU5-0&v=1&s=AMedNnoAAAAAW-Ke1WwAo4rmwPrkj-15PdnsAn8-Qb2R&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1j7r4zrEdQa4b4yf_trlB8OJgl4vOuUCZrzzwUFTaL0A&v=1&s=AMedNnoAAAAAW-Ou1QTAlWi3OCSwyTnAN-KnKNCjM636&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -8339,10 +8182,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:13 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:46 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -8354,7 +8197,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:14 GMT
+      - Thu, 08 Nov 2018 01:34:46 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -8365,9 +8208,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:14:15 GMT
+      - Thu, 08 Nov 2018 01:34:46 GMT
       Date:
-      - Wed, 07 Nov 2018 06:14:15 GMT
+      - Thu, 08 Nov 2018 01:34:46 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -8395,14 +8238,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1OGygyBPY3jNqW2BXToQdQA3x-djD_jaKDUp_oHpsy4M",
+           "id": "1XDDsny4mnHbmJ5xiuZv4lpGFf3IMHGdipRMqhOEy4lg",
            "name": "File B",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5"
+            "1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1OGygyBPY3jNqW2BXToQdQA3x-djD_jaKDUp_oHpsy4M&v=1&s=AMedNnoAAAAAW-Ke12pxMi_QDc8pzp7xUo067FVs5zuy&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1XDDsny4mnHbmJ5xiuZv4lpGFf3IMHGdipRMqhOEy4lg&v=1&s=AMedNnoAAAAAW-Ou1ti_Y5DDpJCRIoqpgOK9j19YsbAH&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -8426,14 +8269,14 @@ http_interactions:
            ]
           },
           {
-           "id": "1ebr5Wp_oSjfqsNT_AYkPlsIkTZ2Hmg1TtqTeCN_Btiw",
+           "id": "1h8hoCjL1fXLkPu0drS4FIJLZSUEXKj7o_GerEVkoUQ4",
            "name": "File C",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5"
+            "1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1ebr5Wp_oSjfqsNT_AYkPlsIkTZ2Hmg1TtqTeCN_Btiw&v=1&s=AMedNnoAAAAAW-Ke18Yk70q-Ot6kjSUfga-XY_nNq-Mz&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1h8hoCjL1fXLkPu0drS4FIJLZSUEXKj7o_GerEVkoUQ4&v=1&s=AMedNnoAAAAAW-Ou1nbeq2wtkY8TNEZ7PRARESDuGWE6&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -8459,10 +8302,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:15 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:46 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271NTe1qMlosZUPFjPrPa2IvsznfsDecDF1%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -8474,7 +8317,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:15 GMT
+      - Thu, 08 Nov 2018 01:34:47 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -8485,9 +8328,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 07 Nov 2018 06:14:18 GMT
+      - Thu, 08 Nov 2018 01:34:47 GMT
       Date:
-      - Wed, 07 Nov 2018 06:14:18 GMT
+      - Thu, 08 Nov 2018 01:34:47 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -8515,12 +8358,12 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1rG7HaJAvKdy6_H5lrB2RBR-zhgA4m3uY",
+           "id": "1pJKmPVsDi4sj27umEonP4hisTAshnwWs",
            "name": "Fol 1",
            "mimeType": "application/vnd.google-apps.folder",
            "trashed": false,
            "parents": [
-            "1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ"
+            "1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -8545,12 +8388,12 @@ http_interactions:
            ]
           },
           {
-           "id": "1avp5m0mME29n1ztKk82n1PuyEXuB4sKV",
+           "id": "1ln1xSI27jmVn3dJIE2Jwx7EVHMeet6zo",
            "name": "Fol 3",
            "mimeType": "application/vnd.google-apps.folder",
            "trashed": false,
            "parents": [
-            "1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ"
+            "1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -8575,12 +8418,12 @@ http_interactions:
            ]
           },
           {
-           "id": "1nqA-OS-Aps1PEL0Y7oJn95gC1-7MzkU5",
+           "id": "1MPgazi_06SWmD7Q_tJ9gNJWTt9XuwewT",
            "name": "Fol 2",
            "mimeType": "application/vnd.google-apps.folder",
            "trashed": false,
            "parents": [
-            "1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ"
+            "1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -8607,10 +8450,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:18 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:47 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1KrjIkDnyXl7tkMaDnp9AeOHz2Te3vXHJ
+    uri: https://www.googleapis.com/drive/v3/files/1NTe1qMlosZUPFjPrPa2IvsznfsDecDF1
     body:
       encoding: UTF-8
       string: ''
@@ -8622,7 +8465,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 07 Nov 2018 06:14:18 GMT
+      - Thu, 08 Nov 2018 01:34:47 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -8639,7 +8482,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 07 Nov 2018 06:14:19 GMT
+      - Thu, 08 Nov 2018 01:34:48 GMT
       Vary:
       - Origin
       - X-Origin
@@ -8651,5 +8494,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 07 Nov 2018 06:14:19 GMT
+  recorded_at: Thu, 08 Nov 2018 01:34:48 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/VCS_Operations_FileRestore/_restore/when_file_content_differs_from_snapshot_content/is_modifies_the_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/VCS_Operations_FileRestore/_restore/when_file_content_differs_from_snapshot_content/is_modifies_the_file.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Wed, 31 Oct 2018 07:15:09 GMT
+      - Thu, 08 Nov 2018 01:30:33 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,14 +53,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:15:09 GMT
+  recorded_at: Thu, 08 Nov 2018 01:30:33 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-31
-        07:15:09 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-11-08
+        01:30:33 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -69,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:15:09 GMT
+      - Thu, 08 Nov 2018 01:30:33 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -86,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:15:10 GMT
+      - Thu, 08 Nov 2018 01:30:34 GMT
       Vary:
       - Origin
       - X-Origin
@@ -110,8 +110,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1D7w1G7FKyDfTD4XFJ9NpRulJYt3VDRfH",
-         "name": "Test @ 2018-10-31 07:15:09 UTC",
+         "id": "1jyx7JkZdHnvZabe5GmiF3ZuLznUr7kS6",
+         "name": "Test @ 2018-11-08 01:30:33 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -131,13 +131,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:15:10 GMT
+  recorded_at: Thu, 08 Nov 2018 01:30:34 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1D7w1G7FKyDfTD4XFJ9NpRulJYt3VDRfH"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1jyx7JkZdHnvZabe5GmiF3ZuLznUr7kS6"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -146,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:15:10 GMT
+      - Thu, 08 Nov 2018 01:30:34 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -163,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:15:11 GMT
+      - Thu, 08 Nov 2018 01:30:35 GMT
       Vary:
       - Origin
       - X-Origin
@@ -187,12 +187,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1Fy3XhHn03BzG8QOFvg2cBohGuTonoouu",
+         "id": "1UONydeugowk44a63pl4MbjfXqg26Of6J",
          "name": "Folder",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1D7w1G7FKyDfTD4XFJ9NpRulJYt3VDRfH"
+          "1jyx7JkZdHnvZabe5GmiF3ZuLznUr7kS6"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -208,14 +208,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:15:11 GMT
+  recorded_at: Thu, 08 Nov 2018 01:30:35 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.document","name":"original
-        name","parents":["1Fy3XhHn03BzG8QOFvg2cBohGuTonoouu"]}'
+        name","parents":["1UONydeugowk44a63pl4MbjfXqg26Of6J"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -224,7 +224,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:15:11 GMT
+      - Thu, 08 Nov 2018 01:30:35 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -241,7 +241,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:15:12 GMT
+      - Thu, 08 Nov 2018 01:30:36 GMT
       Vary:
       - Origin
       - X-Origin
@@ -265,12 +265,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1s84BhZ9PgQEv4BhUypB6kkobjrmWR0wuJlqs0WcG0RA",
+         "id": "1ZUsyIvmPhw-fFlgprjL4Ayz6lG_HgVYlPpohm0HyDyM",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1Fy3XhHn03BzG8QOFvg2cBohGuTonoouu"
+          "1UONydeugowk44a63pl4MbjfXqg26Of6J"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -286,14 +286,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:15:12 GMT
+  recorded_at: Thu, 08 Nov 2018 01:30:36 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"4 Krikkit
-        One (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"2 Bistromath
+        (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -302,7 +302,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:15:12 GMT
+      - Thu, 08 Nov 2018 01:30:36 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -319,7 +319,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:15:13 GMT
+      - Thu, 08 Nov 2018 01:30:36 GMT
       Vary:
       - Origin
       - X-Origin
@@ -343,8 +343,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1Tlc16iVps93qBfIQLl5v1-7wxXwLfYDA",
-         "name": "4 Krikkit One (Archive)",
+         "id": "174FdEzn7RD3K0lQX8QozY5MiUc7jFowu",
+         "name": "2 Bistromath (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -364,10 +364,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:15:13 GMT
+  recorded_at: Thu, 08 Nov 2018 01:30:37 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1Tlc16iVps93qBfIQLl5v1-7wxXwLfYDA/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/174FdEzn7RD3K0lQX8QozY5MiUc7jFowu/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -379,7 +379,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:15:13 GMT
+      - Thu, 08 Nov 2018 01:30:37 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -396,7 +396,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:15:16 GMT
+      - Thu, 08 Nov 2018 01:30:37 GMT
       Vary:
       - Origin
       - X-Origin
@@ -426,10 +426,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:15:16 GMT
+  recorded_at: Thu, 08 Nov 2018 01:30:38 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1s84BhZ9PgQEv4BhUypB6kkobjrmWR0wuJlqs0WcG0RA?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ZUsyIvmPhw-fFlgprjL4Ayz6lG_HgVYlPpohm0HyDyM?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -441,7 +441,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:15:16 GMT
+      - Thu, 08 Nov 2018 01:30:38 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -452,9 +452,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 07:15:16 GMT
+      - Thu, 08 Nov 2018 01:30:38 GMT
       Date:
-      - Wed, 31 Oct 2018 07:15:16 GMT
+      - Thu, 08 Nov 2018 01:30:38 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -480,14 +480,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1s84BhZ9PgQEv4BhUypB6kkobjrmWR0wuJlqs0WcG0RA",
+         "id": "1ZUsyIvmPhw-fFlgprjL4Ayz6lG_HgVYlPpohm0HyDyM",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1Fy3XhHn03BzG8QOFvg2cBohGuTonoouu"
+          "1UONydeugowk44a63pl4MbjfXqg26Of6J"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1s84BhZ9PgQEv4BhUypB6kkobjrmWR0wuJlqs0WcG0RA&v=1&s=AMedNnoAAAAAW9lypMTAjgzgVGO-cokCD1H5Tcod3GfS&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1ZUsyIvmPhw-fFlgprjL4Ayz6lG_HgVYlPpohm0HyDyM&v=1&s=AMedNnoAAAAAW-Ot3qv-Iz5PKj8D0kB1i5jhDJwfj_zZ&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -502,10 +502,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:15:16 GMT
+  recorded_at: Thu, 08 Nov 2018 01:30:38 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1s84BhZ9PgQEv4BhUypB6kkobjrmWR0wuJlqs0WcG0RA/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1ZUsyIvmPhw-fFlgprjL4Ayz6lG_HgVYlPpohm0HyDyM/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -517,7 +517,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:15:16 GMT
+      - Thu, 08 Nov 2018 01:30:38 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -528,9 +528,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 07:15:16 GMT
+      - Thu, 08 Nov 2018 01:30:38 GMT
       Date:
-      - Wed, 31 Oct 2018 07:15:16 GMT
+      - Thu, 08 Nov 2018 01:30:38 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -559,13 +559,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-31T07:15:11.453Z"
+         "modifiedTime": "2018-11-08T01:30:35.487Z"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:15:16 GMT
+  recorded_at: Thu, 08 Nov 2018 01:30:38 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1s84BhZ9PgQEv4BhUypB6kkobjrmWR0wuJlqs0WcG0RA&s=AMedNnoAAAAAW9lypMTAjgzgVGO-cokCD1H5Tcod3GfS&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1ZUsyIvmPhw-fFlgprjL4Ayz6lG_HgVYlPpohm0HyDyM&s=AMedNnoAAAAAW-Ot3qv-Iz5PKj8D0kB1i5jhDJwfj_zZ&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -577,7 +577,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:15:16 GMT
+      - Thu, 08 Nov 2018 01:30:38 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -608,7 +608,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 31 Oct 2018 07:15:17 GMT
+      - Thu, 08 Nov 2018 01:30:39 GMT
       Server:
       - fife
       Content-Length:
@@ -622,13 +622,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:15:17 GMT
+  recorded_at: Thu, 08 Nov 2018 01:30:39 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1s84BhZ9PgQEv4BhUypB6kkobjrmWR0wuJlqs0WcG0RA/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ZUsyIvmPhw-fFlgprjL4Ayz6lG_HgVYlPpohm0HyDyM/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"original name","parents":["1Tlc16iVps93qBfIQLl5v1-7wxXwLfYDA"]}'
+      string: '{"name":"original name","parents":["174FdEzn7RD3K0lQX8QozY5MiUc7jFowu"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -637,7 +637,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:15:17 GMT
+      - Thu, 08 Nov 2018 01:30:39 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -654,7 +654,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:15:18 GMT
+      - Thu, 08 Nov 2018 01:30:40 GMT
       Vary:
       - Origin
       - X-Origin
@@ -678,12 +678,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1gZzRgIqgrf1LViakXv2C5Oq-zXxVxbl7eFZ9DHnHDag",
+         "id": "11zOiNhgJNyCF4_QArDjZS2DUbvQfRPTAYJpo4BFC_ng",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1Tlc16iVps93qBfIQLl5v1-7wxXwLfYDA"
+          "174FdEzn7RD3K0lQX8QozY5MiUc7jFowu"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -708,10 +708,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:15:18 GMT
+  recorded_at: Thu, 08 Nov 2018 01:30:40 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/upload/drive/v3/files/1s84BhZ9PgQEv4BhUypB6kkobjrmWR0wuJlqs0WcG0RA
+    uri: https://www.googleapis.com/upload/drive/v3/files/1ZUsyIvmPhw-fFlgprjL4Ayz6lG_HgVYlPpohm0HyDyM
     body:
       encoding: UTF-8
       string: ''
@@ -723,7 +723,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:15:18 GMT
+      - Thu, 08 Nov 2018 01:30:40 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       X-Goog-Upload-Protocol:
@@ -742,22 +742,22 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2UqumpJKRrtiSZjz9UvPgYJE_VbXcq-JnlIOWX7CsOKuGPRYsj0LyvM6ZGqr8XgJe59MOALsAqrf5J4WSWl-sIHYgK2PQA
+      - AEnB2UoFIHmJacPSlziZZjnEhu8theCvBc4Kjai7lV2c4QzW7JynOuUEfc7mRUdN-4DYQwCjp7CHTGfFCwTO7otrqWJwtllBTg
       X-Goog-Upload-Status:
       - active
       X-Goog-Upload-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1s84BhZ9PgQEv4BhUypB6kkobjrmWR0wuJlqs0WcG0RA?upload_id=AEnB2UqumpJKRrtiSZjz9UvPgYJE_VbXcq-JnlIOWX7CsOKuGPRYsj0LyvM6ZGqr8XgJe59MOALsAqrf5J4WSWl-sIHYgK2PQA&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1ZUsyIvmPhw-fFlgprjL4Ayz6lG_HgVYlPpohm0HyDyM?upload_id=AEnB2UoFIHmJacPSlziZZjnEhu8theCvBc4Kjai7lV2c4QzW7JynOuUEfc7mRUdN-4DYQwCjp7CHTGfFCwTO7otrqWJwtllBTg&upload_protocol=resumable
       X-Goog-Upload-Control-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1s84BhZ9PgQEv4BhUypB6kkobjrmWR0wuJlqs0WcG0RA?upload_id=AEnB2UqumpJKRrtiSZjz9UvPgYJE_VbXcq-JnlIOWX7CsOKuGPRYsj0LyvM6ZGqr8XgJe59MOALsAqrf5J4WSWl-sIHYgK2PQA&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1ZUsyIvmPhw-fFlgprjL4Ayz6lG_HgVYlPpohm0HyDyM?upload_id=AEnB2UoFIHmJacPSlziZZjnEhu8theCvBc4Kjai7lV2c4QzW7JynOuUEfc7mRUdN-4DYQwCjp7CHTGfFCwTO7otrqWJwtllBTg&upload_protocol=resumable
       X-Goog-Upload-Chunk-Granularity:
       - '262144'
       X-Goog-Upload-Header-Vary:
       - Origin
       - X-Origin
       X-Goog-Upload-Header-X-Google-Backends:
-      - iobb66:4014
+      - oif62:4203
       X-Goog-Upload-Header-X-Google-Session-Info:
-      - CLrLzJuGFRoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x4SEJsUkFhWHpGVmFZOEhjOEtnQWdNc1NHbnl4SlZrcGppQ25uV3RDdndyb2RjR3BYZHBETmVPLWlYaHA2bmhJZ3lWdVIwcGFJZC1XUUNCNW1PV1pWblk1My1XM3FTZFdGYy1nRFUzU0ZadTlmZlp5dHhMd2dRMUoyN05RMAQ6DTEvMk0zUkd3d1ZsWn4
+      - CLrLzJuGFRoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqXARKDAXlhMjkuR2x4T0J2YTJIMVZVaWdBbGFZMjFkSE1uYnoxXzJHREhnMHZ3TUJld0dmLUtMdW0zNVhLaktUbWZXckVJNDBPRHNSMWdHa3ItbjVoUk5nbjE4SlZQSnEtclRmQ1ZjRFA0UEl1OXU1SnlrMWRRdUJsOVZtWDI2NV84ZWdYbi1RMAQ6DTEvMk0zUkd3d1ZsWn4
       X-Goog-Upload-Header-Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       X-Goog-Upload-Header-Pragma:
@@ -765,11 +765,11 @@ http_interactions:
       X-Goog-Upload-Header-Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       X-Goog-Upload-Header-Date:
-      - Wed, 31 Oct 2018 07:15:19 GMT
+      - Thu, 08 Nov 2018 01:30:41 GMT
       Content-Length:
       - '0'
       Date:
-      - Wed, 31 Oct 2018 07:15:19 GMT
+      - Thu, 08 Nov 2018 01:30:41 GMT
       Server:
       - UploadServer
       Content-Type:
@@ -780,10 +780,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:15:19 GMT
+  recorded_at: Thu, 08 Nov 2018 01:30:41 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/upload/drive/v3/files/1s84BhZ9PgQEv4BhUypB6kkobjrmWR0wuJlqs0WcG0RA?upload_id=AEnB2UqumpJKRrtiSZjz9UvPgYJE_VbXcq-JnlIOWX7CsOKuGPRYsj0LyvM6ZGqr8XgJe59MOALsAqrf5J4WSWl-sIHYgK2PQA&upload_protocol=resumable
+    uri: https://www.googleapis.com/upload/drive/v3/files/1ZUsyIvmPhw-fFlgprjL4Ayz6lG_HgVYlPpohm0HyDyM?upload_id=AEnB2UoFIHmJacPSlziZZjnEhu8theCvBc4Kjai7lV2c4QzW7JynOuUEfc7mRUdN-4DYQwCjp7CHTGfFCwTO7otrqWJwtllBTg&upload_protocol=resumable
     body:
       encoding: UTF-8
       string: new content
@@ -795,7 +795,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:15:19 GMT
+      - Thu, 08 Nov 2018 01:30:41 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       X-Goog-Upload-Command:
@@ -810,7 +810,7 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2UqumpJKRrtiSZjz9UvPgYJE_VbXcq-JnlIOWX7CsOKuGPRYsj0LyvM6ZGqr8XgJe59MOALsAqrf5J4WSWl-sIHYgK2PQA
+      - AEnB2UoFIHmJacPSlziZZjnEhu8theCvBc4Kjai7lV2c4QzW7JynOuUEfc7mRUdN-4DYQwCjp7CHTGfFCwTO7otrqWJwtllBTg
       X-Goog-Upload-Status:
       - final
       Vary:
@@ -825,7 +825,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:15:20 GMT
+      - Thu, 08 Nov 2018 01:30:42 GMT
       Content-Length:
       - '160'
       Server:
@@ -837,15 +837,15 @@ http_interactions:
       string: |
         {
          "kind": "drive#file",
-         "id": "1s84BhZ9PgQEv4BhUypB6kkobjrmWR0wuJlqs0WcG0RA",
+         "id": "1ZUsyIvmPhw-fFlgprjL4Ayz6lG_HgVYlPpohm0HyDyM",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.document"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:15:20 GMT
+  recorded_at: Thu, 08 Nov 2018 01:30:42 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1s84BhZ9PgQEv4BhUypB6kkobjrmWR0wuJlqs0WcG0RA?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ZUsyIvmPhw-fFlgprjL4Ayz6lG_HgVYlPpohm0HyDyM?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -857,7 +857,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:15:20 GMT
+      - Thu, 08 Nov 2018 01:30:42 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -868,9 +868,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 07:15:20 GMT
+      - Thu, 08 Nov 2018 01:30:42 GMT
       Date:
-      - Wed, 31 Oct 2018 07:15:20 GMT
+      - Thu, 08 Nov 2018 01:30:42 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -896,14 +896,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1s84BhZ9PgQEv4BhUypB6kkobjrmWR0wuJlqs0WcG0RA",
+         "id": "1ZUsyIvmPhw-fFlgprjL4Ayz6lG_HgVYlPpohm0HyDyM",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1Fy3XhHn03BzG8QOFvg2cBohGuTonoouu"
+          "1UONydeugowk44a63pl4MbjfXqg26Of6J"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1s84BhZ9PgQEv4BhUypB6kkobjrmWR0wuJlqs0WcG0RA&v=1&s=AMedNnoAAAAAW9lyqFZa53VPdXUMd8BlpFgJPgXJGa_8&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1ZUsyIvmPhw-fFlgprjL4Ayz6lG_HgVYlPpohm0HyDyM&v=1&s=AMedNnoAAAAAW-Ot4hEo34AFKSRlopUDTsOk-qAyrmMf&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -918,10 +918,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:15:20 GMT
+  recorded_at: Thu, 08 Nov 2018 01:30:42 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1s84BhZ9PgQEv4BhUypB6kkobjrmWR0wuJlqs0WcG0RA/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1ZUsyIvmPhw-fFlgprjL4Ayz6lG_HgVYlPpohm0HyDyM/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -933,7 +933,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:15:20 GMT
+      - Thu, 08 Nov 2018 01:30:42 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -944,9 +944,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 07:15:20 GMT
+      - Thu, 08 Nov 2018 01:30:43 GMT
       Date:
-      - Wed, 31 Oct 2018 07:15:20 GMT
+      - Thu, 08 Nov 2018 01:30:43 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -975,16 +975,16 @@ http_interactions:
          "kind": "drive#revision",
          "id": "3",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-31T07:15:19.720Z"
+         "modifiedTime": "2018-11-08T01:30:41.857Z"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:15:20 GMT
+  recorded_at: Thu, 08 Nov 2018 01:30:43 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1s84BhZ9PgQEv4BhUypB6kkobjrmWR0wuJlqs0WcG0RA/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ZUsyIvmPhw-fFlgprjL4Ayz6lG_HgVYlPpohm0HyDyM/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"original name","parents":["1Tlc16iVps93qBfIQLl5v1-7wxXwLfYDA"]}'
+      string: '{"name":"original name","parents":["174FdEzn7RD3K0lQX8QozY5MiUc7jFowu"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -993,7 +993,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:15:20 GMT
+      - Thu, 08 Nov 2018 01:30:43 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1010,7 +1010,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:15:22 GMT
+      - Thu, 08 Nov 2018 01:30:44 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1034,12 +1034,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1QsrfZvATOVUK5lSF5N6FYh0wgbgMGuvPYkmi-lIZeCY",
+         "id": "14qzgLqxvTIMHJS3YHnqiQQ_yKc7DqHorz_5bTlMkA44",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1Tlc16iVps93qBfIQLl5v1-7wxXwLfYDA"
+          "174FdEzn7RD3K0lQX8QozY5MiUc7jFowu"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1064,13 +1064,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:15:22 GMT
+  recorded_at: Thu, 08 Nov 2018 01:30:45 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1gZzRgIqgrf1LViakXv2C5Oq-zXxVxbl7eFZ9DHnHDag/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/11zOiNhgJNyCF4_QArDjZS2DUbvQfRPTAYJpo4BFC_ng/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"original name","parents":["1Fy3XhHn03BzG8QOFvg2cBohGuTonoouu"]}'
+      string: '{"name":"original name","parents":["1UONydeugowk44a63pl4MbjfXqg26Of6J"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1079,7 +1079,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:15:22 GMT
+      - Thu, 08 Nov 2018 01:30:45 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1096,7 +1096,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:15:24 GMT
+      - Thu, 08 Nov 2018 01:30:46 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1120,12 +1120,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1elYWewUmnAb4r3yHbiqx8MzzTmO-zVrxZNaThh4d5f8",
+         "id": "1nSCFRItZD4jojBTqfjDtYn0K5yTLEmkCB3eQa0eVZLk",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1Fy3XhHn03BzG8QOFvg2cBohGuTonoouu"
+          "1UONydeugowk44a63pl4MbjfXqg26Of6J"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1141,171 +1141,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:15:24 GMT
-- request:
-    method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1s84BhZ9PgQEv4BhUypB6kkobjrmWR0wuJlqs0WcG0RA?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1Fy3XhHn03BzG8QOFvg2cBohGuTonoouu
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 31 Oct 2018 07:15:24 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Wed, 31 Oct 2018 07:15:24 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1s84BhZ9PgQEv4BhUypB6kkobjrmWR0wuJlqs0WcG0RA",
-         "name": "original name",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1s84BhZ9PgQEv4BhUypB6kkobjrmWR0wuJlqs0WcG0RA&v=1&s=AMedNnoAAAAAW9lyrHSNvxWYQirN3wNpZufBGj0sBvdc&sz=s220",
-         "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:15:25 GMT
-- request:
-    method: post
-    uri: https://www.googleapis.com/drive/v3/files/1elYWewUmnAb4r3yHbiqx8MzzTmO-zVrxZNaThh4d5f8/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: '{"name":"original name","parents":["1Tlc16iVps93qBfIQLl5v1-7wxXwLfYDA"]}'
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 31 Oct 2018 07:15:25 GMT
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Wed, 31 Oct 2018 07:15:26 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1tF0nykxW7CM9vNaK6sv5sK3aRsn-QRtt9qD9VtQbtbg",
-         "name": "original name",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1Tlc16iVps93qBfIQLl5v1-7wxXwLfYDA"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:15:26 GMT
+  recorded_at: Thu, 08 Nov 2018 01:30:47 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1elYWewUmnAb4r3yHbiqx8MzzTmO-zVrxZNaThh4d5f8?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1nSCFRItZD4jojBTqfjDtYn0K5yTLEmkCB3eQa0eVZLk/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1317,7 +1156,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:15:26 GMT
+      - Thu, 08 Nov 2018 01:30:47 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1328,85 +1167,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 07:15:26 GMT
+      - Thu, 08 Nov 2018 01:30:47 GMT
       Date:
-      - Wed, 31 Oct 2018 07:15:26 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1elYWewUmnAb4r3yHbiqx8MzzTmO-zVrxZNaThh4d5f8",
-         "name": "original name",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1Fy3XhHn03BzG8QOFvg2cBohGuTonoouu"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1elYWewUmnAb4r3yHbiqx8MzzTmO-zVrxZNaThh4d5f8&v=1&s=AMedNnoAAAAAW9lyriJTL8lHsIPkMvRqFYWJZ8MZdsll&sz=s220",
-         "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:15:27 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1elYWewUmnAb4r3yHbiqx8MzzTmO-zVrxZNaThh4d5f8/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 31 Oct 2018 07:15:27 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Wed, 31 Oct 2018 07:15:27 GMT
-      Date:
-      - Wed, 31 Oct 2018 07:15:27 GMT
+      - Thu, 08 Nov 2018 01:30:47 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1435,13 +1198,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-31T07:15:23.569Z"
+         "modifiedTime": "2018-11-08T01:30:46.133Z"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:15:27 GMT
+  recorded_at: Thu, 08 Nov 2018 01:30:47 GMT
 - request:
-    method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1D7w1G7FKyDfTD4XFJ9NpRulJYt3VDRfH
+    method: patch
+    uri: https://www.googleapis.com/drive/v3/files/1ZUsyIvmPhw-fFlgprjL4Ayz6lG_HgVYlPpohm0HyDyM?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1UONydeugowk44a63pl4MbjfXqg26Of6J
     body:
       encoding: UTF-8
       string: ''
@@ -1453,7 +1216,217 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:15:27 GMT
+      - Thu, 08 Nov 2018 01:30:47 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Thu, 08 Nov 2018 01:30:47 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1ZUsyIvmPhw-fFlgprjL4Ayz6lG_HgVYlPpohm0HyDyM",
+         "name": "original name",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1ZUsyIvmPhw-fFlgprjL4Ayz6lG_HgVYlPpohm0HyDyM&v=1&s=AMedNnoAAAAAW-Ot53AigTaiiMVgael83DWG5sDKcE1U&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 08 Nov 2018 01:30:47 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1nSCFRItZD4jojBTqfjDtYn0K5yTLEmkCB3eQa0eVZLk?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 08 Nov 2018 01:30:47 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 08 Nov 2018 01:30:48 GMT
+      Date:
+      - Thu, 08 Nov 2018 01:30:48 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1nSCFRItZD4jojBTqfjDtYn0K5yTLEmkCB3eQa0eVZLk",
+         "name": "original name",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1UONydeugowk44a63pl4MbjfXqg26Of6J"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 08 Nov 2018 01:30:48 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1nSCFRItZD4jojBTqfjDtYn0K5yTLEmkCB3eQa0eVZLk/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 08 Nov 2018 01:30:48 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 08 Nov 2018 01:30:48 GMT
+      Date:
+      - Thu, 08 Nov 2018 01:30:48 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-11-08T01:30:46.133Z"
+        }
+    http_version: 
+  recorded_at: Thu, 08 Nov 2018 01:30:48 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1jyx7JkZdHnvZabe5GmiF3ZuLznUr7kS6
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 08 Nov 2018 01:30:48 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1470,7 +1443,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:15:27 GMT
+      - Thu, 08 Nov 2018 01:30:48 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1482,5 +1455,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:15:28 GMT
+  recorded_at: Thu, 08 Nov 2018 01:30:49 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/VCS_Operations_FileRestore/_restore/when_file_to_restore_does_not_exist_in_stage/is_added.yml
+++ b/spec/support/fixtures/vcr_cassettes/VCS_Operations_FileRestore/_restore/when_file_to_restore_does_not_exist_in_stage/is_added.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Wed, 31 Oct 2018 07:14:50 GMT
+      - Thu, 08 Nov 2018 01:31:46 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,14 +53,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:14:50 GMT
+  recorded_at: Thu, 08 Nov 2018 01:31:46 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-31
-        07:14:50 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-11-08
+        01:31:46 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -69,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:14:50 GMT
+      - Thu, 08 Nov 2018 01:31:46 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -86,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:14:50 GMT
+      - Thu, 08 Nov 2018 01:31:47 GMT
       Vary:
       - Origin
       - X-Origin
@@ -110,8 +110,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1E2ObBr15WJAPvFxItX2MSvY1DZ8EP9B7",
-         "name": "Test @ 2018-10-31 07:14:50 UTC",
+         "id": "1MzOg_ZfmtQmrQYM1rEMJWFhXSo5scwfJ",
+         "name": "Test @ 2018-11-08 01:31:46 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -131,13 +131,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:14:51 GMT
+  recorded_at: Thu, 08 Nov 2018 01:31:47 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1E2ObBr15WJAPvFxItX2MSvY1DZ8EP9B7"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1MzOg_ZfmtQmrQYM1rEMJWFhXSo5scwfJ"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -146,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:14:51 GMT
+      - Thu, 08 Nov 2018 01:31:47 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -163,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:14:51 GMT
+      - Thu, 08 Nov 2018 01:31:48 GMT
       Vary:
       - Origin
       - X-Origin
@@ -187,12 +187,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1bAVZJFq9Q4Tb1QCGHqFSSEblRxkfqKjd",
+         "id": "18HtjgZumU3ntxfYGAY0x_rzo3Bp0azta",
          "name": "Folder",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1E2ObBr15WJAPvFxItX2MSvY1DZ8EP9B7"
+          "1MzOg_ZfmtQmrQYM1rEMJWFhXSo5scwfJ"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -208,14 +208,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:14:51 GMT
+  recorded_at: Thu, 08 Nov 2018 01:31:48 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.document","name":"original
-        name","parents":["1bAVZJFq9Q4Tb1QCGHqFSSEblRxkfqKjd"]}'
+        name","parents":["18HtjgZumU3ntxfYGAY0x_rzo3Bp0azta"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -224,7 +224,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:14:51 GMT
+      - Thu, 08 Nov 2018 01:31:48 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -241,7 +241,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:14:53 GMT
+      - Thu, 08 Nov 2018 01:31:49 GMT
       Vary:
       - Origin
       - X-Origin
@@ -265,12 +265,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1XUOqBJrKwOBIfbU4_OOxS7kjZ05TmrTDWT3W6G6BWvs",
+         "id": "17k3mqD9Fv4nYR8iFJBD57oSoLa1sZn9wRuxMahTrowM",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1bAVZJFq9Q4Tb1QCGHqFSSEblRxkfqKjd"
+          "18HtjgZumU3ntxfYGAY0x_rzo3Bp0azta"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -286,14 +286,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:14:53 GMT
+  recorded_at: Thu, 08 Nov 2018 01:31:49 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"2 Bistromath
-        (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"7 Krikkit
+        One (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -302,7 +302,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:14:53 GMT
+      - Thu, 08 Nov 2018 01:31:49 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -319,7 +319,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:14:53 GMT
+      - Thu, 08 Nov 2018 01:31:50 GMT
       Vary:
       - Origin
       - X-Origin
@@ -343,8 +343,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1fSsrr6DLTltSqZhK10WCxAFhSfv1l845",
-         "name": "2 Bistromath (Archive)",
+         "id": "19Yp7-xbXk23MnpZZPUVISzRUw4JNQLOy",
+         "name": "7 Krikkit One (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -364,10 +364,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:14:54 GMT
+  recorded_at: Thu, 08 Nov 2018 01:31:50 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1fSsrr6DLTltSqZhK10WCxAFhSfv1l845/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/19Yp7-xbXk23MnpZZPUVISzRUw4JNQLOy/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -379,7 +379,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:14:54 GMT
+      - Thu, 08 Nov 2018 01:31:50 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -396,7 +396,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:14:54 GMT
+      - Thu, 08 Nov 2018 01:31:51 GMT
       Vary:
       - Origin
       - X-Origin
@@ -426,10 +426,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:14:54 GMT
+  recorded_at: Thu, 08 Nov 2018 01:31:51 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1XUOqBJrKwOBIfbU4_OOxS7kjZ05TmrTDWT3W6G6BWvs?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/17k3mqD9Fv4nYR8iFJBD57oSoLa1sZn9wRuxMahTrowM?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -441,7 +441,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:14:55 GMT
+      - Thu, 08 Nov 2018 01:31:51 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -452,9 +452,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 07:14:55 GMT
+      - Thu, 08 Nov 2018 01:31:51 GMT
       Date:
-      - Wed, 31 Oct 2018 07:14:55 GMT
+      - Thu, 08 Nov 2018 01:31:51 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -480,15 +480,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1XUOqBJrKwOBIfbU4_OOxS7kjZ05TmrTDWT3W6G6BWvs",
+         "id": "17k3mqD9Fv4nYR8iFJBD57oSoLa1sZn9wRuxMahTrowM",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1bAVZJFq9Q4Tb1QCGHqFSSEblRxkfqKjd"
+          "18HtjgZumU3ntxfYGAY0x_rzo3Bp0azta"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1XUOqBJrKwOBIfbU4_OOxS7kjZ05TmrTDWT3W6G6BWvs&v=1&s=AMedNnoAAAAAW9lyjw5-9vwHBFtvnrFTzkgVD5hiYonV&sz=s220",
-         "thumbnailVersion": "1",
+         "thumbnailVersion": "0",
          "permissions": [
           {
            "kind": "drive#permission",
@@ -502,10 +501,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:14:55 GMT
+  recorded_at: Thu, 08 Nov 2018 01:31:51 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1XUOqBJrKwOBIfbU4_OOxS7kjZ05TmrTDWT3W6G6BWvs/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/17k3mqD9Fv4nYR8iFJBD57oSoLa1sZn9wRuxMahTrowM/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -517,7 +516,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:14:55 GMT
+      - Thu, 08 Nov 2018 01:31:51 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -528,9 +527,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 07:14:55 GMT
+      - Thu, 08 Nov 2018 01:31:52 GMT
       Date:
-      - Wed, 31 Oct 2018 07:14:55 GMT
+      - Thu, 08 Nov 2018 01:31:52 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -559,76 +558,16 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-31T07:14:52.095Z"
+         "modifiedTime": "2018-11-08T01:31:48.686Z"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:14:55 GMT
-- request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1XUOqBJrKwOBIfbU4_OOxS7kjZ05TmrTDWT3W6G6BWvs&s=AMedNnoAAAAAW9lyjw5-9vwHBFtvnrFTzkgVD5hiYonV&sz=s350&v=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 31 Oct 2018 07:14:55 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Expose-Headers:
-      - Content-Length
-      Etag:
-      - '"v1"'
-      Expires:
-      - Fri, 01 Jan 1990 00:00:00 GMT
-      Cache-Control:
-      - private, max-age=86400, no-transform
-      Content-Disposition:
-      - inline;filename="unnamed.png"
-      Content-Type:
-      - image/png
-      Vary:
-      - Origin
-      Access-Control-Allow-Origin:
-      - "*"
-      Timing-Allow-Origin:
-      - "*"
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Wed, 31 Oct 2018 07:14:55 GMT
-      Server:
-      - fife
-      Content-Length:
-      - '1022'
-      X-Xss-Protection:
-      - 1; mode=block
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
-    http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:14:55 GMT
+  recorded_at: Thu, 08 Nov 2018 01:31:52 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1XUOqBJrKwOBIfbU4_OOxS7kjZ05TmrTDWT3W6G6BWvs/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/17k3mqD9Fv4nYR8iFJBD57oSoLa1sZn9wRuxMahTrowM/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"original name","parents":["1fSsrr6DLTltSqZhK10WCxAFhSfv1l845"]}'
+      string: '{"name":"original name","parents":["19Yp7-xbXk23MnpZZPUVISzRUw4JNQLOy"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -637,7 +576,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:14:55 GMT
+      - Thu, 08 Nov 2018 01:31:52 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -654,7 +593,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:14:57 GMT
+      - Thu, 08 Nov 2018 01:31:54 GMT
       Vary:
       - Origin
       - X-Origin
@@ -678,12 +617,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1Db3pgByRkY6_5UFV3iiJ3esluIaGKhcg4bVQOK5RSos",
+         "id": "1MiHSos1a7sNWsxpdJZjr8BBukDpFFWODjW1uIssEvFo",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1fSsrr6DLTltSqZhK10WCxAFhSfv1l845"
+          "19Yp7-xbXk23MnpZZPUVISzRUw4JNQLOy"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -708,10 +647,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:14:57 GMT
+  recorded_at: Thu, 08 Nov 2018 01:31:54 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1XUOqBJrKwOBIfbU4_OOxS7kjZ05TmrTDWT3W6G6BWvs
+    uri: https://www.googleapis.com/drive/v3/files/17k3mqD9Fv4nYR8iFJBD57oSoLa1sZn9wRuxMahTrowM
     body:
       encoding: UTF-8
       string: ''
@@ -723,7 +662,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:14:57 GMT
+      - Thu, 08 Nov 2018 01:31:54 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -740,7 +679,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:14:58 GMT
+      - Thu, 08 Nov 2018 01:31:54 GMT
       Vary:
       - Origin
       - X-Origin
@@ -752,10 +691,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:14:58 GMT
+  recorded_at: Thu, 08 Nov 2018 01:31:54 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1XUOqBJrKwOBIfbU4_OOxS7kjZ05TmrTDWT3W6G6BWvs?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/17k3mqD9Fv4nYR8iFJBD57oSoLa1sZn9wRuxMahTrowM?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -767,7 +706,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:14:58 GMT
+      - Thu, 08 Nov 2018 01:31:54 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -785,9 +724,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 31 Oct 2018 07:14:58 GMT
+      - Thu, 08 Nov 2018 01:31:55 GMT
       Expires:
-      - Wed, 31 Oct 2018 07:14:58 GMT
+      - Thu, 08 Nov 2018 01:31:55 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -811,23 +750,23 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1XUOqBJrKwOBIfbU4_OOxS7kjZ05TmrTDWT3W6G6BWvs.",
+            "message": "File not found: 17k3mqD9Fv4nYR8iFJBD57oSoLa1sZn9wRuxMahTrowM.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1XUOqBJrKwOBIfbU4_OOxS7kjZ05TmrTDWT3W6G6BWvs."
+          "message": "File not found: 17k3mqD9Fv4nYR8iFJBD57oSoLa1sZn9wRuxMahTrowM."
          }
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:14:58 GMT
+  recorded_at: Thu, 08 Nov 2018 01:31:55 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1Db3pgByRkY6_5UFV3iiJ3esluIaGKhcg4bVQOK5RSos/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1MiHSos1a7sNWsxpdJZjr8BBukDpFFWODjW1uIssEvFo/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"original name","parents":["1bAVZJFq9Q4Tb1QCGHqFSSEblRxkfqKjd"]}'
+      string: '{"name":"original name","parents":["18HtjgZumU3ntxfYGAY0x_rzo3Bp0azta"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -836,7 +775,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:14:58 GMT
+      - Thu, 08 Nov 2018 01:31:55 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -853,7 +792,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:15:00 GMT
+      - Thu, 08 Nov 2018 01:32:00 GMT
       Vary:
       - Origin
       - X-Origin
@@ -877,12 +816,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1LnG7-bWSSomCsSlrFkYSWMqpYRmOrTCk14jwWz9LzVg",
+         "id": "1Dkyrjx8kZyapXBhxZtWb5R57KnXtCOy_Sa_B3wETchQ",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1bAVZJFq9Q4Tb1QCGHqFSSEblRxkfqKjd"
+          "18HtjgZumU3ntxfYGAY0x_rzo3Bp0azta"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -898,96 +837,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:15:00 GMT
-- request:
-    method: post
-    uri: https://www.googleapis.com/drive/v3/files/1LnG7-bWSSomCsSlrFkYSWMqpYRmOrTCk14jwWz9LzVg/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: '{"name":"original name","parents":["1fSsrr6DLTltSqZhK10WCxAFhSfv1l845"]}'
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 31 Oct 2018 07:15:00 GMT
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Wed, 31 Oct 2018 07:15:02 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1xOPlnpbg18HsHadoFpY-wPoq4BHKEjaqolIPMaD7yzs",
-         "name": "original name",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1fSsrr6DLTltSqZhK10WCxAFhSfv1l845"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:15:02 GMT
+  recorded_at: Thu, 08 Nov 2018 01:32:00 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1LnG7-bWSSomCsSlrFkYSWMqpYRmOrTCk14jwWz9LzVg?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1Dkyrjx8kZyapXBhxZtWb5R57KnXtCOy_Sa_B3wETchQ/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -999,7 +852,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:15:02 GMT
+      - Thu, 08 Nov 2018 01:32:00 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1010,84 +863,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 07:15:02 GMT
+      - Thu, 08 Nov 2018 01:32:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:15:02 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1LnG7-bWSSomCsSlrFkYSWMqpYRmOrTCk14jwWz9LzVg",
-         "name": "original name",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1bAVZJFq9Q4Tb1QCGHqFSSEblRxkfqKjd"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:15:02 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1LnG7-bWSSomCsSlrFkYSWMqpYRmOrTCk14jwWz9LzVg/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 31 Oct 2018 07:15:02 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Wed, 31 Oct 2018 07:15:02 GMT
-      Date:
-      - Wed, 31 Oct 2018 07:15:02 GMT
+      - Thu, 08 Nov 2018 01:32:00 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1116,13 +894,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-10-31T07:14:59.264Z"
+         "modifiedTime": "2018-11-08T01:31:59.550Z"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:15:02 GMT
+  recorded_at: Thu, 08 Nov 2018 01:32:00 GMT
 - request:
-    method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1E2ObBr15WJAPvFxItX2MSvY1DZ8EP9B7
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1Dkyrjx8kZyapXBhxZtWb5R57KnXtCOy_Sa_B3wETchQ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1134,7 +912,142 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:15:02 GMT
+      - Thu, 08 Nov 2018 01:32:00 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 08 Nov 2018 01:32:01 GMT
+      Date:
+      - Thu, 08 Nov 2018 01:32:01 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1Dkyrjx8kZyapXBhxZtWb5R57KnXtCOy_Sa_B3wETchQ",
+         "name": "original name",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "18HtjgZumU3ntxfYGAY0x_rzo3Bp0azta"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 08 Nov 2018 01:32:01 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1Dkyrjx8kZyapXBhxZtWb5R57KnXtCOy_Sa_B3wETchQ/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 08 Nov 2018 01:32:01 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 08 Nov 2018 01:32:01 GMT
+      Date:
+      - Thu, 08 Nov 2018 01:32:01 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-11-08T01:31:59.550Z"
+        }
+    http_version: 
+  recorded_at: Thu, 08 Nov 2018 01:32:01 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1MzOg_ZfmtQmrQYM1rEMJWFhXSo5scwfJ
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 08 Nov 2018 01:32:01 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1151,7 +1064,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:15:03 GMT
+      - Thu, 08 Nov 2018 01:32:01 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1163,5 +1076,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:15:03 GMT
+  recorded_at: Thu, 08 Nov 2018 01:32:02 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/VCS_Operations_FileRestore/_restore/when_file_to_restore_does_not_exist_in_stage/when_file_to_restore_is_folder/is_added.yml
+++ b/spec/support/fixtures/vcr_cassettes/VCS_Operations_FileRestore/_restore/when_file_to_restore_does_not_exist_in_stage/when_file_to_restore_is_folder/is_added.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Wed, 31 Oct 2018 07:23:16 GMT
+      - Thu, 08 Nov 2018 01:32:02 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,14 +53,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:23:16 GMT
+  recorded_at: Thu, 08 Nov 2018 01:32:02 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-10-31
-        07:23:16 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-11-08
+        01:32:02 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -69,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:23:16 GMT
+      - Thu, 08 Nov 2018 01:32:02 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -86,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:23:17 GMT
+      - Thu, 08 Nov 2018 01:32:02 GMT
       Vary:
       - Origin
       - X-Origin
@@ -110,8 +110,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1UVGik_xpRUurow6ARfjScdNl5dJdq-v7",
-         "name": "Test @ 2018-10-31 07:23:16 UTC",
+         "id": "1OiagPAvorwVrD_vNowfraHbMi2_yPXug",
+         "name": "Test @ 2018-11-08 01:32:02 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -131,13 +131,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:23:17 GMT
+  recorded_at: Thu, 08 Nov 2018 01:32:03 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1UVGik_xpRUurow6ARfjScdNl5dJdq-v7"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1OiagPAvorwVrD_vNowfraHbMi2_yPXug"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -146,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:23:17 GMT
+      - Thu, 08 Nov 2018 01:32:03 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -163,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:23:17 GMT
+      - Thu, 08 Nov 2018 01:32:03 GMT
       Vary:
       - Origin
       - X-Origin
@@ -187,12 +187,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1_3T5Txt5XF5yBJe1Pku3PetVi0uKtiRl",
+         "id": "1JlB72uaEVF5iaBvR1IF37-mJdm3E3FOC",
          "name": "Folder",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1UVGik_xpRUurow6ARfjScdNl5dJdq-v7"
+          "1OiagPAvorwVrD_vNowfraHbMi2_yPXug"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -208,13 +208,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:23:17 GMT
+  recorded_at: Thu, 08 Nov 2018 01:32:03 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"original name","parents":["1_3T5Txt5XF5yBJe1Pku3PetVi0uKtiRl"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"original name","parents":["1JlB72uaEVF5iaBvR1IF37-mJdm3E3FOC"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -223,7 +223,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:23:17 GMT
+      - Thu, 08 Nov 2018 01:32:03 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -240,7 +240,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:23:18 GMT
+      - Thu, 08 Nov 2018 01:32:04 GMT
       Vary:
       - Origin
       - X-Origin
@@ -264,12 +264,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1bJmWbmPilXMuwf_h9lMFEXP8adn-ISrw",
+         "id": "1ayHxu9_7-4q5LmLhcQlrwCkOgX7YwM9o",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1_3T5Txt5XF5yBJe1Pku3PetVi0uKtiRl"
+          "1JlB72uaEVF5iaBvR1IF37-mJdm3E3FOC"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -285,14 +285,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:23:18 GMT
+  recorded_at: Thu, 08 Nov 2018 01:32:04 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"5 Heart of
-        Gold (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"8 Starship
+        Titanic (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -301,7 +301,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:23:18 GMT
+      - Thu, 08 Nov 2018 01:32:04 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -318,7 +318,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:23:19 GMT
+      - Thu, 08 Nov 2018 01:32:05 GMT
       Vary:
       - Origin
       - X-Origin
@@ -342,8 +342,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1Lv3_uQsy8cPE1rRzQnJolmyuHEJsBSBs",
-         "name": "5 Heart of Gold (Archive)",
+         "id": "1yW4g6ko3xb50a4KJciFP7yaHeQLHVyAF",
+         "name": "8 Starship Titanic (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -363,10 +363,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:23:19 GMT
+  recorded_at: Thu, 08 Nov 2018 01:32:05 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1Lv3_uQsy8cPE1rRzQnJolmyuHEJsBSBs/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1yW4g6ko3xb50a4KJciFP7yaHeQLHVyAF/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -378,7 +378,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:23:19 GMT
+      - Thu, 08 Nov 2018 01:32:05 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -395,7 +395,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:23:20 GMT
+      - Thu, 08 Nov 2018 01:32:05 GMT
       Vary:
       - Origin
       - X-Origin
@@ -425,10 +425,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:23:20 GMT
+  recorded_at: Thu, 08 Nov 2018 01:32:06 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1bJmWbmPilXMuwf_h9lMFEXP8adn-ISrw?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ayHxu9_7-4q5LmLhcQlrwCkOgX7YwM9o?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -440,7 +440,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:23:20 GMT
+      - Thu, 08 Nov 2018 01:32:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -451,9 +451,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 31 Oct 2018 07:23:20 GMT
+      - Thu, 08 Nov 2018 01:32:06 GMT
       Date:
-      - Wed, 31 Oct 2018 07:23:20 GMT
+      - Thu, 08 Nov 2018 01:32:06 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -479,12 +479,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1bJmWbmPilXMuwf_h9lMFEXP8adn-ISrw",
+         "id": "1ayHxu9_7-4q5LmLhcQlrwCkOgX7YwM9o",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1_3T5Txt5XF5yBJe1Pku3PetVi0uKtiRl"
+          "1JlB72uaEVF5iaBvR1IF37-mJdm3E3FOC"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -500,10 +500,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:23:20 GMT
+  recorded_at: Thu, 08 Nov 2018 01:32:06 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1bJmWbmPilXMuwf_h9lMFEXP8adn-ISrw/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1ayHxu9_7-4q5LmLhcQlrwCkOgX7YwM9o/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -515,7 +515,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:23:20 GMT
+      - Thu, 08 Nov 2018 01:32:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -533,9 +533,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 31 Oct 2018 07:23:20 GMT
+      - Thu, 08 Nov 2018 01:32:06 GMT
       Expires:
-      - Wed, 31 Oct 2018 07:23:20 GMT
+      - Thu, 08 Nov 2018 01:32:06 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -567,10 +567,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:23:20 GMT
+  recorded_at: Thu, 08 Nov 2018 01:32:06 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1bJmWbmPilXMuwf_h9lMFEXP8adn-ISrw
+    uri: https://www.googleapis.com/drive/v3/files/1ayHxu9_7-4q5LmLhcQlrwCkOgX7YwM9o
     body:
       encoding: UTF-8
       string: ''
@@ -582,7 +582,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:23:20 GMT
+      - Thu, 08 Nov 2018 01:32:06 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -599,7 +599,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:23:21 GMT
+      - Thu, 08 Nov 2018 01:32:07 GMT
       Vary:
       - Origin
       - X-Origin
@@ -611,10 +611,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:23:21 GMT
+  recorded_at: Thu, 08 Nov 2018 01:32:07 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1bJmWbmPilXMuwf_h9lMFEXP8adn-ISrw?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ayHxu9_7-4q5LmLhcQlrwCkOgX7YwM9o?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -626,7 +626,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:23:21 GMT
+      - Thu, 08 Nov 2018 01:32:07 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -644,9 +644,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 31 Oct 2018 07:23:21 GMT
+      - Thu, 08 Nov 2018 01:32:07 GMT
       Expires:
-      - Wed, 31 Oct 2018 07:23:21 GMT
+      - Thu, 08 Nov 2018 01:32:07 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -670,23 +670,23 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1bJmWbmPilXMuwf_h9lMFEXP8adn-ISrw.",
+            "message": "File not found: 1ayHxu9_7-4q5LmLhcQlrwCkOgX7YwM9o.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1bJmWbmPilXMuwf_h9lMFEXP8adn-ISrw."
+          "message": "File not found: 1ayHxu9_7-4q5LmLhcQlrwCkOgX7YwM9o."
          }
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:23:21 GMT
+  recorded_at: Thu, 08 Nov 2018 01:32:07 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"original name","parents":["1_3T5Txt5XF5yBJe1Pku3PetVi0uKtiRl"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"original name","parents":["1JlB72uaEVF5iaBvR1IF37-mJdm3E3FOC"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -695,7 +695,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:23:21 GMT
+      - Thu, 08 Nov 2018 01:32:07 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -712,7 +712,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:23:21 GMT
+      - Thu, 08 Nov 2018 01:32:08 GMT
       Vary:
       - Origin
       - X-Origin
@@ -736,12 +736,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1MfP9PtT9K_wq0IMVHPyr4dfsMezHSuNe",
+         "id": "1AApLYuraqVoc7hU8UstMT1ni1xEMNsRh",
          "name": "original name",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1_3T5Txt5XF5yBJe1Pku3PetVi0uKtiRl"
+          "1JlB72uaEVF5iaBvR1IF37-mJdm3E3FOC"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -757,10 +757,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:23:22 GMT
+  recorded_at: Thu, 08 Nov 2018 01:32:08 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1MfP9PtT9K_wq0IMVHPyr4dfsMezHSuNe?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1AApLYuraqVoc7hU8UstMT1ni1xEMNsRh/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -772,82 +772,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:23:22 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Wed, 31 Oct 2018 07:23:22 GMT
-      Date:
-      - Wed, 31 Oct 2018 07:23:22 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1MfP9PtT9K_wq0IMVHPyr4dfsMezHSuNe",
-         "name": "original name",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "1_3T5Txt5XF5yBJe1Pku3PetVi0uKtiRl"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:23:22 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1MfP9PtT9K_wq0IMVHPyr4dfsMezHSuNe/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 31 Oct 2018 07:23:22 GMT
+      - Thu, 08 Nov 2018 01:32:08 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -865,9 +790,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 31 Oct 2018 07:23:22 GMT
+      - Thu, 08 Nov 2018 01:32:08 GMT
       Expires:
-      - Wed, 31 Oct 2018 07:23:22 GMT
+      - Thu, 08 Nov 2018 01:32:08 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -899,10 +824,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:23:22 GMT
+  recorded_at: Thu, 08 Nov 2018 01:32:08 GMT
 - request:
-    method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1UVGik_xpRUurow6ARfjScdNl5dJdq-v7
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1AApLYuraqVoc7hU8UstMT1ni1xEMNsRh?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -914,7 +839,149 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 31 Oct 2018 07:23:22 GMT
+      - Thu, 08 Nov 2018 01:32:08 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 08 Nov 2018 01:32:08 GMT
+      Date:
+      - Thu, 08 Nov 2018 01:32:08 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1AApLYuraqVoc7hU8UstMT1ni1xEMNsRh",
+         "name": "original name",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "1JlB72uaEVF5iaBvR1IF37-mJdm3E3FOC"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 08 Nov 2018 01:32:09 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1AApLYuraqVoc7hU8UstMT1ni1xEMNsRh/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 08 Nov 2018 01:32:09 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Thu, 08 Nov 2018 01:32:09 GMT
+      Expires:
+      - Thu, 08 Nov 2018 01:32:09 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Thu, 08 Nov 2018 01:32:09 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1OiagPAvorwVrD_vNowfraHbMi2_yPXug
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Thu, 08 Nov 2018 01:32:09 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -931,7 +998,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 31 Oct 2018 07:23:22 GMT
+      - Thu, 08 Nov 2018 01:32:09 GMT
       Vary:
       - Origin
       - X-Origin
@@ -943,5 +1010,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 31 Oct 2018 07:23:22 GMT
+  recorded_at: Thu, 08 Nov 2018 01:32:09 GMT
 recorded_with: VCR 4.0.0


### PR DESCRIPTION
An instance of VCS::Content represents one content version of a file.
We are moving away from having the remote file's content version ID
be the determinant of whether the file was modified because when we
replace a file (as part of restoration or merge), the file's external
ID changes and its remote content version resets to 1. Two file
snapshots could have completely different external IDs and version IDs,
but represent the same content.

Using VCS::RemoteContent maps a remote file ID and its remote
content version ID to a local instance of VCS::Content. This allows us
to map multiple remote files to the same content version, as would be
the case in a file restore, branch, or merge (because all of them work by
replacing the remote file with a new file).