### PR TITLE
Upgrade gem 'rack' to v2.0.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -349,7 +349,7 @@ GEM
       pry (>= 0.10.4)
     public_suffix (3.0.3)
     puma (3.12.0)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.1)


### PR DESCRIPTION
Fixes [CVE-2018-16471](https://nvd.nist.gov/vuln/detail/CVE-2018-16471)
and [CVE-2018-16470](https://nvd.nist.gov/vuln/detail/CVE-2018-16470)

[ci skip] because no testable files were touched.