### PR TITLE
Git: Ignore /public/spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ bower.json
 
 # Ignore app-data file storage (such as Git repositories)
 /system
+
+# Ignore any temporary files placed under public spec
+/public/spec


### PR DESCRIPTION
Ignore public spec directory to avoid tracking files generated during
RSpec tests.