### PR TITLE
Hotfix 0.29.1: Backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v0.29.1 (Nov 24, 2018)
+
+**Fixes:**
+- Dereference source directory when backing up (Paperclip) attachments, so that
+  the actual files are copied and not just a symlink
+- On deployment, backup database and attachment before running migrations
+
 ## v0.29 (Nov 19, 2018)
 
 **New Features:**

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -156,8 +156,8 @@ namespace :deploy do
   end
 
   before :starting,       :check_revision
-  after  :finishing,      'backup:all'
   after  :finishing,      :compile_assets
+  before :migrate,        'backup:all'
   after  :migrate,        'paperclip:build_missing_styles'
   after  :finishing,      :cleanup
   after  :published,      :generate_500_html

--- a/lib/tasks/backup/attachments/capture.rake
+++ b/lib/tasks/backup/attachments/capture.rake
@@ -18,7 +18,8 @@ namespace :backup do
       FileUtils.copy_entry(
         AttachmentsBackupTaskHelper.attachments_directory,
         backup_path,
-        preserve: true
+        true, # preserve file permissions
+        true  # dereference source (b/c source is a symlink in production)
       )
 
       backup_size =


### PR DESCRIPTION
**Fixes:**
- Dereference source directory when backing up (Paperclip) attachments, so that
  the actual files are copied and not just a symlink
- On deployment, backup database and attachment before running migrations