### PR TITLE
Capistrano: Fix 500 page generation

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -119,7 +119,7 @@ namespace :deploy do
     on roles(:web) do |host|
       public_500_html = File.join(release_path, 'public/500.html')
       execute :curl,
-              '-k',
+              '-k -L',
               "https://#{host.hostname}/500", "> #{public_500_html}"
     end
   end


### PR DESCRIPTION
When generating the 500 error page, curl is called on the hostname with
path 500. In our case, the hostname is openly.one but the error page
lives at www.openly.one. Curl did not follow the redirect, so the 500
page became a 'moved permanently' message. Add flag -L to instruct curl
to follow redirects.

[ci skip] because no testable files were touched.