### PR TITLE
Notifications: Fix order by sorting by ID descending

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -23,6 +23,6 @@ class NotificationsController < ApplicationController
   private
 
   def notifications
-    Notification.where(target: current_account)
+    Notification.where(target: current_account).order(id: :desc)
   end
 end

--- a/spec/regressions/controllers/notifications_controller_spec.rb
+++ b/spec/regressions/controllers/notifications_controller_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe NotificationsController, type: :controller do
+  let(:current_account) { create :account }
+  before                { sign_in current_account }
+
+  describe 'GET #index' do
+    let(:run_request) { get :index }
+
+    let(:relation) { instance_double ActiveRecord::Relation }
+
+    before do
+      allow(Notification).to receive(:where).and_return relation
+      allow(relation).to receive(:order).and_return relation
+      allow(relation).to receive(:includes)
+    end
+
+    it 'orders notifications in descending order' do
+      run_request
+      expect(relation).to have_received(:order).with(id: :desc)
+    end
+  end
+end


### PR DESCRIPTION
We had not specified an order on the SQL statement that loads
notifications. This led to notifications having a very inconsistent
order, with some new notifications showing up last while others were
showing up first.

Fix this by making order by ID descending explicit.