### PR TITLE
Backup database & attachments on deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ bower.json
 
 # Ignore any temporary files placed under public spec
 /public/spec
+
+# Ignore backups
+/backup

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ branches:
 env:
   global:
     - CI=true
+    - ALL_TESTS=true
     - APPLICATION_DOMAIN=openly.one
     - GOOGLE_DRIVE_TRACKING_ACCOUNT=example.one@gmail.com
     - GOOGLE_DRIVE_USER_ACCOUNT=example.two@gmail.com

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -57,7 +57,8 @@ set :linked_dirs,
     %W[public/.well-known
        tmp/pids
        log
-       #{Settings.attachment_storage}]
+       #{Settings.attachment_storage}
+       #{Settings.backup_storage}]
 
 namespace :puma do
   desc 'Create Directories for Puma Pids and Socket'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -97,6 +97,19 @@ task :invoke, [:command] => 'deploy:set_rails_env' do |_task, args|
   end
 end
 
+namespace :backup do
+  desc 'Backup the database'
+  task :database do
+    on roles(:app) do
+      within release_path do
+        with rails_env: fetch(:rails_env) do
+          execute :rake, 'backup:database'
+        end
+      end
+    end
+  end
+end
+
 namespace :deploy do
   desc 'Make sure local git is in sync with remote.'
   task :check_revision do
@@ -126,6 +139,7 @@ namespace :deploy do
   end
 
   before :starting,       :check_revision
+  after  :finishing,      'backup:database'
   after  :finishing,      :compile_assets
   after  :migrate,        'paperclip:build_missing_styles'
   after  :finishing,      :cleanup

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -98,12 +98,29 @@ task :invoke, [:command] => 'deploy:set_rails_env' do |_task, args|
 end
 
 namespace :backup do
+  desc 'Backup database & attachments'
+  task :all do
+    invoke 'backup:database'
+    invoke 'backup:attachments'
+  end
+
   desc 'Backup the database'
   task :database do
     on roles(:app) do
       within release_path do
         with rails_env: fetch(:rails_env) do
           execute :rake, 'backup:database'
+        end
+      end
+    end
+  end
+
+  desc 'Backup the attachments'
+  task :attachments do
+    on roles(:app) do
+      within release_path do
+        with rails_env: fetch(:rails_env) do
+          execute :rake, 'backup:attachments'
         end
       end
     end
@@ -139,7 +156,7 @@ namespace :deploy do
   end
 
   before :starting,       :check_revision
-  after  :finishing,      'backup:database'
+  after  :finishing,      'backup:all'
   after  :finishing,      :compile_assets
   after  :migrate,        'paperclip:build_missing_styles'
   after  :finishing,      :cleanup

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,6 +10,8 @@ app_slug: <%= ENV['APPLICATION_SLUG'] || 'openly' %>
 app_url: "www.<%= ENV['APPLICATION_DOMAIN'] %>"
 # The location for storing Paperclip attachments, such as profile pictures
 attachment_storage: 'public/system'
+# The location for storing backups of database and attachments
+backup_storage: 'backup'
 # Allow users to register new accounts
 enable_account_registration: true
 # The account used to access, monitor, and manage files

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,2 +1,3 @@
 # The location for storing Paperclip attachments, such as profile pictures
 attachment_storage: 'public/spec/system'
+backup_storage: 'spec/tmp/backup'

--- a/lib/tasks/backup/all.rake
+++ b/lib/tasks/backup/all.rake
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+desc 'Backup: Backup the database and attachments'
+namespace :backup do
+  task all: ['backup:database', 'backup:attachments']
+end

--- a/lib/tasks/backup/attachments.rake
+++ b/lib/tasks/backup/attachments.rake
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+desc 'Backup: Create a backup of the (Paperclip) attachments'
+namespace :backup do
+  task attachments: ['attachments:capture']
+end

--- a/lib/tasks/backup/attachments/attachments_backup_task_helper.rb
+++ b/lib/tasks/backup/attachments/attachments_backup_task_helper.rb
@@ -19,6 +19,13 @@ class AttachmentsBackupTaskHelper < BackupTaskHelper
     backup_directory.join("#{timestamp}_#{Rails.env}_attachments")
   end
 
+  # Should the backup be performed?
+  # Yes, if attachment folder exists
+  # No, if no attachments exist
+  def self.perform_backup?
+    File.exist?(attachments_directory)
+  end
+
   def self.timestamp
     Time.now.strftime('%Y-%m-%d-%Hh-%Mm-%Ss')
   end

--- a/lib/tasks/backup/attachments/attachments_backup_task_helper.rb
+++ b/lib/tasks/backup/attachments/attachments_backup_task_helper.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative '../backup_task_helper.rb'
+
+# Helper for attachments backup tasks
+class AttachmentsBackupTaskHelper < BackupTaskHelper
+  # The directory where attachments are stored
+  def self.attachments_directory
+    Rails.root.join(Settings.attachment_storage)
+  end
+
+  # The directory for storing database backups
+  def self.backup_directory
+    toplevel_backup_directory.join('attachments')
+  end
+
+  # Return the path for a new backup
+  def self.path_for_new_backup
+    backup_directory.join("#{timestamp}_#{Rails.env}_attachments")
+  end
+
+  def self.timestamp
+    Time.now.strftime('%Y-%m-%d-%Hh-%Mm-%Ss')
+  end
+end

--- a/lib/tasks/backup/attachments/capture.rake
+++ b/lib/tasks/backup/attachments/capture.rake
@@ -6,6 +6,11 @@ namespace :backup do
   namespace :attachments do
     desc 'Backup: Attachments: Backup the attachments using recursive copy'
     task capture: %i[environment create_directory] do
+      unless AttachmentsBackupTaskHelper.perform_backup?
+        puts 'Skipping backup of attachments because no attachments exist'
+        next
+      end
+
       backup_path = AttachmentsBackupTaskHelper.path_for_new_backup
 
       puts "Capturing backup of attachments to #{backup_path}..."

--- a/lib/tasks/backup/attachments/capture.rake
+++ b/lib/tasks/backup/attachments/capture.rake
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative 'attachments_backup_task_helper.rb'
+
+namespace :backup do
+  namespace :attachments do
+    desc 'Backup: Attachments: Backup the attachments using recursive copy'
+    task capture: %i[environment create_directory] do
+      backup_path = AttachmentsBackupTaskHelper.path_for_new_backup
+
+      puts "Capturing backup of attachments to #{backup_path}..."
+
+      FileUtils.copy_entry(
+        AttachmentsBackupTaskHelper.attachments_directory,
+        backup_path,
+        preserve: true
+      )
+
+      backup_size =
+        (`du -b -s #{backup_path}`.split.first.to_i / 1.0.megabyte).round(3)
+
+      puts "Done. File size of backup: #{backup_size} MB"
+    end
+  end
+end

--- a/lib/tasks/backup/attachments/create_directory.rake
+++ b/lib/tasks/backup/attachments/create_directory.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative 'attachments_backup_task_helper.rb'
+
+namespace :backup do
+  desc 'Backup: Database: Create the directory for storing attachment backups'
+  namespace :attachments do
+    task create_directory: :environment do
+      backup_directory = AttachmentsBackupTaskHelper.backup_directory
+
+      puts "Creating #{backup_directory}..."
+      FileUtils.mkdir_p(backup_directory)
+      puts 'Done'
+    end
+  end
+end

--- a/lib/tasks/backup/backup_task_helper.rb
+++ b/lib/tasks/backup/backup_task_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Helper class for backup tasks
+class BackupTaskHelper
+  def self.toplevel_backup_directory
+    Rails.root.join(Settings.backup_storage)
+  end
+end

--- a/lib/tasks/backup/database.rake
+++ b/lib/tasks/backup/database.rake
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+desc 'Backup: Create a backup of the database'
+namespace :backup do
+  task database: ['database:capture']
+end

--- a/lib/tasks/backup/database/capture.rake
+++ b/lib/tasks/backup/database/capture.rake
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'open3'
+require_relative 'database_backup_task_helper.rb'
+
+namespace :backup do
+  desc 'Backup: Database: Backup the database using pg_dump'
+  namespace :database do
+    task capture: %i[environment create_directory] do
+      backup_path = DatabaseBackupTaskHelper.path_for_new_backup
+
+      puts "Capturing backup of #{DatabaseBackupTaskHelper.database_name} " \
+           "to #{backup_path}..."
+
+      _stdout, stderr, status = Open3.capture3(
+        DatabaseBackupTaskHelper.authentication_environment_variables,
+        'pg_dump',
+        '--format=custom',
+        '--verbose',
+        '--no-owner',
+        '--oids',
+        '--dbname',
+        DatabaseBackupTaskHelper.database_name,
+        '--file',
+        backup_path.to_s
+      )
+
+      # Print stderr because stdout is empty on success
+      puts stderr
+      raise("Error encountered: #{status}") unless status.success?
+
+      backup_size = (File.size(backup_path) / 1.0.megabyte).round(3)
+
+      puts "Done. File size of backup: #{backup_size} MB"
+    end
+  end
+end

--- a/lib/tasks/backup/database/create_directory.rake
+++ b/lib/tasks/backup/database/create_directory.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative 'database_backup_task_helper.rb'
+
+namespace :backup do
+  desc 'Backup: Database: Create the directory for storing database backups'
+  namespace :database do
+    task create_directory: :environment do
+      backup_directory = DatabaseBackupTaskHelper.backup_directory
+
+      puts "Creating #{backup_directory}..."
+      FileUtils.mkdir_p(backup_directory)
+      puts 'Done'
+    end
+  end
+end

--- a/lib/tasks/backup/database/database_backup_task_helper.rb
+++ b/lib/tasks/backup/database/database_backup_task_helper.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative '../backup_task_helper.rb'
+
+# Helper for database backup tasks
+class DatabaseBackupTaskHelper < BackupTaskHelper
+  class << self
+    delegate :connection_config, to: 'ActiveRecord::Base'
+    alias config connection_config
+  end
+
+  # The directory for storing database backups
+  def self.backup_directory
+    toplevel_backup_directory.join('database')
+  end
+
+  # Name of the database to backup
+  def self.database_name
+    config.fetch(:database)
+  end
+
+  # Name of the database user
+  def self.username
+    config.fetch(:username, nil)
+  end
+
+  # Password of the database user
+  def self.password
+    config.fetch(:password, nil)
+  end
+
+  def self.authentication_environment_variables
+    {}.tap do |hash|
+      hash['PGUSER']      = username if username.present?
+      hash['PGPASSWORD']  = password if password.present?
+    end
+  end
+
+  # Return the path for a new backup
+  def self.path_for_new_backup
+    backup_directory.join("#{timestamp}_#{database_name}.dump")
+  end
+
+  def self.timestamp
+    Time.now.strftime('%Y-%m-%d-%Hh-%Mm-%Ss')
+  end
+end

--- a/spec/lib/shared_contexts/rake.rb
+++ b/spec/lib/shared_contexts/rake.rb
@@ -3,33 +3,49 @@
 require 'rake'
 
 shared_context 'rake' do
-  let(:rake)      { Rake::Application.new }
-  let(:task_name) { self.class.top_level_description }
-  let(:task_path) { "lib/tasks/#{task_name.split(':').first}" }
-  subject(:task)  { rake[task_name] }
+  subject(:task) { Rake.application[task_name] }
 
-  def loaded_files_excluding_current_rake_file
+  # The name of the task can be derived from the name of the spec
+  let(:task_name) { self.class.top_level_description }
+  # Specify additional tasks to load upon which the main task depends
+  let(:tasks_to_load) { [] }
+
+  # Helper method for loading paths
+  def loaded_files_excluding(path)
     $LOADED_FEATURES
-      .reject { |file| file == Rails.root.join("#{task_path}.rake").to_s }
+      .reject { |file| file == Rails.root.join("#{path}.rake").to_s }
   end
 
   # Reenable all rake tasks to allow them being called a second time
   def reenable_all_tasks
-    rake.tasks.each(&:reenable)
+    Rake.application.tasks.each(&:reenable)
+  end
+
+  # The path to a task
+  def path_to_task(task_name)
+    "lib/tasks/#{task_name.to_s.tr(':', '/')}"
   end
 
   before do
-    Rake.application = rake
-    Rake.application.rake_require(
-      task_path, [Rails.root.to_s], loaded_files_excluding_current_rake_file
-    )
-    if defined? depends_on_task_paths
-      depends_on_task_paths.each do |task|
-        Rake.application.rake_require(
-          task, [Rails.root.to_s], loaded_files_excluding_current_rake_file
-        )
-      end
+    Rake.application ||= Rake::Application.new
+
+    # Load each task if not yet defined
+    ([task_name] + tasks_to_load).each do |task|
+      next if Rake::Task.task_defined?(task)
+
+      path = path_to_task(task)
+
+      Rake.application.rake_require(
+        path, [Rails.root.to_s], loaded_files_excluding(path)
+      )
     end
+
+    # Allow all tasks to be called
+    reenable_all_tasks
+
+    # Define default environment task because it is needed by almost every
+    # Rake task
+    next if Rake::Task.task_defined?(:environment)
 
     Rake::Task.define_task(:environment)
   end

--- a/spec/lib/shared_contexts/rake.rb
+++ b/spec/lib/shared_contexts/rake.rb
@@ -6,11 +6,16 @@ shared_context 'rake' do
   let(:rake)      { Rake::Application.new }
   let(:task_name) { self.class.top_level_description }
   let(:task_path) { "lib/tasks/#{task_name.split(':').first}" }
-  subject         { rake[task_name] }
+  subject(:task)  { rake[task_name] }
 
   def loaded_files_excluding_current_rake_file
     $LOADED_FEATURES
       .reject { |file| file == Rails.root.join("#{task_path}.rake").to_s }
+  end
+
+  # Reenable all rake tasks to allow them being called a second time
+  def reenable_all_tasks
+    rake.tasks.each(&:reenable)
   end
 
   before do
@@ -18,6 +23,13 @@ shared_context 'rake' do
     Rake.application.rake_require(
       task_path, [Rails.root.to_s], loaded_files_excluding_current_rake_file
     )
+    if defined? depends_on_task_paths
+      depends_on_task_paths.each do |task|
+        Rake.application.rake_require(
+          task, [Rails.root.to_s], loaded_files_excluding_current_rake_file
+        )
+      end
+    end
 
     Rake::Task.define_task(:environment)
   end

--- a/spec/lib/tasks/accounts_create_from_csv_spec.rb
+++ b/spec/lib/tasks/accounts_create_from_csv_spec.rb
@@ -5,7 +5,6 @@ require 'lib/shared_contexts/rake.rb'
 RSpec.describe 'accounts:create_from_csv' do
   include_context 'rake'
 
-  let(:task_path)   { "lib/tasks/#{task_name.tr(':', '/')}" }
   let(:path_to_csv) { 'spec/support/fixtures/accounts/import.csv' }
 
   let(:account1)    { Account.find_by_email('a1@example.com') }

--- a/spec/lib/tasks/backup/all_spec.rb
+++ b/spec/lib/tasks/backup/all_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe 'backup:all' do
       ActiveRecord::Base.remove_connection
       system('rake db:drop RAILS_ENV=test', out: File::NULL)
       system('rake db:create RAILS_ENV=test', out: File::NULL)
+      system('rake db:schema:load RAILS_ENV=test', out: File::NULL)
       ActiveRecord::Base.establish_connection
     end
 

--- a/spec/lib/tasks/backup/all_spec.rb
+++ b/spec/lib/tasks/backup/all_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'lib/shared_contexts/rake.rb'
+
+RSpec.describe 'backup:all' do
+  include_context 'rake'
+
+  subject(:run_task) { task.invoke }
+
+  let(:task_path) { "lib/tasks/#{task_name.tr(':', '/')}" }
+  let(:depends_on_task_paths) do
+    ['lib/tasks/backup/database',
+     'lib/tasks/backup/database/capture',
+     'lib/tasks/backup/database/create_directory',
+     'lib/tasks/backup/attachments',
+     'lib/tasks/backup/attachments/capture',
+     'lib/tasks/backup/attachments/create_directory']
+  end
+  let(:database_backups)    { Pathname.new(database_backups_path).children }
+  let(:attachment_backups)  { Pathname.new(attachment_backups_path).children }
+  let(:backups_path)        { Rails.root.join(Settings.backup_storage) }
+  let(:database_backups_path)   { backups_path.join('database') }
+  let(:attachment_backups_path) { backups_path.join('attachments') }
+
+  let(:attachments_path) { Rails.root.join(Settings.attachment_storage) }
+  let(:profile_picture) do
+    File.new(
+      Rails.root.join('spec', 'support', 'fixtures', 'profiles', 'picture.jpg')
+    )
+  end
+
+  before { allow(STDOUT).to receive(:puts) }
+
+  context 'when restoring backup', :no_db_cleaner, :slow do
+    before do
+      # create backup
+      create_list(:account, 3)
+      Profiles::User.find_each do |user|
+        user.update(picture: profile_picture)
+      end
+      run_task
+
+      # clear database
+      ActiveRecord::Base.remove_connection
+      system('rake db:drop RAILS_ENV=test', out: File::NULL)
+      system('rake db:create RAILS_ENV=test', out: File::NULL)
+
+      # clear attachments
+      FileUtils.rm_rf attachments_path
+    end
+
+    # Ensure state restoration
+    after do
+      ActiveRecord::Base.remove_connection
+      system('rake db:drop RAILS_ENV=test', out: File::NULL)
+      system('rake db:create RAILS_ENV=test', out: File::NULL)
+      ActiveRecord::Base.establish_connection
+    end
+
+    it 'succeeds' do
+      # import database
+      `pg_restore \
+       -d #{Rails.configuration.database_configuration['test']['database']} \
+       -1 \
+       #{database_backups.first.to_s}`
+
+      # import images
+      FileUtils.copy_entry(
+        attachment_backups.first.to_s,
+        attachments_path,
+        preserve: true
+      )
+
+      # reconnect to database
+      ActiveRecord::Base.establish_connection
+
+      expect(Account.count).to eq 3
+      Profiles::User.find_each do |user|
+        expect(user.picture).to be_exists
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/backup/all_spec.rb
+++ b/spec/lib/tasks/backup/all_spec.rb
@@ -7,14 +7,13 @@ RSpec.describe 'backup:all' do
 
   subject(:run_task) { task.invoke }
 
-  let(:task_path) { "lib/tasks/#{task_name.tr(':', '/')}" }
-  let(:depends_on_task_paths) do
-    ['lib/tasks/backup/database',
-     'lib/tasks/backup/database/capture',
-     'lib/tasks/backup/database/create_directory',
-     'lib/tasks/backup/attachments',
-     'lib/tasks/backup/attachments/capture',
-     'lib/tasks/backup/attachments/create_directory']
+  let(:tasks_to_load) do
+    ['backup:database',
+     'backup:database:capture',
+     'backup:database:create_directory',
+     'backup:attachments',
+     'backup:attachments:capture',
+     'backup:attachments:create_directory']
   end
   let(:database_backups)    { Pathname.new(database_backups_path).children }
   let(:attachment_backups)  { Pathname.new(attachment_backups_path).children }

--- a/spec/lib/tasks/backup/attachments_spec.rb
+++ b/spec/lib/tasks/backup/attachments_spec.rb
@@ -43,4 +43,10 @@ RSpec.describe 'backup:attachments' do
       expect(backups.count).to eq 2
     end
   end
+
+  context 'when attachment folder does not exist' do
+    before { FileUtils.rm_rf Rails.root.join(Settings.attachment_storage) }
+
+    it { expect { run_task }.not_to raise_error }
+  end
 end

--- a/spec/lib/tasks/backup/attachments_spec.rb
+++ b/spec/lib/tasks/backup/attachments_spec.rb
@@ -7,10 +7,9 @@ RSpec.describe 'backup:attachments' do
 
   subject(:run_task) { task.invoke }
 
-  let(:task_path) { "lib/tasks/#{task_name.tr(':', '/')}" }
-  let(:depends_on_task_paths) do
-    ['lib/tasks/backup/attachments/capture',
-     'lib/tasks/backup/attachments/create_directory']
+  let(:tasks_to_load) do
+    ['backup:attachments:capture',
+     'backup:attachments:create_directory']
   end
   let(:backups)      { Pathname.new(backups_path).children }
   let(:backups_path) { Rails.root.join(Settings.backup_storage, 'attachments') }

--- a/spec/lib/tasks/backup/attachments_spec.rb
+++ b/spec/lib/tasks/backup/attachments_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'lib/shared_contexts/rake.rb'
+
+RSpec.describe 'backup:attachments' do
+  include_context 'rake'
+
+  subject(:run_task) { task.invoke }
+
+  let(:task_path) { "lib/tasks/#{task_name.tr(':', '/')}" }
+  let(:depends_on_task_paths) do
+    ['lib/tasks/backup/attachments/capture',
+     'lib/tasks/backup/attachments/create_directory']
+  end
+  let(:backups)      { Pathname.new(backups_path).children }
+  let(:backups_path) { Rails.root.join(Settings.backup_storage, 'attachments') }
+
+  before { allow(STDOUT).to receive(:puts) }
+
+  let(:profile_picture) do
+    File.new(
+      Rails.root.join('spec', 'support', 'fixtures', 'profiles', 'picture.jpg')
+    )
+  end
+
+  before { create(:user, picture: profile_picture) }
+
+  it 'creates a backup' do
+    run_task
+    expect(backups.count).to eq 1
+  end
+
+  context 'when creating a second backup' do
+    include ActiveSupport::Testing::TimeHelpers
+
+    before { task.invoke }
+
+    it 'does not overwrite first backup' do
+      travel 1.day do
+        reenable_all_tasks
+        run_task
+      end
+      expect(backups.count).to eq 2
+    end
+  end
+end

--- a/spec/lib/tasks/backup/database_spec.rb
+++ b/spec/lib/tasks/backup/database_spec.rb
@@ -35,36 +35,4 @@ RSpec.describe 'backup:database' do
       expect(backups.count).to eq 2
     end
   end
-
-  context 'when restoring backup', :no_db_cleaner, :slow do
-    before do
-      # create backup
-      create_list(:account, 3)
-      run_task
-
-      # clear database
-      ActiveRecord::Base.remove_connection
-      system('rake db:drop RAILS_ENV=test', out: File::NULL)
-      system('rake db:create RAILS_ENV=test', out: File::NULL)
-    end
-
-    # Ensure state restoration
-    after do
-      system('rake db:create RAILS_ENV=test', out: File::NULL, err: File::NULL)
-      ActiveRecord::Base.establish_connection
-    end
-
-    it 'succeeds' do
-      # import database
-      `pg_restore \
-       -d #{Rails.configuration.database_configuration['test']['database']} \
-       -1 \
-       #{backups.first.to_s}`
-
-      # reconnect to database
-      ActiveRecord::Base.establish_connection
-
-      expect(Account.count).to eq 3
-    end
-  end
 end

--- a/spec/lib/tasks/backup/database_spec.rb
+++ b/spec/lib/tasks/backup/database_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'lib/shared_contexts/rake.rb'
+
+RSpec.describe 'backup:database' do
+  include_context 'rake'
+
+  subject(:run_task) { task.invoke }
+
+  let(:task_path) { "lib/tasks/#{task_name.tr(':', '/')}" }
+  let(:depends_on_task_paths) do
+    ['lib/tasks/backup/database/capture',
+     'lib/tasks/backup/database/create_directory']
+  end
+  let(:backups)       { Pathname.new(backups_path).children }
+  let(:backups_path)  { Rails.root.join(Settings.backup_storage, 'database') }
+
+  before { allow(STDOUT).to receive(:puts) }
+
+  it 'creates a backup' do
+    run_task
+    expect(backups.count).to eq 1
+  end
+
+  context 'when creating a second backup' do
+    include ActiveSupport::Testing::TimeHelpers
+
+    before { task.invoke }
+
+    it 'does not overwrite first backup' do
+      travel 1.day do
+        reenable_all_tasks
+        run_task
+      end
+      expect(backups.count).to eq 2
+    end
+  end
+end

--- a/spec/lib/tasks/backup/database_spec.rb
+++ b/spec/lib/tasks/backup/database_spec.rb
@@ -7,10 +7,9 @@ RSpec.describe 'backup:database' do
 
   subject(:run_task) { task.invoke }
 
-  let(:task_path) { "lib/tasks/#{task_name.tr(':', '/')}" }
-  let(:depends_on_task_paths) do
-    ['lib/tasks/backup/database/capture',
-     'lib/tasks/backup/database/create_directory']
+  let(:tasks_to_load) do
+    ['backup:database:capture',
+     'backup:database:create_directory']
   end
   let(:backups)       { Pathname.new(backups_path).children }
   let(:backups_path)  { Rails.root.join(Settings.backup_storage, 'database') }

--- a/spec/lib/tasks/backup/database_spec.rb
+++ b/spec/lib/tasks/backup/database_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'backup:database' do
     end
   end
 
-  context 'when restoring backup', :no_db_cleaner do
+  context 'when restoring backup', :no_db_cleaner, :slow do
     before do
       # create backup
       create_list(:account, 3)

--- a/spec/lib/tasks/backup/database_spec.rb
+++ b/spec/lib/tasks/backup/database_spec.rb
@@ -35,4 +35,36 @@ RSpec.describe 'backup:database' do
       expect(backups.count).to eq 2
     end
   end
+
+  context 'when restoring backup', :no_db_cleaner do
+    before do
+      # create backup
+      create_list(:account, 3)
+      run_task
+
+      # clear database
+      ActiveRecord::Base.remove_connection
+      system('rake db:drop RAILS_ENV=test', out: File::NULL)
+      system('rake db:create RAILS_ENV=test', out: File::NULL)
+    end
+
+    # Ensure state restoration
+    after do
+      system('rake db:create RAILS_ENV=test', out: File::NULL, err: File::NULL)
+      ActiveRecord::Base.establish_connection
+    end
+
+    it 'succeeds' do
+      # import database
+      `pg_restore \
+       -d #{Rails.configuration.database_configuration['test']['database']} \
+       -1 \
+       #{backups.first.to_s}`
+
+      # reconnect to database
+      ActiveRecord::Base.establish_connection
+
+      expect(Account.count).to eq 3
+    end
+  end
 end

--- a/spec/lib/tasks/data_migration/file_snapshots_content_spec.rb
+++ b/spec/lib/tasks/data_migration/file_snapshots_content_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe 'data_migration:file_snapshots_content', :archived do
   include_context 'rake'
 
   let(:run_the_task) { subject.invoke }
-  let(:task_path)    { "lib/tasks/#{task_name.tr(':', '/')}" }
 
   let!(:snapshots) { create_list(:vcs_file_snapshot, 3) }
 

--- a/spec/lib/tasks/data_migration/file_thumbnails_spec.rb
+++ b/spec/lib/tasks/data_migration/file_thumbnails_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe 'data_migration:file_thumbnails', :archived do
   include_context 'rake'
 
   let(:run_the_task) { subject.invoke }
-  let(:task_path)    { "lib/tasks/#{task_name.tr(':', '/')}" }
 
   let!(:old_thumbnails) do
     build_list(:vcs_file_thumbnail, 3, file_record_id: nil).each do |record|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -87,6 +87,7 @@ RSpec.configure do |config|
 
   # Skip archived specs, such as data migrations
   config.filter_run_excluding(archived: true)
+  config.filter_run_excluding(slow: true) unless ENV['ALL_TESTS']
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -38,11 +38,15 @@ RSpec.configure do |config|
     end
   end
 
-  config.before(:each) do
+  config.before(:each) do |example|
+    next if example.metadata[:no_db_cleaner]
+
     DatabaseCleaner.start
   end
 
-  config.append_after(:each) do
+  config.append_after(:each) do |example|
+    next if example.metadata[:no_db_cleaner]
+
     DatabaseCleaner.clean
   end
 end


### PR DESCRIPTION
When code has been pushed to the server but prior to running migrations,
perform a database and attachments backup.

The database can also be backed up by manually running the backup:database rake
task in the desired Rails environment. Backups are created using `pg_dump` and
are stored in a backup directory.

The attachments can also be backed up by manually running the backup:attachments
rake task in the desired Rails environment. Backups are created using recursive copy
and are stored in a backup directory.