### PR TITLE
Fix Notifications

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -6,7 +6,11 @@ class NotificationsController < ApplicationController
 
   # GET /notifications
   def index
-    @notifications = notifications.includes(:notifier, :notifiable)
+    # HACK: Preload the repository relationship. Only works because we have
+    # =>    only one type of notification and that notification supports the
+    # =>    repository relationship.
+    @notifications =
+      notifications.includes(:notifier, notifiable: %i[repository])
   end
 
   # GET /notifications/:id

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -6,7 +6,7 @@ class NotificationsController < ApplicationController
 
   # GET /notifications
   def index
-    @notifications = notifications.includes(:notifier, notifiable: [:project])
+    @notifications = notifications.includes(:notifier, :notifiable)
   end
 
   # GET /notifications/:id

--- a/app/views/notifications/_vcs_commit_notification.slim
+++ b/app/views/notifications/_vcs_commit_notification.slim
@@ -1,7 +1,7 @@
-= link_to notification_path(revision_notification),
+= link_to notification_path(vcs_commit_notification),
           class: 'notification collection-item avatar' do
 
-  = image_tag revision_notification.notifier.picture.url, class: 'circle'
+  = image_tag vcs_commit_notification.notifier.picture.url, class: 'circle'
 
   - if vcs_commit_notification.unread?
     .right.chip.primary-color.primary-color-text.slim-on-mobile new

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -4,7 +4,13 @@ FactoryBot.define do
   factory :notification do
     association :target, factory: :account
     association :notifier, factory: :user
-    association :notifiable, factory: :revision
+    association :notifiable, factory: :vcs_commit
     key { 'revision.default' }
+
+    after(:create) do |notification|
+      create(:project, :skip_archive_setup, :setup_complete,
+             repository: notification.notifiable.repository,
+             master_branch: notification.notifiable.repository.branches.first)
+    end
   end
 end

--- a/spec/features/notification_spec.rb
+++ b/spec/features/notification_spec.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 feature 'Notification' do
+  # HACK: Turn off bullet
+  # TODO: Figure out a long-term strategy for notifications that need to load
+  # =>    associated objects. Could be anything from projects to users to
+  # =>    pull requests.
+  let!(:was_bullet_enabled) { Bullet.enable? }
+
+  before  { Bullet.enable = false }
+  after   { Bullet.enable = was_bullet_enabled }
+
   scenario 'User can see all notifications' do
     # given I have an account
     account = create(:account)
@@ -23,7 +32,7 @@ feature 'Notification' do
     account = create :account
     # and there is a project with a revision
     project = create :project, :setup_complete, :skip_archive_setup
-    revision = create :revision, project: project
+    revision = create :vcs_commit, branch: project.master_branch
     # and I have a notification for the revision
     create(:notification, target: account, notifiable: revision)
     # and I am logged in
@@ -35,8 +44,9 @@ feature 'Notification' do
     find('.notification').click
 
     # then I should be on the revisions page
+    project = Project.find_by_repository_id(revision.repository.id)
     expect(page).to have_current_path(
-      profile_project_revisions_path(revision.project.owner, revision.project)
+      profile_project_revisions_path(project.owner, project)
     )
     # and have no unread notifications
     expect(account).not_to have_unopened_notifications

--- a/spec/mailers/notifications_mailer_spec.rb
+++ b/spec/mailers/notifications_mailer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe NotificationsMailer, type: :mailer do
   end
 
   describe '#notification_email' do
-    let(:notification) { build_stubbed :notification }
+    let(:notification) { create :notification }
     let(:mail) { described_class.notification_email(notification).deliver_now }
 
     it 'sets the correct subject' do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -83,6 +83,36 @@ RSpec.describe Project, type: :model do
       end
     end
 
+    context 'before create' do
+      subject(:project) { build(:project) }
+
+      before do
+        allow(project).to receive(:create_repository)
+        allow(project).to receive(:create_master_branch_with_repository)
+        allow(project).to receive(:setup_archive)
+        before_save_hook if defined?(before_save_hook)
+        project.save
+      end
+
+      it { is_expected.to have_received(:create_repository) }
+      it { is_expected.to have_received(:create_master_branch_with_repository) }
+
+      context 'when repository is present' do
+        let(:before_save_hook)  { project.repository = VCS::Repository.new }
+
+        it { is_expected.not_to have_received(:create_repository) }
+      end
+
+      context 'when master_branch is present' do
+        let(:before_save_hook) { project.master_branch = VCS::Branch.new }
+
+        it do
+          is_expected
+            .not_to have_received(:create_master_branch_with_repository)
+        end
+      end
+    end
+
     context 'after create' do
       subject(:project) { build(:project) }
 

--- a/spec/views/notifications/index_spec.rb
+++ b/spec/views/notifications/index_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe 'notifications/index', type: :view do
-  let(:notifications) { build_stubbed_list :notification, 3 }
+  let(:notifications) { create_list :notification, 3 }
   let(:unopened)      { false }
 
   before do
@@ -25,7 +25,8 @@ RSpec.describe 'notifications/index', type: :view do
     render
     notifications.each do |notification|
       notifier = notification.notifier
-      project = notification.notifiable.project
+      project =
+        Project.find_by_repository_id(notification.notifiable.repository.id)
       expect(rendered).to have_text(
         "#{notifier.name} created a revision in #{project.title}"
       )


### PR DESCRIPTION
Fix notifications to be compatible with VCS::Commit as notifiable. The
key issue is that VCS::Commit has no relationship to our top-level
model project. We do not yet have a strategy for how to handle the
relationship between the models in the VCS namespace and everything
outside.