### PR TITLE
Hotfix v0.27.1: Pull FileUpdateJob updates only to branches w/ staged files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v0.27.1 (Nov 13, 2018)
+
+**Fixes:**
+- When adding a file to a folder that once was present in a repository,
+  FileUpdateJob no longer fails.
+
 ## v0.27 (Nov 8, 2018)
 
 **New Features:**

--- a/app/models/vcs/branch.rb
+++ b/app/models/vcs/branch.rb
@@ -51,6 +51,7 @@ module VCS
     # external IDs
     scope :where_staged_files_include_external_id, lambda { |external_ids|
       joins(:staged_files)
+        .merge(VCS::StagedFile.joins_staged_snapshot)
         .where(vcs_staged_files: { external_id: external_ids.to_a })
         .distinct
     }

--- a/spec/integrations/vcs/branch_spec.rb
+++ b/spec/integrations/vcs/branch_spec.rb
@@ -28,5 +28,18 @@ RSpec.describe VCS::Branch, type: :model do
         is_expected.to match_array [file1, file2, file3].map(&:branch)
       end
     end
+
+    context 'when branch includes removed files that match' do
+      before do
+        VCS::StagedFile.update_all(
+          current_snapshot_id: nil,
+          committed_snapshot_id: nil
+        )
+      end
+
+      it 'does not return branch' do
+        is_expected.to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
This fix resolves the following issue:
1) A folder exists in branch A
2) The folder is moved to another branch B, but an instance of
   VCS::StagedFile with its external id and current_snapshot_id = NULL
   and committed_snapshot_id = NULL still exists in branch A
3) A file is added to the folder
4) FileUpdateJob wants to add file to branches A & B. It fails trying to
   add it to branch A when validating that file its not its own
   ancestor.

This issue is fixed by pulling file updates only to branches where the
parent is actually staged (i.e. current or committed snapshot is
present).