### PR TITLE
Rename `external` to `remote`

### DIFF
--- a/app/controllers/file_infos_controller.rb
+++ b/app/controllers/file_infos_controller.rb
@@ -36,7 +36,7 @@ class FileInfosController < ApplicationController
       @project
       .repository
       .file_snapshots
-      .find_by!(external_id: params[:id])
+      .find_by!(remote_file_id: params[:id])
       .file_record_id
   end
 

--- a/app/controllers/file_restores_controller.rb
+++ b/app/controllers/file_restores_controller.rb
@@ -37,7 +37,7 @@ class FileRestoresController < ApplicationController
     # TODO: Redirect to file infos path by file record ID. That is the only
     # =>    stable identifier.
     profile_project_file_infos_path(@project.owner, @project,
-                                    staged_file.external_id)
+                                    staged_file.remote_file_id)
   end
 
   def set_file_snapshot

--- a/app/controllers/folders_controller.rb
+++ b/app/controllers/folders_controller.rb
@@ -34,7 +34,7 @@ class FoldersController < ApplicationController
   end
 
   def set_folder_from_param
-    @folder = @master_branch.staged_folders.find_by_external_id(params[:id])
+    @folder = @master_branch.staged_folders.find_by_remote_file_id(params[:id])
 
     raise ActiveRecord::RecordNotFound unless @folder&.staged_snapshot&.folder?
   end

--- a/app/controllers/force_syncs_controller.rb
+++ b/app/controllers/force_syncs_controller.rb
@@ -44,6 +44,6 @@ class ForceSyncsController < ApplicationController
   def set_file_resource
     @file =
       @project.master_branch
-              .staged_files.without_root.find_by!(external_id: file_id)
+              .staged_files.without_root.find_by!(remote_file_id: file_id)
   end
 end

--- a/app/controllers/revisions/folders_controller.rb
+++ b/app/controllers/revisions/folders_controller.rb
@@ -48,7 +48,7 @@ module Revisions
       @folder =
         @revision
         .committed_snapshots
-        .find_by!(external_id: params[:id])
+        .find_by!(remote_file_id: params[:id])
 
       # TODO: Don't check if file resource is folder NOW, check if committed
       # =>    file resource snapshot was folder BACK at commit

--- a/app/helpers/file_helper.rb
+++ b/app/helpers/file_helper.rb
@@ -13,7 +13,7 @@ module FileHelper
 
     # external link to the original file on Google Drive
     else
-      path = file.external_link
+      path = file.link_to_remote
       options = options.reverse_merge target: '_blank'
     end
 
@@ -45,7 +45,7 @@ module FileHelper
       profile_project_revision_folder_path(project.owner, project,
                                            revision.id, file.remote_file_id)
     else
-      file.backup&.external_link
+      file.backup&.link_to_remote
     end
   end
 end

--- a/app/helpers/file_helper.rb
+++ b/app/helpers/file_helper.rb
@@ -4,14 +4,14 @@
 module FileHelper
   # Wrap block into a link_to the file.
   # If the file is a directory, wraps into an internal link to that directory.
-  # If the file is not a directory, wraps into an external link to Drive.
+  # If the file is not a directory, wraps into an remote link to Drive.
   def link_to_file(file, project, options = {}, &block)
     # internal link to that folder
     if file.folder?
       path =
         profile_project_folder_path(project.owner, project, file.remote_file_id)
 
-    # external link to the original file on Google Drive
+    # remote link to the original file on Google Drive
     else
       path = file.link_to_remote
       options = options.reverse_merge target: '_blank'

--- a/app/helpers/file_helper.rb
+++ b/app/helpers/file_helper.rb
@@ -9,7 +9,7 @@ module FileHelper
     # internal link to that folder
     if file.folder?
       path =
-        profile_project_folder_path(project.owner, project, file.external_id)
+        profile_project_folder_path(project.owner, project, file.remote_file_id)
 
     # external link to the original file on Google Drive
     else
@@ -43,7 +43,7 @@ module FileHelper
   def file_backup_path(file, revision, project)
     if file.folder? && revision.published?
       profile_project_revision_folder_path(project.owner, project,
-                                           revision.id, file.external_id)
+                                           revision.id, file.remote_file_id)
     else
       file.backup&.external_link
     end

--- a/app/jobs/file_update_job.rb
+++ b/app/jobs/file_update_job.rb
@@ -52,17 +52,18 @@ class FileUpdateJob < ApplicationJob
 
   # TODO: Rename this to ChangesListJob. Extract into ChangeProcessJob.
   def process_change(change)
-    external_ids =
+    remote_file_ids =
       [change.file_id].concat(change&.file&.parents.to_a).compact.uniq
 
     # Find branches that have either the file or its parents staged
-    branches = VCS::Branch.where_staged_files_include_external_id(external_ids)
+    branches =
+      VCS::Branch.where_staged_files_include_remote_file_id(remote_file_ids)
 
     # Pull the file in each branch
     branches.find_each do |branch|
       # TODO: Extract into FileUpdateJob
       VCS::StagedFile.find_or_initialize_by(
-        external_id: change.file_id,
+        remote_file_id: change.file_id,
         branch: branch
       ).pull
     end

--- a/app/models/concerns/vcs/diffing.rb
+++ b/app/models/concerns/vcs/diffing.rb
@@ -7,8 +7,8 @@ module VCS
 
     # Delegations
     delegate :id, to: :current_or_previous_snapshot, prefix: true
-    delegate :external_id, :external_link, :folder?, :icon, :mime_type, :name,
-             :parent_id, :provider, :symbolic_mime_type, :thumbnail_id,
+    delegate :remote_file_id, :external_link, :folder?, :icon, :mime_type,
+             :name, :parent_id, :provider, :symbolic_mime_type, :thumbnail_id,
              :thumbnail_image, :thumbnail_image_or_fallback,
              to: :current_or_previous_snapshot
 

--- a/app/models/concerns/vcs/diffing.rb
+++ b/app/models/concerns/vcs/diffing.rb
@@ -7,7 +7,7 @@ module VCS
 
     # Delegations
     delegate :id, to: :current_or_previous_snapshot, prefix: true
-    delegate :remote_file_id, :external_link, :folder?, :icon, :mime_type,
+    delegate :remote_file_id, :link_to_remote, :folder?, :icon, :mime_type,
              :name, :parent_id, :provider, :symbolic_mime_type, :thumbnail_id,
              :thumbnail_image, :thumbnail_image_or_fallback,
              to: :current_or_previous_snapshot

--- a/app/models/concerns/vcs/downloadable.rb
+++ b/app/models/concerns/vcs/downloadable.rb
@@ -31,7 +31,7 @@ module VCS
 
       ContentDownloadJob.send(
         method,
-        remote_file_id: backup.external_id,
+        remote_file_id: backup.remote_file_id,
         content_id: content.id
       )
     end

--- a/app/models/concerns/vcs/having_remote.rb
+++ b/app/models/concerns/vcs/having_remote.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module VCS
+  # Adds support for performing actions on the remote
+  # Concerning model must implement the #remote_file_id attribute/method.
+  module HavingRemote
+    extend ActiveSupport::Concern
+
+    included do
+      attr_writer :remote
+    end
+
+    # Instantiate the remote
+    def remote
+      @remote ||= remote_class.new(remote_file_id)
+    end
+
+    # Reset the remote when calling #reload
+    def reload
+      reset_remote
+      super
+    end
+
+    private
+
+    # Reset the remote
+    def reset_remote
+      @remote = nil
+    end
+
+    # The class for the remote
+    def remote_class
+      'Providers::GoogleDrive::FileSync'.constantize
+    end
+  end
+end

--- a/app/models/concerns/vcs/resourceable.rb
+++ b/app/models/concerns/vcs/resourceable.rb
@@ -23,7 +23,10 @@ module VCS
     end
 
     def external_link
-      provider_link_class.for(external_id: external_id, mime_type: mime_type)
+      provider_link_class.for(
+        remote_file_id: remote_file_id,
+        mime_type: mime_type
+      )
     end
 
     def icon

--- a/app/models/concerns/vcs/resourceable.rb
+++ b/app/models/concerns/vcs/resourceable.rb
@@ -22,7 +22,7 @@ module VCS
       folder? || folder_before_last_save?
     end
 
-    def external_link
+    def link_to_remote
       provider_link_class.for(
         remote_file_id: remote_file_id,
         mime_type: mime_type

--- a/app/models/concerns/vcs/syncable.rb
+++ b/app/models/concerns/vcs/syncable.rb
@@ -49,7 +49,7 @@ module VCS
     end
 
     def remote
-      @remote ||= remote_class.new(external_id)
+      @remote ||= remote_class.new(remote_file_id)
     end
 
     # Get version ID of thumbnail
@@ -67,7 +67,7 @@ module VCS
               .create_with(remote: remote_child)
               .find_or_initialize_by(
                 branch: branch,
-                external_id: remote_child.id
+                remote_file_id: remote_child.id
               )
 
         # Pull (fetch+save) child if it is a new record
@@ -78,7 +78,8 @@ module VCS
     # Find an instance of syncable's class from the external parent ID
     # and set instance to parent of current syncable resource
     def external_parent_id=(external_parent_id)
-      self.parent = branch.staged_files.find_by_external_id(external_parent_id)
+      self.parent =
+        branch.staged_files.find_by_remote_file_id(external_parent_id)
     end
 
     # Reset the file's synchronization adapter

--- a/app/models/concerns/vcs/syncable.rb
+++ b/app/models/concerns/vcs/syncable.rb
@@ -6,7 +6,7 @@ module VCS
     extend ActiveSupport::Concern
 
     included do
-      attr_writer :sync_adapter
+      attr_writer :remote
       # Set force sync to execute all jobs synchronously
       attr_accessor :force_sync
     end
@@ -21,12 +21,12 @@ module VCS
     # Fetch the most recent information about this syncable resource from its
     # provider
     def fetch
-      self.is_deleted = sync_adapter.deleted?
-      self.name = sync_adapter.name
-      self.mime_type = sync_adapter.mime_type
-      self.content_version = sync_adapter.content_version
-      self.external_parent_id = sync_adapter.parent_id
-      thumbnail_from_sync_adapter
+      self.is_deleted = remote.deleted?
+      self.name = remote.name
+      self.mime_type = remote.mime_type
+      self.content_version = remote.content_version
+      self.external_parent_id = remote.parent_id
+      thumbnail_from_remote
     end
 
     # Fetch and save the most recent information about this syncable resource
@@ -39,35 +39,35 @@ module VCS
 
     # Fetch and save the children of this syncable resource from its provider
     def pull_children
-      self.staged_children = children_from_sync_adapter
+      self.staged_children = children_from_remote
     end
 
     # Reset sync state when calling #reload
     def reload
-      reset_sync_adapter
+      reset_remote
       super
     end
 
-    def sync_adapter
-      @sync_adapter ||= sync_adapter_class.new(external_id)
+    def remote
+      @remote ||= remote_class.new(external_id)
     end
 
     # Get version ID of thumbnail
     def thumbnail_version_id
-      sync_adapter&.thumbnail_version
+      remote&.thumbnail_version
     end
 
     private
 
     # Fetch children from sync adapter and convert to file resources
-    def children_from_sync_adapter
-      sync_adapter.children.map do |child_sync_adapter|
+    def children_from_remote
+      remote.children.map do |remote_child|
         staged_child =
           self.class
-              .create_with(sync_adapter: child_sync_adapter)
+              .create_with(remote: remote_child)
               .find_or_initialize_by(
                 branch: branch,
-                external_id: child_sync_adapter.id
+                external_id: remote_child.id
               )
 
         # Pull (fetch+save) child if it is a new record
@@ -82,24 +82,24 @@ module VCS
     end
 
     # Reset the file's synchronization adapter
-    def reset_sync_adapter
-      @sync_adapter = nil
+    def reset_remote
+      @remote = nil
       @destroy_on_save = nil
     end
 
-    def sync_adapter_class
+    def remote_class
       'Providers::GoogleDrive::FileSync'.constantize
     end
 
     # Set thumbnail from sync adapter, either by finding an existing thumbnail
     # for this file and its thumbnail version id or by creating a new one and
     # fetching the thumbnail
-    def thumbnail_from_sync_adapter
-      return unless sync_adapter.thumbnail?
+    def thumbnail_from_remote
+      return unless remote.thumbnail?
 
       self.thumbnail =
         VCS::FileThumbnail
-        .create_with(raw_image: proc { sync_adapter.thumbnail })
+        .create_with(raw_image: proc { remote.thumbnail })
         .find_or_initialize_by_staged_file(self)
     end
   end

--- a/app/models/concerns/vcs/syncable.rb
+++ b/app/models/concerns/vcs/syncable.rb
@@ -25,7 +25,7 @@ module VCS
       self.name = remote.name
       self.mime_type = remote.mime_type
       self.content_version = remote.content_version
-      self.external_parent_id = remote.parent_id
+      self.remote_parent_id = remote.parent_id
       thumbnail_from_remote
     end
 
@@ -65,11 +65,11 @@ module VCS
       end
     end
 
-    # Find an instance of syncable's class from the external parent ID
+    # Find an instance of syncable's class from the remote parent ID
     # and set instance to parent of current syncable resource
-    def external_parent_id=(external_parent_id)
+    def remote_parent_id=(remote_parent_id)
       self.parent =
-        branch.staged_files.find_by_remote_file_id(external_parent_id)
+        branch.staged_files.find_by_remote_file_id(remote_parent_id)
     end
 
     # Reset the file's synchronization adapter

--- a/app/models/concerns/vcs/syncable.rb
+++ b/app/models/concerns/vcs/syncable.rb
@@ -4,9 +4,9 @@ module VCS
   # A syncable file
   module Syncable
     extend ActiveSupport::Concern
+    include VCS::HavingRemote
 
     included do
-      attr_writer :remote
       # Set force sync to execute all jobs synchronously
       attr_accessor :force_sync
     end
@@ -42,16 +42,6 @@ module VCS
       self.staged_children = children_from_remote
     end
 
-    # Reset sync state when calling #reload
-    def reload
-      reset_remote
-      super
-    end
-
-    def remote
-      @remote ||= remote_class.new(remote_file_id)
-    end
-
     # Get version ID of thumbnail
     def thumbnail_version_id
       remote&.thumbnail_version
@@ -84,12 +74,8 @@ module VCS
 
     # Reset the file's synchronization adapter
     def reset_remote
-      @remote = nil
+      super
       @destroy_on_save = nil
-    end
-
-    def remote_class
-      'Providers::GoogleDrive::FileSync'.constantize
     end
 
     # Set thumbnail from sync adapter, either by finding an existing thumbnail

--- a/app/models/project/setup.rb
+++ b/app/models/project/setup.rb
@@ -121,7 +121,7 @@ class Project
       @file ||=
         master_branch
         .staged_files
-        .build(is_root: true, external_id: id_from_link)
+        .build(is_root: true, remote_file_id: id_from_link)
         .tap(&:fetch)
     end
 

--- a/app/models/providers/google_drive/link.rb
+++ b/app/models/providers/google_drive/link.rb
@@ -8,9 +8,10 @@ module Providers
         "https://#{subdomain}.google.com"
       end
 
-      def self.for(external_id:, mime_type:)
+      def self.for(remote_file_id:, mime_type:)
         type_symbol = MimeType.to_symbol(mime_type)
-        safe_send(:"for_#{type_symbol}", external_id) || for_other(external_id)
+        safe_send(:"for_#{type_symbol}", remote_file_id) ||
+          for_other(remote_file_id)
       end
 
       def self.for_document(id)

--- a/app/models/vcs/archive.rb
+++ b/app/models/vcs/archive.rb
@@ -36,7 +36,7 @@ module VCS
     def setup
       raise 'Already set up' if setup_completed?
 
-      create_external_folder
+      create_remote_folder
       # TODO: Move this to project and archive no longer needs to know the
       # =>    owner account
       grant_read_access_to(owner_account_email)
@@ -50,7 +50,7 @@ module VCS
     private
 
     # Creates the archive folder with the provider
-    def create_external_folder
+    def create_remote_folder
       folder = sync_adapter_class.create(
         name: "#{name} (Archive)",
         parent_id: 'root',

--- a/app/models/vcs/archive.rb
+++ b/app/models/vcs/archive.rb
@@ -13,7 +13,7 @@ module VCS
 
     # Validations
     validates :repository_id, uniqueness: { message: 'already has an archive' }
-    validates :external_id, presence: true
+    validates :remote_file_id, presence: true
 
     def default_api_connection
       api_connection_class.default
@@ -22,13 +22,13 @@ module VCS
     # Add the given email address as a viewer to the archive folder
     def grant_read_access_to(email)
       # TODO: Call method #share on remote_archive
-      default_api_connection.share_file(external_id, email, :reader)
+      default_api_connection.share_file(remote_file_id, email, :reader)
     end
 
     # Remove the given email address as a viewer from the archive folder
     def remove_read_access_from(email)
       # TODO: Call method #unshare on remote_archive
-      default_api_connection.unshare_file(external_id, email)
+      default_api_connection.unshare_file(remote_file_id, email)
     end
 
     # Set up the archive folder with the provider by creating it and granting
@@ -44,7 +44,7 @@ module VCS
 
     # Return true if setup has been completed (i.e. file resource is present)
     def setup_completed?
-      external_id.present?
+      remote_file_id.present?
     end
 
     private
@@ -56,7 +56,7 @@ module VCS
         parent_id: 'root',
         mime_type: mime_type_class.folder
       )
-      self.external_id = folder.id
+      self.remote_file_id = folder.id
     end
 
     def api_connection_class

--- a/app/models/vcs/branch.rb
+++ b/app/models/vcs/branch.rb
@@ -49,10 +49,10 @@ module VCS
     # Scopes
     # Return branches that have one or more staged files with the given
     # external IDs
-    scope :where_staged_files_include_external_id, lambda { |external_ids|
+    scope :where_staged_files_include_remote_file_id, lambda { |remote_file_ids|
       joins(:staged_files)
         .merge(VCS::StagedFile.joins_staged_snapshot)
-        .where(vcs_staged_files: { external_id: external_ids.to_a })
+        .where(vcs_staged_files: { remote_file_id: remote_file_ids.to_a })
         .distinct
     }
   end

--- a/app/models/vcs/branch.rb
+++ b/app/models/vcs/branch.rb
@@ -48,7 +48,7 @@ module VCS
 
     # Scopes
     # Return branches that have one or more staged files with the given
-    # external IDs
+    # remote IDs
     scope :where_staged_files_include_remote_file_id, lambda { |remote_file_ids|
       joins(:staged_files)
         .merge(VCS::StagedFile.joins_staged_snapshot)

--- a/app/models/vcs/file_backup.rb
+++ b/app/models/vcs/file_backup.rb
@@ -39,7 +39,7 @@ module VCS
     end
 
     # TODO: Refactor onto snapshot
-    def external_link
+    def link_to_remote
       Providers::GoogleDrive::Link
         .for(remote_file_id: remote_file_id, mime_type: file_snapshot.mime_type)
     end

--- a/app/models/vcs/file_backup.rb
+++ b/app/models/vcs/file_backup.rb
@@ -11,7 +11,7 @@ module VCS
               presence: { message: 'must exist' },
               uniqueness: { message: 'already has a backup' }
     validates :archive, presence: true, on: :capture
-    validates :external_id, presence: true, on: %i[create update]
+    validates :remote_file_id, presence: true, on: %i[create update]
 
     # TODO: after_destroy --> destroy backup if this is last reference to it
 
@@ -35,13 +35,13 @@ module VCS
 
       return false unless file.present?
 
-      self.external_id = file.id
+      self.remote_file_id = file.id
     end
 
     # TODO: Refactor onto snapshot
     def external_link
       Providers::GoogleDrive::Link
-        .for(external_id: external_id, mime_type: file_snapshot.mime_type)
+        .for(remote_file_id: remote_file_id, mime_type: file_snapshot.mime_type)
     end
 
     private
@@ -51,11 +51,11 @@ module VCS
     end
 
     def archive_folder_id
-      archive.external_id
+      archive.remote_file_id
     end
 
     def staged_file_remote
-      sync_adapter_class.new(file_snapshot.external_id)
+      sync_adapter_class.new(file_snapshot.remote_file_id)
     end
 
     def provider

--- a/app/models/vcs/file_diff/change.rb
+++ b/app/models/vcs/file_diff/change.rb
@@ -44,7 +44,7 @@ module VCS
         type == 'deletion'
       end
 
-      # The identifier for the change, consisting of external ID and change type
+      # The identifier for the change, consisting of remote ID and change type
       def id
         "#{remote_file_id}_#{type}"
       end

--- a/app/models/vcs/file_diff/change.rb
+++ b/app/models/vcs/file_diff/change.rb
@@ -10,8 +10,8 @@ module VCS
 
       # Delegations
       delegate :ancestor_path, :current_snapshot, :current_snapshot=,
-               :current_or_previous_snapshot, :file_resource_id, :external_id,
-               :icon, :name, :parent_id, :previous_parent_id,
+               :current_or_previous_snapshot, :file_resource_id,
+               :remote_file_id, :icon, :name, :parent_id, :previous_parent_id,
                :previous_snapshot, :symbolic_mime_type, :revision,
                :content_change,
                to: :diff
@@ -46,7 +46,7 @@ module VCS
 
       # The identifier for the change, consisting of external ID and change type
       def id
-        "#{external_id}_#{type}"
+        "#{remote_file_id}_#{type}"
       end
 
       # Return true if the change is a ::Modification

--- a/app/models/vcs/file_diff/changes/modification.rb
+++ b/app/models/vcs/file_diff/changes/modification.rb
@@ -30,7 +30,7 @@ module VCS
         end
 
         # Undo modification of the file resource
-        # TODO: Remove rolling back of external ID & content version
+        # TODO: Remove rolling back of remote ID & content version
         # rubocop:disable Metrics/AbcSize
         def unapply
           current_snapshot.content_id       = previous_snapshot.content_id

--- a/app/models/vcs/file_diff/changes/modification.rb
+++ b/app/models/vcs/file_diff/changes/modification.rb
@@ -33,11 +33,11 @@ module VCS
         # TODO: Remove rolling back of external ID & content version
         # rubocop:disable Metrics/AbcSize
         def unapply
-          current_snapshot.content_id      = previous_snapshot.content_id
-          current_snapshot.content_version = previous_snapshot.content_version
-          current_snapshot.mime_type       = previous_snapshot.mime_type
-          current_snapshot.external_id     = previous_snapshot.external_id
-          current_snapshot.thumbnail_id    = previous_snapshot.thumbnail_id
+          current_snapshot.content_id       = previous_snapshot.content_id
+          current_snapshot.content_version  = previous_snapshot.content_version
+          current_snapshot.mime_type        = previous_snapshot.mime_type
+          current_snapshot.remote_file_id   = previous_snapshot.remote_file_id
+          current_snapshot.thumbnail_id     = previous_snapshot.thumbnail_id
         end
         # rubocop:enable Metrics/AbcSize
       end

--- a/app/models/vcs/file_snapshot.rb
+++ b/app/models/vcs/file_snapshot.rb
@@ -81,7 +81,7 @@ module VCS
     validates :name,              presence: true
     validates :content_version,   presence: true
     validates :mime_type,         presence: true
-    validates :external_id,       presence: true
+    validates :remote_file_id,    presence: true
     validates :file_record_id,
               uniqueness: {
                 scope: %i[name content_id mime_type file_record_parent_id],
@@ -109,7 +109,7 @@ module VCS
       attributes.symbolize_keys!
       VCS::Operations::ContentGenerator.generate(
         repository: repository(attributes),
-        remote_file_id: attributes[:external_id],
+        remote_file_id: attributes[:remote_file_id],
         remote_content_version_id: attributes[:content_version]
       )&.id
     end
@@ -144,7 +144,7 @@ module VCS
 
     # The set of supplemental attributes to a snapshot
     def self.supplemental_attribute_keys
-      %i[thumbnail_id external_id content_version]
+      %i[thumbnail_id remote_file_id content_version]
     end
 
     # The plain text content of this snapshot

--- a/app/models/vcs/file_thumbnail.rb
+++ b/app/models/vcs/file_thumbnail.rb
@@ -33,7 +33,7 @@ module VCS
                    message: 'must be JPEG, PNG, or GIF'
     validates :version_id, uniqueness: {
       scope: %i[file_record_id remote_file_id],
-      message: 'with external ID already exists for this file record'
+      message: 'with remote ID already exists for this file record'
     }, if: :new_record?
 
     # Callbacks
@@ -51,7 +51,7 @@ module VCS
       }
     end
 
-    # Find or initialize a Thumbnail instance by provider ID, external ID, and
+    # Find or initialize a Thumbnail instance by provider ID, remote ID, and
     # version ID
     def self.find_or_initialize_by_staged_file(staged_file)
       find_or_initialize_by(
@@ -74,7 +74,7 @@ module VCS
       end
     end
 
-    # Set external ID and version ID from the given staged file
+    # Set remote ID and version ID from the given staged file
     def staged_file=(staged_file)
       assign_attributes(
         self.class.attributes_from_staged_file(staged_file)

--- a/app/models/vcs/file_thumbnail.rb
+++ b/app/models/vcs/file_thumbnail.rb
@@ -13,10 +13,10 @@ module VCS
     has_attached_file :image,
                       styles: { original: '200x200#' },
                       path: ':attachment_path/:class/' \
-                            ':file_record_id/:external_id/:version_id/' \
+                            ':file_record_id/:remote_file_id/:version_id/' \
                             ':hash.:content_type_extension',
                       url:  ':attachment_url/:class/' \
-                            ':file_record_id/:external_id/:version_id/' \
+                            ':file_record_id/:remote_file_id/:version_id/' \
                             ':hash.:content_type_extension',
                       default_url: '/fallback/file_resources/thumbnail.png',
                       hash_secret: ENV['THUMBNAIL_HASH_SECRET']
@@ -32,7 +32,7 @@ module VCS
                    content_type: %w[image/jpeg image/gif image/png],
                    message: 'must be JPEG, PNG, or GIF'
     validates :version_id, uniqueness: {
-      scope: %i[file_record_id external_id],
+      scope: %i[file_record_id remote_file_id],
       message: 'with external ID already exists for this file record'
     }, if: :new_record?
 
@@ -46,7 +46,7 @@ module VCS
     def self.attributes_from_staged_file(staged_file)
       {
         file_record_id: staged_file.file_record_id,
-        external_id: staged_file.external_id,
+        remote_file_id: staged_file.remote_file_id,
         version_id:  staged_file.thumbnail_version_id
       }
     end

--- a/app/models/vcs/operations/file_restore.rb
+++ b/app/models/vcs/operations/file_restore.rb
@@ -90,8 +90,8 @@ module VCS
       # Calling the delete API endpoint results in insufficient permission
       # error unless the action is performed by the file owner.
       def remove_file
-        file_sync_class
-          .new(staged_file.remote_file_id)
+        staged_file
+          .remote
           .relocate(to: nil, from: staged_file.parent.remote_file_id)
       end
 
@@ -103,8 +103,8 @@ module VCS
 
       # Move remote file
       def relocate_file
-        file_sync_class
-          .new(staged_file.remote_file_id)
+        staged_file
+          .remote
           .relocate(
             to: staged_parent.remote_file_id,
             from: staged_file.parent.remote_file_id
@@ -113,7 +113,7 @@ module VCS
 
       # Rename remote file
       def rename_file
-        file_sync_class.new(staged_file.remote_file_id).rename(snapshot.name)
+        staged_file.remote.rename(snapshot.name)
       end
 
       # Calculate the diff of new snapshot vs currently staged snapshot

--- a/app/models/vcs/operations/file_restore.rb
+++ b/app/models/vcs/operations/file_restore.rb
@@ -26,7 +26,7 @@ module VCS
 
         # Update in stage
         staged_file.update(
-          snapshot_attributes.merge(external_id: external_id,
+          snapshot_attributes.merge(remote_file_id: remote_file_id,
                                     content_version: content_version,
                                     is_deleted: snapshot.nil?)
         )
@@ -50,12 +50,12 @@ module VCS
       private
 
       attr_accessor :snapshot, :target_branch, :file_record_id
-      attr_writer :external_id, :content_version
+      attr_writer :remote_file_id, :content_version
 
       # Create remote file from backup copy
       def add_file
         replacement = snapshot.folder? ? create_folder : duplicate_file
-        self.external_id = replacement.id
+        self.remote_file_id = replacement.id
         self.content_version = replacement.content_version
 
         # Create a new remote content record that points at the same content
@@ -65,23 +65,23 @@ module VCS
         # TODO: Add helper method for creating a new remote version of content
         snapshot.content.remote_contents.create!(
           repository: snapshot.repository,
-          remote_file_id: external_id,
+          remote_file_id: remote_file_id,
           remote_content_version_id: content_version
         )
       end
 
       # Duplicate or create file depending on whether this is a folder or not
       def duplicate_file
-        file_sync_class.new(snapshot.backup.external_id).duplicate(
+        file_sync_class.new(snapshot.backup.remote_file_id).duplicate(
           name: snapshot.name,
-          parent_id: staged_parent.external_id
+          parent_id: staged_parent.remote_file_id
         )
       end
 
       def create_folder
         file_sync_class.create(
           name: snapshot.name,
-          parent_id: staged_parent.external_id,
+          parent_id: staged_parent.remote_file_id,
           mime_type: snapshot.mime_type
         )
       end
@@ -91,8 +91,8 @@ module VCS
       # error unless the action is performed by the file owner.
       def remove_file
         file_sync_class
-          .new(staged_file.external_id)
-          .relocate(to: nil, from: staged_file.parent.external_id)
+          .new(staged_file.remote_file_id)
+          .relocate(to: nil, from: staged_file.parent.remote_file_id)
       end
 
       # Create remote file from backup copy and delete current file
@@ -104,16 +104,16 @@ module VCS
       # Move remote file
       def relocate_file
         file_sync_class
-          .new(staged_file.external_id)
+          .new(staged_file.remote_file_id)
           .relocate(
-            to: staged_parent.external_id,
-            from: staged_file.parent.external_id
+            to: staged_parent.remote_file_id,
+            from: staged_file.parent.remote_file_id
           )
       end
 
       # Rename remote file
       def rename_file
-        file_sync_class.new(staged_file.external_id).rename(snapshot.name)
+        file_sync_class.new(staged_file.remote_file_id).rename(snapshot.name)
       end
 
       # Calculate the diff of new snapshot vs currently staged snapshot
@@ -125,8 +125,8 @@ module VCS
           )
       end
 
-      def external_id
-        @external_id ||= staged_file.external_id
+      def remote_file_id
+        @remote_file_id ||= staged_file.remote_file_id
       end
 
       def content_version

--- a/app/models/vcs/staged_file.rb
+++ b/app/models/vcs/staged_file.rb
@@ -48,9 +48,9 @@ module VCS
     }
 
     # Validations
-    validates :external_id, presence: true
-    validates :external_id, uniqueness: { scope: :branch_id },
-                            if: :will_save_change_to_external_id?
+    validates :remote_file_id, presence: true
+    validates :remote_file_id, uniqueness: { scope: :branch_id },
+                               if: :will_save_change_to_remote_file_id?
 
     # Only perform validation if no errors have been encountered
     with_options unless: :any_errors? do

--- a/app/views/file_infos/_link_to_force_sync.slim
+++ b/app/views/file_infos/_link_to_force_sync.slim
@@ -1,6 +1,6 @@
 / render a button to force sync the file
 
-= button_to profile_project_force_syncs_path(project.owner, project, file.external_id),
+= button_to profile_project_force_syncs_path(project.owner, project, file.remote_file_id),
           method: :post,
           class: 'btn btn-large primary-color primary-color-text' do
   i.left.material_icons

--- a/app/views/file_infos/_link_to_open_in_drive.slim
+++ b/app/views/file_infos/_link_to_open_in_drive.slim
@@ -1,6 +1,6 @@
 / render a link to the file on Google Drive
 
-= link_to file.external_link,
+= link_to file.link_to_remote,
           class: 'btn btn-large primary-color primary-color-text',
           target: '_blank' do
   i.left.material_icons

--- a/app/views/file_infos/_link_to_parent_folder.slim
+++ b/app/views/file_infos/_link_to_parent_folder.slim
@@ -6,7 +6,7 @@
   - label = 'Home'
 - else
   / TODO: REFACTOR!
-  - path = profile_project_folder_path(project.owner, project, @staged_parent&.external_id)
+  - path = profile_project_folder_path(project.owner, project, @staged_parent&.remote_file_id)
   - label = 'Parent'
 
 = link_to path,

--- a/app/views/folders/_ancestor.slim
+++ b/app/views/folders/_ancestor.slim
@@ -7,5 +7,5 @@ svg.separator viewBox='0 0 24 24'
 
 / link to the ancestor
 =<> link_to ancestor.name,
-            profile_project_folder_path(project.owner, project, ancestor.external_id),
+            profile_project_folder_path(project.owner, project, ancestor.remote_file_id),
             class: "breadcrumb#{ancestor == current_folder ? ' active' : ''}"

--- a/app/views/folders/_file_diff.slim
+++ b/app/views/folders/_file_diff.slim
@@ -10,7 +10,7 @@
 ]
 
   = render partial: 'link_to_file_info',
-           locals: { file_id: file_diff.external_id, project: project }
+           locals: { file_id: file_diff.remote_file_id, project: project }
 
   = link_to_file(file_diff, project, class: 'file-link') do
 

--- a/app/views/projects/_head.slim
+++ b/app/views/projects/_head.slim
@@ -34,7 +34,7 @@
                 = link_to 'Revisions', profile_project_revisions_path(project.owner, project),
                           class: ('active' if active_tab == :revisions)
               div.tab
-                = link_to project.master_branch.root.external_link, target: '_blank' do
+                = link_to project.master_branch.root.link_to_remote, target: '_blank' do
                   svg style="width:24px;height:24px" viewBox="0 0 24 24" class="left"
                     path fill="currentColor" d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
                   | Open in Drive

--- a/app/views/revisions/_file_change.slim
+++ b/app/views/revisions/_file_change.slim
@@ -13,7 +13,7 @@ div.file[class=file_change.symbolic_mime_type
 
   - if show_link_to_file_info
    = render partial: 'revisions/link_to_file_info',
-             locals: { file_id: file_change.external_id,
+             locals: { file_id: file_change.remote_file_id,
                        project: project,
                        device: :mobile_and_tablet,
                        link_options: link_options }
@@ -31,7 +31,7 @@ div.file[class=file_change.symbolic_mime_type
 
     - if show_link_to_file_info
       = render partial: 'revisions/link_to_file_info',
-               locals: { file_id: file_change.external_id,
+               locals: { file_id: file_change.remote_file_id,
                          project: project,
                          device: :desktop,
                         link_options: link_options }

--- a/app/views/revisions/folders/_ancestor.slim
+++ b/app/views/revisions/folders/_ancestor.slim
@@ -7,5 +7,5 @@ svg.separator viewBox='0 0 24 24'
 
 / link to the ancestor
 =<> link_to ancestor.name,
-            profile_project_revision_folder_path(project.owner, project, revision, ancestor.external_id),
+            profile_project_revision_folder_path(project.owner, project, revision, ancestor.remote_file_id),
             class: "breadcrumb#{ancestor == current_folder ? ' active' : ''}"

--- a/app/views/revisions/folders/_committed_file_snapshot.slim
+++ b/app/views/revisions/folders/_committed_file_snapshot.slim
@@ -8,7 +8,7 @@
 ]
 
   = render partial: 'folders/link_to_file_info',
-           locals: { file_id: committed_file_snapshot.external_id, project: project }
+           locals: { file_id: committed_file_snapshot.remote_file_id, project: project }
 
   = link_to_file_backup(committed_file_snapshot, revision, project, class: 'file-link') do
 

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -16,9 +16,9 @@ Paperclip.interpolates :file_record_id do |attachment, _style|
   attachment.instance.file_record_id.to_s
 end
 
-# Paperclip interpolator for the instance's external ID attribute
-Paperclip.interpolates :external_id do |attachment, _style|
-  attachment.instance.external_id
+# Paperclip interpolator for the instance's remote file ID attribute
+Paperclip.interpolates :remote_file_id do |attachment, _style|
+  attachment.instance.remote_file_id
 end
 
 # Paperclip interpolator for the instance's version ID attribute

--- a/db/migrate/20181126235110_rename_external_id_to_remote_id.rb
+++ b/db/migrate/20181126235110_rename_external_id_to_remote_id.rb
@@ -1,0 +1,11 @@
+class RenameExternalIdToRemoteId < ActiveRecord::Migration[5.2]
+  def change
+    tables_with_external_id_column =
+      %i[vcs_archives vcs_file_backups vcs_file_snapshots vcs_file_thumbnails
+         vcs_staged_files]
+
+    tables_with_external_id_column.each do |table|
+      rename_column table, :external_id, :remote_file_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_24_200148) do
+ActiveRecord::Schema.define(version: 2018_11_26_235110) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -223,7 +223,7 @@ ActiveRecord::Schema.define(version: 2018_11_24_200148) do
 
   create_table "vcs_archives", force: :cascade do |t|
     t.bigint "repository_id", null: false
-    t.text "external_id", null: false
+    t.text "remote_file_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["repository_id"], name: "index_vcs_archives_on_repository_id"
@@ -272,7 +272,7 @@ ActiveRecord::Schema.define(version: 2018_11_24_200148) do
 
   create_table "vcs_file_backups", force: :cascade do |t|
     t.bigint "file_snapshot_id", null: false
-    t.text "external_id", null: false
+    t.text "remote_file_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["file_snapshot_id"], name: "index_vcs_file_backups_on_file_snapshot_id"
@@ -302,7 +302,7 @@ ActiveRecord::Schema.define(version: 2018_11_24_200148) do
     t.bigint "file_record_parent_id"
     t.text "name", null: false
     t.text "content_version", null: false
-    t.text "external_id", null: false
+    t.text "remote_file_id", null: false
     t.string "mime_type", null: false
     t.bigint "thumbnail_id"
     t.datetime "created_at", null: false
@@ -316,7 +316,7 @@ ActiveRecord::Schema.define(version: 2018_11_24_200148) do
   end
 
   create_table "vcs_file_thumbnails", force: :cascade do |t|
-    t.text "external_id", null: false
+    t.text "remote_file_id", null: false
     t.text "version_id", null: false
     t.string "image_file_name"
     t.string "image_content_type"
@@ -347,7 +347,7 @@ ActiveRecord::Schema.define(version: 2018_11_24_200148) do
   create_table "vcs_staged_files", force: :cascade do |t|
     t.bigint "branch_id", null: false
     t.bigint "file_record_id", null: false
-    t.text "external_id", null: false
+    t.text "remote_file_id", null: false
     t.bigint "file_record_parent_id"
     t.text "name"
     t.text "content_version"
@@ -359,8 +359,8 @@ ActiveRecord::Schema.define(version: 2018_11_24_200148) do
     t.boolean "is_root", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["branch_id", "external_id"], name: "index_vcs_staged_files_on_branch_id_and_external_id", unique: true
     t.index ["branch_id", "file_record_id"], name: "index_vcs_staged_files_on_branch_id_and_file_record_id", unique: true
+    t.index ["branch_id", "remote_file_id"], name: "index_vcs_staged_files_on_branch_id_and_remote_file_id", unique: true
     t.index ["branch_id"], name: "index_vcs_staged_files_on_branch_id"
     t.index ["branch_id"], name: "index_vcs_staged_files_on_root", unique: true, where: "(is_root IS TRUE)"
     t.index ["committed_snapshot_id"], name: "index_vcs_staged_files_on_committed_snapshot_id"

--- a/spec/controllers/file_infos_controller_spec.rb
+++ b/spec/controllers/file_infos_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe FileInfosController, type: :controller do
     {
       profile_handle: project.owner.to_param,
       project_slug:   project.slug,
-      id:             folder.external_id
+      id:             folder.remote_file_id
     }
   end
   let(:current_account) { project.owner.account }
@@ -33,7 +33,7 @@ RSpec.describe FileInfosController, type: :controller do
     it_should_behave_like 'authorizing project access'
 
     context 'when id is of root folder' do
-      before      { params[:id] = root.external_id }
+      before      { params[:id] = root.remote_file_id }
 
       it 'raises a 404 error' do
         expect { run_request }.to raise_error ActiveRecord::RecordNotFound

--- a/spec/controllers/file_restores_controller_spec.rb
+++ b/spec/controllers/file_restores_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe FileRestoresController, type: :controller do
     it_should_behave_like 'an authorized action' do
       let(:redirect_location) do
         profile_project_file_infos_path(
-          project.owner, project, snapshot.external_id
+          project.owner, project, snapshot.remote_file_id
         )
       end
       let(:unauthorized_message) do
@@ -55,7 +55,7 @@ RSpec.describe FileRestoresController, type: :controller do
       run_request
       expect(response).to redirect_to(
         profile_project_file_infos_path(
-          project.owner, project, snapshot.external_id
+          project.owner, project, snapshot.remote_file_id
         )
       )
       is_expected.to set_flash[:notice].to 'File successfully restored.'

--- a/spec/controllers/folders_controller_spec.rb
+++ b/spec/controllers/folders_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe FoldersController, type: :controller do
     {
       profile_handle: project.owner.to_param,
       project_slug:   project.slug,
-      id:             folder.external_id
+      id:             folder.remote_file_id
     }
   end
   let(:current_account) { project.owner.account }
@@ -49,7 +49,7 @@ RSpec.describe FoldersController, type: :controller do
 
     context 'when file is not a directory' do
       let(:file)  { create :vcs_staged_file, parent: folder }
-      before      { params[:id] = file.external_id }
+      before      { params[:id] = file.remote_file_id }
 
       it 'raises a 404 error' do
         expect { run_request }.to raise_error ActiveRecord::RecordNotFound

--- a/spec/controllers/force_syncs_controller_spec.rb
+++ b/spec/controllers/force_syncs_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ForceSyncsController, type: :controller do
     {
       profile_handle: project.owner.to_param,
       project_slug:   project.slug,
-      id:             folder.external_id
+      id:             folder.remote_file_id
     }
   end
 
@@ -74,7 +74,7 @@ RSpec.describe ForceSyncsController, type: :controller do
     end
 
     context 'when id is of root folder' do
-      before      { params[:id] = root.external_id }
+      before      { params[:id] = root.remote_file_id }
 
       it 'raises a 404 error' do
         expect { run_request }.to raise_error ActiveRecord::RecordNotFound

--- a/spec/controllers/project_setups_controller_spec.rb
+++ b/spec/controllers/project_setups_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ProjectSetupsController, :delayed_job, type: :controller do
   let!(:project)      { create :project, :skip_archive_setup, :with_repository }
   let(:file)          { build :vcs_staged_file, :root, branch: master_branch }
   let(:master_branch) { project.master_branch }
-  let(:link)          { file.external_link }
+  let(:link)          { file.link_to_remote }
   let(:default_params) do
     {
       profile_handle: project.owner.to_param,
@@ -64,7 +64,7 @@ RSpec.describe ProjectSetupsController, :delayed_job, type: :controller do
     let(:add_params) do
       {
         project_setup: {
-          link: file.external_link
+          link: file.link_to_remote
         }
       }
     end

--- a/spec/controllers/revisions/folders_controller_spec.rb
+++ b/spec/controllers/revisions/folders_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Revisions::FoldersController, type: :controller do
       profile_handle: project.owner.to_param,
       project_slug:   project.slug,
       revision_id:    revision.id,
-      id:             folder.external_id
+      id:             folder.remote_file_id
     }
   end
   let(:current_account) { project.owner.account }
@@ -54,7 +54,7 @@ RSpec.describe Revisions::FoldersController, type: :controller do
     it_should_behave_like 'authorizing project access'
 
     context 'when file is not a directory' do
-      before { params[:id] = committed_file.file_snapshot.external_id }
+      before { params[:id] = committed_file.file_snapshot.remote_file_id }
 
       it 'raises a 404 error' do
         expect { run_request }.to raise_error ActiveRecord::RecordNotFound

--- a/spec/factories/project/setups.rb
+++ b/spec/factories/project/setups.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     link { '' }
 
     trait :with_link do
-      link { file.external_link }
+      link { file.link_to_remote }
 
       transient do
         file { create :vcs_staged_file, :folder }

--- a/spec/factories/vcs/vcs_archives.rb
+++ b/spec/factories/vcs/vcs_archives.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :vcs_archive, class: 'VCS::Archive' do
     association :repository, factory: :vcs_repository
-    external_id { Faker::Crypto.unique.sha1 }
+    remote_file_id { Faker::Crypto.unique.sha1 }
   end
 end

--- a/spec/factories/vcs/vcs_file_backups.rb
+++ b/spec/factories/vcs/vcs_file_backups.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :vcs_file_backup, class: 'VCS::FileBackup' do
     association :file_snapshot, factory: :vcs_file_snapshot
-    external_id { Faker::Crypto.unique.sha1 }
+    remote_file_id { Faker::Crypto.unique.sha1 }
   end
 end

--- a/spec/factories/vcs/vcs_file_snapshots.rb
+++ b/spec/factories/vcs/vcs_file_snapshots.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     end
 
     association :file_record, factory: :vcs_file_record
-    external_id         { Faker::Crypto.unique.sha1 }
+    remote_file_id      { Faker::Crypto.unique.sha1 }
     file_record_parent  { parent&.file_record || create(:vcs_file_record) }
     name                { Faker::File.file_name('', nil, nil, '') }
     content_version     { rand(1..1000) }
@@ -32,7 +32,7 @@ FactoryBot.define do
       snapshot.content =
         VCS::Operations::ContentGenerator.generate(
           repository: snapshot.repository,
-          remote_file_id: snapshot.external_id,
+          remote_file_id: snapshot.remote_file_id,
           remote_content_version_id: snapshot.content_version
         )
     end

--- a/spec/factories/vcs/vcs_file_thumbnails.rb
+++ b/spec/factories/vcs/vcs_file_thumbnails.rb
@@ -3,8 +3,8 @@
 FactoryBot.define do
   factory :vcs_file_thumbnail, class: 'VCS::FileThumbnail' do
     association :file_record, factory: :vcs_file_record
-    external_id { Faker::Crypto.unique.sha1 }
-    version_id  { "v#{rand(0..1000)}" }
+    remote_file_id  { Faker::Crypto.unique.sha1 }
+    version_id      { "v#{rand(0..1000)}" }
     image do
       File.new(
         "#{Rails.root}/spec/support/fixtures/file_resource/thumbnail.png"

--- a/spec/factories/vcs/vcs_staged_files.rb
+++ b/spec/factories/vcs/vcs_staged_files.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
 
     branch          { parent&.branch || create(:vcs_branch) }
     file_record     { create(:vcs_file_record, repository: repository) }
-    external_id     { Faker::Crypto.unique.sha1 }
+    remote_file_id  { Faker::Crypto.unique.sha1 }
     name            { Faker::File.file_name('', nil, nil, '') }
     content_version { rand(1..1000) }
     mime_type       { 'application/vnd.google-apps.document' }

--- a/spec/features/collaborator_spec.rb
+++ b/spec/features/collaborator_spec.rb
@@ -122,7 +122,7 @@ feature 'Collaborators: As a collaborator' do
 
       scenario 'I no longer have read access to the archive' do
         # and fetch a file that has been backed up
-        backup_id = project.repository.file_backups.first.external_id
+        backup_id = project.repository.file_backups.first.remote_file_id
         expect { collaborator_api_connection.find_file!(backup_id) }
           .to raise_error(
             Google::Apis::ClientError,

--- a/spec/features/file_info_spec.rb
+++ b/spec/features/file_info_spec.rb
@@ -21,7 +21,7 @@ feature 'File Info' do
     # then I should be on the file's info page
     expect(page).to have_current_path(
       "/#{project.owner.to_param}/#{project.to_param}/" \
-      "files/#{file.external_id}/info"
+      "files/#{file.remote_file_id}/info"
     )
     # and see one revision
     expect(page.find_all('.revision .metadata .title b').map(&:text))
@@ -46,7 +46,7 @@ feature 'File Info' do
     # then I should be on the file's info page
     expect(page).to have_current_path(
       "/#{project.owner.to_param}/#{project.to_param}/" \
-      "files/#{file.external_id}/info"
+      "files/#{file.remote_file_id}/info"
     )
     # and see no revisions
     expect(page).to have_text 'No previous versions'
@@ -71,7 +71,7 @@ feature 'File Info' do
     # then I should be on the file's info page
     expect(page).to have_current_path(
       "/#{project.owner.to_param}/#{project.to_param}/" \
-      "files/#{file.external_id}/info"
+      "files/#{file.remote_file_id}/info"
     )
     # and see two revisions
     expect(page.find_all('.revision .metadata .title b').map(&:text))

--- a/spec/features/file_restore_spec.rb
+++ b/spec/features/file_restore_spec.rb
@@ -167,7 +167,7 @@ feature 'File Restore', vcr: true do
                              text: 'original name'
     # and have a new external ID
     expect(project.staged_files.reload.find_by(name: 'original name'))
-      .not_to have_attributes(external_id: remote_file.id)
+      .not_to have_attributes(remote_file_id: remote_file.id)
   end
 
   context 'when remote file is a folder' do

--- a/spec/features/file_restore_spec.rb
+++ b/spec/features/file_restore_spec.rb
@@ -165,7 +165,7 @@ feature 'File Restore', vcr: true do
     # and be moved, modified, and renamed
     expect(page).to have_css '.file.movement.modification.rename',
                              text: 'original name'
-    # and have a new external ID
+    # and have a new remote ID
     expect(project.staged_files.reload.find_by(name: 'original name'))
       .not_to have_attributes(remote_file_id: remote_file.id)
   end

--- a/spec/features/file_update_spec.rb
+++ b/spec/features/file_update_spec.rb
@@ -49,7 +49,7 @@ feature 'File Update', :vcr do
     # then I should see the file among my project's files
     then_i_should_see_file_in_project(name: 'My New File', status: 'addition')
     # and have a backup of the file snapshot
-    staged = project.staged_files.find_by_external_id(file.id)
+    staged = project.staged_files.find_by_remote_file_id(file.id)
     and_have_a_backup_of_file_snapshot(staged.current_snapshot)
   end
 
@@ -74,7 +74,7 @@ feature 'File Update', :vcr do
     then_i_should_see_file_in_project(name: 'File', status: 'modification')
 
     # and have a backup of the file snapshot as it is now
-    staged = project.staged_files.find_by_external_id(file_to_modify.id)
+    staged = project.staged_files.find_by_remote_file_id(file_to_modify.id)
     and_have_a_backup_of_file_snapshot(staged.current_snapshot)
 
     # and have a backup of the file snapshot as it was before
@@ -102,7 +102,7 @@ feature 'File Update', :vcr do
     then_i_should_see_file_in_project(name: 'New File Name', status: 'rename')
 
     # and have a backup of the file snapshot as it is now
-    staged = project.staged_files.find_by_external_id(file_to_rename.id)
+    staged = project.staged_files.find_by_remote_file_id(file_to_rename.id)
     and_have_a_backup_of_file_snapshot(staged.current_snapshot)
 
     # and have a backup of the file snapshot as it was before
@@ -285,11 +285,12 @@ end
 # rubocop:disable Metrics/AbcSize
 # TODO: Reduce complexity
 def and_have_a_backup_of_file_snapshot(file_snapshot)
-  external_id_of_backup = file_snapshot.backup.external_id
-  external_backup = Providers::GoogleDrive::FileSync.new(external_id_of_backup)
+  remote_file_id_of_backup = file_snapshot.backup.remote_file_id
+  external_backup =
+    Providers::GoogleDrive::FileSync.new(remote_file_id_of_backup)
   expect(external_backup.name).to eq(file_snapshot.name)
   expect(external_backup.parent_id)
-    .to eq(project.archive.external_id)
+    .to eq(project.archive.remote_file_id)
 end
 # rubocop:enable Metrics/AbcSize
 

--- a/spec/features/file_update_spec.rb
+++ b/spec/features/file_update_spec.rb
@@ -286,10 +286,10 @@ end
 # TODO: Reduce complexity
 def and_have_a_backup_of_file_snapshot(file_snapshot)
   remote_file_id_of_backup = file_snapshot.backup.remote_file_id
-  external_backup =
+  remote_backup =
     Providers::GoogleDrive::FileSync.new(remote_file_id_of_backup)
-  expect(external_backup.name).to eq(file_snapshot.name)
-  expect(external_backup.parent_id)
+  expect(remote_backup.name).to eq(file_snapshot.name)
+  expect(remote_backup.parent_id)
     .to eq(project.archive.remote_file_id)
 end
 # rubocop:enable Metrics/AbcSize

--- a/spec/features/folder_import_spec.rb
+++ b/spec/features/folder_import_spec.rb
@@ -55,7 +55,7 @@ feature 'Folder Import', :vcr do
     expect(project.archive.backups.count).to eq 3
     external_archive =
       Providers::GoogleDrive::FileSync
-      .new(project.archive.external_id)
+      .new(project.archive.remote_file_id)
     expect(external_archive.children.count).to eq 3
   end
 end

--- a/spec/features/folder_import_spec.rb
+++ b/spec/features/folder_import_spec.rb
@@ -53,9 +53,9 @@ feature 'Folder Import', :vcr do
 
     # and have 3 files in archive
     expect(project.archive.backups.count).to eq 3
-    external_archive =
+    remote_archive =
       Providers::GoogleDrive::FileSync
       .new(project.archive.remote_file_id)
-    expect(external_archive.children.count).to eq 3
+    expect(remote_archive.children.count).to eq 3
   end
 end

--- a/spec/features/folder_spec.rb
+++ b/spec/features/folder_spec.rb
@@ -48,7 +48,7 @@ feature 'Folder' do
     # then I should be on the project's subfolder page
     expect(page).to have_current_path(
       "/#{project.owner.to_param}/#{project.to_param}/" \
-      "folders/#{subfolder.external_id}"
+      "folders/#{subfolder.remote_file_id}"
     )
     # and see the files in the project subfolder
     subfiles.each do |file|
@@ -123,7 +123,7 @@ feature 'Folder' do
     let(:action) do
       # when I visit the code folder
       visit "#{project.owner.to_param}/#{project.to_param}/" \
-            "folders/#{code.external_id}"
+            "folders/#{code.remote_file_id}"
     end
 
     context 'when code folder exists' do

--- a/spec/features/force_sync_spec.rb
+++ b/spec/features/force_sync_spec.rb
@@ -65,12 +65,12 @@ feature 'Force Sync', :vcr do
 
     # and have a backup of the file
     # TODO: Refactor
-    staged = project.staged_files.find_by_external_id(file.id)
-    external_id_of_backup = staged.current_snapshot.backup.external_id
+    staged = project.staged_files.find_by_remote_file_id(file.id)
+    remote_file_id_of_backup = staged.current_snapshot.backup.remote_file_id
     external_backup =
-      Providers::GoogleDrive::FileSync.new(external_id_of_backup)
+      Providers::GoogleDrive::FileSync.new(remote_file_id_of_backup)
     expect(external_backup.name).to eq(staged.name)
     expect(external_backup.parent_id)
-      .to eq(project.archive.external_id)
+      .to eq(project.archive.remote_file_id)
   end
 end

--- a/spec/features/force_sync_spec.rb
+++ b/spec/features/force_sync_spec.rb
@@ -67,10 +67,10 @@ feature 'Force Sync', :vcr do
     # TODO: Refactor
     staged = project.staged_files.find_by_remote_file_id(file.id)
     remote_file_id_of_backup = staged.current_snapshot.backup.remote_file_id
-    external_backup =
+    remote_backup =
       Providers::GoogleDrive::FileSync.new(remote_file_id_of_backup)
-    expect(external_backup.name).to eq(staged.name)
-    expect(external_backup.parent_id)
+    expect(remote_backup.name).to eq(staged.name)
+    expect(remote_backup.parent_id)
       .to eq(project.archive.remote_file_id)
   end
 end

--- a/spec/features/time_travel_spec.rb
+++ b/spec/features/time_travel_spec.rb
@@ -34,7 +34,7 @@ feature 'Time Travel' do
     files.each do |file|
       expect(page).to have_link(
         file.name,
-        href: file.current_snapshot.backup.external_link
+        href: file.current_snapshot.backup.link_to_remote
       )
     end
   end

--- a/spec/features/time_travel_spec.rb
+++ b/spec/features/time_travel_spec.rb
@@ -83,7 +83,7 @@ feature 'Time Travel' do
     # then I should be on the project's subfolder page
     expect(page).to have_current_path(
       "/#{project.owner.to_param}/#{project.to_param}/" \
-      "revisions/#{commit.id}/folders/#{code.external_id}"
+      "revisions/#{commit.id}/folders/#{code.remote_file_id}"
     )
     # and see the files in the project subfolder
     subfiles.each do |file|

--- a/spec/helpers/file_helper_spec.rb
+++ b/spec/helpers/file_helper_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe FileHelper, type: :helper do
 
     before do
       allow(file).to receive(:folder?).and_return is_folder
-      allow(file).to receive(:remote_file_id).and_return 'external-id'
-      allow(file).to receive(:link_to_remote).and_return 'external-link'
+      allow(file).to receive(:remote_file_id).and_return 'remote-id'
+      allow(file).to receive(:link_to_remote).and_return 'remote-link'
     end
 
     context 'when file is folder' do
@@ -18,7 +18,7 @@ RSpec.describe FileHelper, type: :helper do
 
       it 'returns internal link to directory' do
         expect(helper).to receive(:link_to).with(
-          "/#{project.owner.handle}/#{project.slug}/folders/external-id",
+          "/#{project.owner.handle}/#{project.slug}/folders/remote-id",
           any_args
         )
         method
@@ -34,7 +34,7 @@ RSpec.describe FileHelper, type: :helper do
       let(:is_folder) { false }
 
       it 'sets url to link_to_remote_for_file' do
-        expect(helper).to receive(:link_to).with('external-link', kind_of(Hash))
+        expect(helper).to receive(:link_to).with('remote-link', kind_of(Hash))
         method
       end
 
@@ -218,10 +218,10 @@ RSpec.describe FileHelper, type: :helper do
 
       before do
         allow(file).to receive(:backup).and_return backup
-        allow(backup).to receive(:link_to_remote).and_return 'external'
+        allow(backup).to receive(:link_to_remote).and_return 'remote'
       end
 
-      it { is_expected.to eq 'external' }
+      it { is_expected.to eq 'remote' }
     end
 
     context 'when file does not have backup' do

--- a/spec/helpers/file_helper_spec.rb
+++ b/spec/helpers/file_helper_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe FileHelper, type: :helper do
     let(:is_folder)   { false }
 
     before { allow(file).to receive(:folder?).and_return is_folder }
-    before { allow(file).to receive(:external_id).and_return 'external-id' }
+    before { allow(file).to receive(:remote_file_id).and_return 'external-id' }
     before { allow(file).to receive(:external_link).and_return 'external-link' }
 
     context 'when file is folder' do
@@ -192,7 +192,7 @@ RSpec.describe FileHelper, type: :helper do
         allow(project).to receive(:to_param).and_return 'project'
         allow(revision).to receive(:id).and_return 'r-id'
         allow(revision).to receive(:published?).and_return is_published
-        allow(file).to receive(:external_id).and_return 'ext-id'
+        allow(file).to receive(:remote_file_id).and_return 'ext-id'
       end
 
       it do

--- a/spec/helpers/file_helper_spec.rb
+++ b/spec/helpers/file_helper_spec.rb
@@ -7,9 +7,11 @@ RSpec.describe FileHelper, type: :helper do
     let(:file)        { instance_double VCS::FileSnapshot }
     let(:is_folder)   { false }
 
-    before { allow(file).to receive(:folder?).and_return is_folder }
-    before { allow(file).to receive(:remote_file_id).and_return 'external-id' }
-    before { allow(file).to receive(:external_link).and_return 'external-link' }
+    before do
+      allow(file).to receive(:folder?).and_return is_folder
+      allow(file).to receive(:remote_file_id).and_return 'external-id'
+      allow(file).to receive(:link_to_remote).and_return 'external-link'
+    end
 
     context 'when file is folder' do
       let(:is_folder) { true }
@@ -31,7 +33,7 @@ RSpec.describe FileHelper, type: :helper do
     context 'when file is not directory' do
       let(:is_folder) { false }
 
-      it 'sets url to external_link_for_file' do
+      it 'sets url to link_to_remote_for_file' do
         expect(helper).to receive(:link_to).with('external-link', kind_of(Hash))
         method
       end
@@ -216,7 +218,7 @@ RSpec.describe FileHelper, type: :helper do
 
       before do
         allow(file).to receive(:backup).and_return backup
-        allow(backup).to receive(:external_link).and_return 'external'
+        allow(backup).to receive(:link_to_remote).and_return 'external'
       end
 
       it { is_expected.to eq 'external' }

--- a/spec/integrations/project/setup_spec.rb
+++ b/spec/integrations/project/setup_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Project::Setup, type: :model, vcr: true do
       .share_file(google_drive_test_folder_id, tracking_acct)
   end
   let(:link) do
-    Providers::GoogleDrive::Link.for(external_id: remote_root.id,
+    Providers::GoogleDrive::Link.for(remote_file_id: remote_root.id,
                                      mime_type: folder_type)
   end
 
@@ -44,7 +44,7 @@ RSpec.describe Project::Setup, type: :model, vcr: true do
 
     it 'sets root folder' do
       expect(project.staged_files.root).to be_present
-      expect(project.staged_files.root.external_id).to eq remote_root.id
+      expect(project.staged_files.root.remote_file_id).to eq remote_root.id
     end
 
     it 'creates a FolderImportJob' do
@@ -95,7 +95,7 @@ RSpec.describe Project::Setup, type: :model, vcr: true do
 
     context 'when link ends with ?usp=sharing' do
       let(:raw_link) do
-        Providers::GoogleDrive::Link.for(external_id: remote_root.id,
+        Providers::GoogleDrive::Link.for(remote_file_id: remote_root.id,
                                          mime_type: folder_type)
       end
       let(:link) { "#{raw_link}?usp=sharing" }
@@ -148,7 +148,7 @@ RSpec.describe Project::Setup, type: :model, vcr: true do
     context 'when link is a google drive doc' do
       let(:mime_type) { document_type }
       let(:link) do
-        Providers::GoogleDrive::Link.for(external_id: remote_root.id,
+        Providers::GoogleDrive::Link.for(remote_file_id: remote_root.id,
                                          mime_type: mime_type)
       end
 

--- a/spec/integrations/shared_examples/vcs/including_downloadable_integration.rb
+++ b/spec/integrations/shared_examples/vcs/including_downloadable_integration.rb
@@ -2,7 +2,7 @@
 
 RSpec.shared_examples 'vcs: including downloadable integration', :vcr do
   let(:file) do
-    create :vcs_staged_file, external_id: remote_file.id, parent: root
+    create :vcs_staged_file, remote_file_id: remote_file.id, parent: root
   end
   let(:remote_file) do
     file_sync_class.create(

--- a/spec/integrations/shared_examples/vcs/including_syncable_integration.rb
+++ b/spec/integrations/shared_examples/vcs/including_syncable_integration.rb
@@ -11,7 +11,7 @@ RSpec.shared_examples 'vcs: including syncable integration', :vcr do
 
   describe '#fetch' do
     subject(:fetch)         { syncable.fetch }
-    let(:external_id)       { file_sync.id }
+    let(:remote_file_id)    { file_sync.id }
     let(:before_fetch_hook) { nil }
     let(:update_content) do
       Providers::GoogleDrive::ApiConnection
@@ -47,10 +47,10 @@ RSpec.shared_examples 'vcs: including syncable integration', :vcr do
 
   describe '#pull' do
     subject(:pull)          { syncable.pull }
-    let(:external_id)       { file_sync.id }
+    let(:remote_file_id)    { file_sync.id }
     let(:before_pull_hook)  { nil }
     let(:syncable_from_db) do
-      described_class.find_by!(external_id: file_sync.id)
+      described_class.find_by!(remote_file_id: file_sync.id)
     end
     let(:update_content) do
       Providers::GoogleDrive::ApiConnection
@@ -99,21 +99,21 @@ RSpec.shared_examples 'vcs: including syncable integration', :vcr do
   end
 
   describe '#pull_children' do
-    let(:external_id) { file_sync.id }
-    let(:mime_type)   { folder_mime_type }
+    let(:remote_file_id) { file_sync.id }
+    let(:mime_type) { folder_mime_type }
     let(:syncable_from_db) do
-      described_class.find_by!(external_id: external_id)
+      described_class.find_by!(remote_file_id: remote_file_id)
     end
 
     let(:subfile1) { file_sync_class.create(attributes.merge(name: 'sub1')) }
     let(:subfile2) { file_sync_class.create(attributes.merge(name: 'sub2')) }
-    let(:attributes) { { parent_id: external_id, mime_type: mime_type } }
+    let(:attributes) { { parent_id: remote_file_id, mime_type: mime_type } }
 
     before { subfile1 && subfile2 }
     before { syncable.pull && syncable.pull_children }
 
     it 'has children subfile1 and subfile2' do
-      expect(syncable_from_db.children.map(&:external_id))
+      expect(syncable_from_db.children.map(&:remote_file_id))
         .to contain_exactly subfile1.id, subfile2.id
     end
 
@@ -124,7 +124,7 @@ RSpec.shared_examples 'vcs: including syncable integration', :vcr do
 
       it 'updates children to subfile2 and subfile3' do
         syncable.reload.pull_children
-        expect(syncable_from_db.children.map(&:external_id))
+        expect(syncable_from_db.children.map(&:remote_file_id))
           .to contain_exactly subfile2.id, subfile3.id
       end
     end

--- a/spec/integrations/vcs/archive_spec.rb
+++ b/spec/integrations/vcs/archive_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe VCS::Archive, type: :model do
   end
   let(:account_email)   { ENV['GOOGLE_DRIVE_USER_ACCOUNT'] }
   let(:name)            { 'DEMO' }
-  let(:external_folder) { archive.file_resource }
+  let(:remote_folder) { archive.file_resource }
 
   describe '#setup', :vcr do
     before  { prepare_google_drive_test }

--- a/spec/integrations/vcs/archive_spec.rb
+++ b/spec/integrations/vcs/archive_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe VCS::Archive, type: :model do
     before  { prepare_google_drive_test }
     after   { tear_down_google_drive_test }
 
-    let(:remote_folder_id) { archive.external_id }
+    let(:remote_folder_id) { archive.remote_file_id }
 
     before { archive.setup }
     after do

--- a/spec/integrations/vcs/branch_spec.rb
+++ b/spec/integrations/vcs/branch_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe VCS::Branch, type: :model do
-  describe 'scope: where_staged_files_include_external_id' do
-    subject { described_class.where_staged_files_include_external_id(ids) }
-    let(:ids)     { [file1, file2, file3].map(&:external_id) }
+  describe 'scope: where_staged_files_include_remote_file_id' do
+    subject { described_class.where_staged_files_include_remote_file_id(ids) }
+    let(:ids)     { [file1, file2, file3].map(&:remote_file_id) }
 
     let!(:file1)  { create :vcs_staged_file }
     let!(:file2)  { create :vcs_staged_file }
@@ -22,7 +22,7 @@ RSpec.describe VCS::Branch, type: :model do
     context 'when a branch has a multiple matches' do
       let!(:extra_match) { create :vcs_staged_file, branch: file1.branch }
 
-      before { ids << extra_match.external_id }
+      before { ids << extra_match.remote_file_id }
 
       it 'returns the branch only once' do
         is_expected.to match_array [file1, file2, file3].map(&:branch)

--- a/spec/integrations/vcs/file_backup_spec.rb
+++ b/spec/integrations/vcs/file_backup_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe VCS::FileBackup, type: :model do
   let(:owner)           { build(:user, account: account) }
   let(:account)         { build(:account, email: account_email) }
   let(:account_email)   { ENV['GOOGLE_DRIVE_USER_ACCOUNT'] }
-  let(:external_folder) { archive.file_resource }
+  let(:remote_folder) { archive.file_resource }
 
   describe '#capture', :vcr do
     before  { prepare_google_drive_test }
@@ -20,11 +20,11 @@ RSpec.describe VCS::FileBackup, type: :model do
     let(:file_name)     { 'An Awesome File' }
     let(:staged_file) do
       project.master_branch.staged_files.build(
-        remote_file_id: external_file.id,
+        remote_file_id: remote_file.id,
         file_record: VCS::FileRecord.new(repository: project.repository)
       )
     end
-    let(:external_file) do
+    let(:remote_file) do
       Providers::GoogleDrive::FileSync.create(
         name: file_name,
         parent_id: google_drive_test_folder_id,

--- a/spec/integrations/vcs/file_backup_spec.rb
+++ b/spec/integrations/vcs/file_backup_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe VCS::FileBackup, type: :model do
     let(:file_name)     { 'An Awesome File' }
     let(:staged_file) do
       project.master_branch.staged_files.build(
-        external_id: external_file.id,
+        remote_file_id: external_file.id,
         file_record: VCS::FileRecord.new(repository: project.repository)
       )
     end
@@ -31,14 +31,14 @@ RSpec.describe VCS::FileBackup, type: :model do
         mime_type: Providers::GoogleDrive::MimeType.document
       )
     end
-    let(:archive_folder_id) { archive.external_id }
+    let(:archive_folder_id) { archive.remote_file_id }
     let(:archive)           { project.archive }
     let(:project)           { create(:project, owner_account_email: user_acct) }
 
     before do
       create :vcs_staged_file, :root,
              branch: project.master_branch,
-             external_id: google_drive_test_folder_id
+             remote_file_id: google_drive_test_folder_id
 
       # Prevent automatic backup
       allow(staged_file).to receive(:backup_on_save?).and_return(false)
@@ -53,22 +53,22 @@ RSpec.describe VCS::FileBackup, type: :model do
     end
 
     it 'stores a copy of the file snapshot in archive' do
-      copy = Providers::GoogleDrive::FileSync.new(backup.external_id)
+      copy = Providers::GoogleDrive::FileSync.new(backup.remote_file_id)
       expect(copy).to have_attributes(
         name: file_name,
-        parent_id: archive.external_id
+        parent_id: archive.remote_file_id
       )
     end
 
     it 'inherits access permissions from archive folder' do
       archive_permissions_hash =
         Providers::GoogleDrive::FileSync
-        .new(archive.external_id)
+        .new(archive.remote_file_id)
         .permissions
         .map(&:to_h)
       backup_permissions_hash =
         Providers::GoogleDrive::FileSync
-        .new(backup.external_id)
+        .new(backup.remote_file_id)
         .permissions
         .map(&:to_h)
       expect(backup_permissions_hash).to match_array(archive_permissions_hash)

--- a/spec/integrations/vcs/file_thumbnail_spec.rb
+++ b/spec/integrations/vcs/file_thumbnail_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe VCS::FileThumbnail, type: :model do
     subject               { thumbnail.image.path }
     let(:thumbnail)       { create :vcs_file_thumbnail }
     let(:file_record_id)  { thumbnail.file_record_id }
-    let(:external_id)     { thumbnail.external_id }
+    let(:remote_file_id)  { thumbnail.remote_file_id }
     let(:version_id)      { thumbnail.version_id }
 
     it 'interpolates correctly' do
       is_expected.to start_with("#{Rails.root}/public/spec/system")
       is_expected.to match(
         %r{vcs/file_thumbnails/#{file_record_id}/
-           #{external_id}/#{version_id}/\w+.png$}x
+           #{remote_file_id}/#{version_id}/\w+.png$}x
       )
     end
   end
@@ -21,14 +21,14 @@ RSpec.describe VCS::FileThumbnail, type: :model do
     subject               { thumbnail.image.url }
     let(:thumbnail)       { create :vcs_file_thumbnail }
     let(:file_record_id)  { thumbnail.file_record_id }
-    let(:external_id)     { thumbnail.external_id }
+    let(:remote_file_id)  { thumbnail.remote_file_id }
     let(:version_id)      { thumbnail.version_id }
 
     it 'interpolates correctly' do
       is_expected.to start_with('/spec/system')
       is_expected.to match(
         %r{vcs/file_thumbnails/#{file_record_id}/
-           #{external_id}/#{version_id}/\w+.png}x
+           #{remote_file_id}/#{version_id}/\w+.png}x
       )
     end
   end

--- a/spec/integrations/vcs/operations/file_restore_spec.rb
+++ b/spec/integrations/vcs/operations/file_restore_spec.rb
@@ -105,9 +105,7 @@ RSpec.describe VCS::Operations::FileRestore, type: :model, vcr: true do
         is_deleted: expected_deletion_status,
         thumbnail_id: snapshot_to_restore&.thumbnail_id
       )
-      expect(remote_file_after_restore).to have_attributes(
-        expected_remote_attributes
-      )
+      expect(file.remote).to have_attributes(expected_remote_attributes)
     end
 
     let(:expected_remote_attributes) do
@@ -195,9 +193,7 @@ RSpec.describe VCS::Operations::FileRestore, type: :model, vcr: true do
 
     context 'when file content differs from snapshot content' do
       let(:file_actions) { remote_file.update_content('new content') }
-      let(:expected_content_version) do
-        remote_file_after_restore.content_version
-      end
+      let(:expected_content_version) { file.remote.content_version }
 
       it 'is modifies the file' do
         expect(file_change).to be_modification

--- a/spec/integrations/vcs/operations/file_restore_spec.rb
+++ b/spec/integrations/vcs/operations/file_restore_spec.rb
@@ -34,17 +34,18 @@ RSpec.describe VCS::Operations::FileRestore, type: :model, vcr: true do
 
     let!(:root) do
       create :vcs_staged_file, :root,
-             external_id: google_drive_test_folder_id,
+             remote_file_id: google_drive_test_folder_id,
              branch: project.master_branch
     end
 
     let!(:subfolder) do
       create :vcs_staged_file, :folder,
-             parent: root, external_id: remote_subfolder.id
+             parent: root, remote_file_id: remote_subfolder.id
     end
 
     let!(:file) do
-      build(:vcs_staged_file, external_id: remote_file.id, branch: root.branch)
+      build(:vcs_staged_file,
+            remote_file_id: remote_file.id, branch: root.branch)
     end
 
     let(:file_change) do
@@ -62,7 +63,7 @@ RSpec.describe VCS::Operations::FileRestore, type: :model, vcr: true do
 
     let(:snapshot_before_performing_restoration)  { file.current_snapshot }
     let(:snapshot_to_restore)                     { file.current_snapshot }
-    let(:remote_file_after_restore) { file_sync_class.new(file.external_id) }
+    let(:remote_file_after_restore) { file_sync_class.new(file.remote_file_id) }
     let(:parent_of_snapshot_to_restore) do
       root.branch
           .staged_files
@@ -111,9 +112,9 @@ RSpec.describe VCS::Operations::FileRestore, type: :model, vcr: true do
 
     let(:expected_remote_attributes) do
       {
-        id: file.external_id,
+        id: file.remote_file_id,
         name: snapshot_to_restore&.name,
-        parent_id: expected_parent&.external_id,
+        parent_id: expected_parent&.remote_file_id,
         content_version: expected_content_version
       }
     end
@@ -153,7 +154,7 @@ RSpec.describe VCS::Operations::FileRestore, type: :model, vcr: true do
       end
       let(:subfolder2) do
         create :vcs_staged_file, :folder,
-               parent: root, external_id: remote_subfolder2.id
+               parent: root, remote_file_id: remote_subfolder2.id
       end
       let(:file_actions) do
         remote_subfolder2
@@ -200,7 +201,7 @@ RSpec.describe VCS::Operations::FileRestore, type: :model, vcr: true do
 
       it 'is modifies the file' do
         expect(file_change).to be_modification
-        expect(file.external_id).not_to eq remote_file.id
+        expect(file.remote_file_id).not_to eq remote_file.id
         expect(file.current_snapshot_id).to eq snapshot_to_restore.id
       end
     end
@@ -223,8 +224,8 @@ RSpec.describe VCS::Operations::FileRestore, type: :model, vcr: true do
       # doing the manual override here.
       let(:expected_remote_attributes) do
         {
-          id: file.external_id,
-          parent_id: expected_parent&.external_id
+          id: file.remote_file_id,
+          parent_id: expected_parent&.remote_file_id
         }
       end
 

--- a/spec/integrations/vcs/staged_file_spec.rb
+++ b/spec/integrations/vcs/staged_file_spec.rb
@@ -7,14 +7,14 @@ require 'integrations/shared_examples/vcs/including_syncable_integration.rb'
 RSpec.describe VCS::StagedFile, type: :model do
   subject(:file) do
     described_class.new(
-      external_id: external_id,
+      remote_file_id: remote_file_id,
       branch: branch,
       file_record: file_record
     )
   end
-  let(:branch) { create :vcs_branch }
-  let(:file_record) { create :vcs_file_record }
-  let(:external_id) { 'id' }
+  let(:branch)          { create :vcs_branch }
+  let(:file_record)     { create :vcs_file_record }
+  let(:remote_file_id)  { 'id' }
 
   it_should_behave_like 'vcs: including snapshotable integration' do
     let(:file)                    { build :vcs_staged_file }
@@ -35,7 +35,7 @@ RSpec.describe VCS::StagedFile, type: :model do
 
     let!(:root) do
       create(:vcs_staged_file, :root, :folder,
-             branch: branch, external_id: parent_id)
+             branch: branch, remote_file_id: parent_id)
     end
   end
 
@@ -54,7 +54,7 @@ RSpec.describe VCS::StagedFile, type: :model do
 
     let!(:root) do
       create(:vcs_staged_file, :root, :folder,
-             branch: branch, external_id: parent_id)
+             branch: branch, remote_file_id: parent_id)
     end
   end
 
@@ -70,7 +70,7 @@ RSpec.describe VCS::StagedFile, type: :model do
     end
     let!(:parent) do
       described_class.new(
-        external_id: google_drive_test_folder_id,
+        remote_file_id: google_drive_test_folder_id,
         branch: branch,
         file_record: file_record_parent,
         is_root: true
@@ -79,9 +79,9 @@ RSpec.describe VCS::StagedFile, type: :model do
     let(:file_record_parent)  { create :vcs_file_record }
     let(:projects)            { create_list :project, 3 }
     let(:api)                 { Providers::GoogleDrive::ApiConnection.default }
-    let(:external_id)         { file_sync.id }
+    let(:remote_file_id)      { file_sync.id }
     let(:file_from_database) do
-      described_class.find_by_external_id!(external_id)
+      described_class.find_by_remote_file_id!(remote_file_id)
     end
     let(:file_attributes)     { file_from_database.attributes }
     let(:snapshot_attributes) { file_from_database.current_snapshot.attributes }
@@ -91,7 +91,7 @@ RSpec.describe VCS::StagedFile, type: :model do
         'file_record_parent_id' => parent.file_record_id,
         'content_version' => '1',
         'mime_type' => Providers::GoogleDrive::MimeType.document,
-        'external_id' => external_id,
+        'remote_file_id' => remote_file_id,
         'thumbnail_id' => nil
       }
     end
@@ -126,7 +126,7 @@ RSpec.describe VCS::StagedFile, type: :model do
 
     it 'can pull a snapshot of a removed file' do
       file.pull
-      api.delete_file(file.external_id)
+      api.delete_file(file.remote_file_id)
       file.reload.pull
       expect(file_from_database).to be_deleted
       expect(file_from_database.current_snapshot).to be nil

--- a/spec/jobs/file_update_job_spec.rb
+++ b/spec/jobs/file_update_job_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe FileUpdateJob, type: :job do
       allow(file).to receive(:parents).and_return parents if file.present?
 
       allow(VCS::Branch)
-        .to receive(:where_staged_files_include_external_id)
+        .to receive(:where_staged_files_include_remote_file_id)
         .and_return branches
 
       allow(branches)
@@ -118,11 +118,11 @@ RSpec.describe FileUpdateJob, type: :job do
 
       allow(VCS::StagedFile)
         .to receive(:find_or_initialize_by)
-        .with(external_id: 'id', branch: branch1)
+        .with(remote_file_id: 'id', branch: branch1)
         .and_return file1
       allow(VCS::StagedFile)
         .to receive(:find_or_initialize_by)
-        .with(external_id: 'id', branch: branch2)
+        .with(remote_file_id: 'id', branch: branch2)
         .and_return file2
 
       allow(file1).to receive(:pull)
@@ -132,7 +132,7 @@ RSpec.describe FileUpdateJob, type: :job do
     it 'finds branches with the correct staged files' do
       process_change
       expect(VCS::Branch)
-        .to have_received(:where_staged_files_include_external_id)
+        .to have_received(:where_staged_files_include_remote_file_id)
         .with(%w[id p1 p2 p3])
     end
 
@@ -148,7 +148,7 @@ RSpec.describe FileUpdateJob, type: :job do
       it 'find branches with staged files with external id of change' do
         process_change
         expect(VCS::Branch)
-          .to have_received(:where_staged_files_include_external_id)
+          .to have_received(:where_staged_files_include_remote_file_id)
           .with(['id'])
       end
     end

--- a/spec/jobs/file_update_job_spec.rb
+++ b/spec/jobs/file_update_job_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe FileUpdateJob, type: :job do
     context 'when file is not present' do
       let(:file) { nil }
 
-      it 'find branches with staged files with external id of change' do
+      it 'find branches with staged files with remote id of change' do
         process_change
         expect(VCS::Branch)
           .to have_received(:where_staged_files_include_remote_file_id)

--- a/spec/lib/tasks/data_migration/file_snapshots_content_spec.rb
+++ b/spec/lib/tasks/data_migration/file_snapshots_content_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'data_migration:file_snapshots_content', :archived do
       expect(VCS::RemoteContent).to be_exists(
         repository_id: snapshot.repository.id,
         content_id: snapshot.content_id,
-        remote_file_id: snapshot.external_id,
+        remote_file_id: snapshot.remote_file_id,
         remote_content_version_id: snapshot.content_version
       )
     end
@@ -38,7 +38,7 @@ RSpec.describe 'data_migration:file_snapshots_content', :archived do
   context 'when multiple snapshots have the same content version' do
     let(:snapshots) do
       create_list :vcs_file_snapshot, 2,
-                  file_record: fr, external_id: 'id', content_version: 'v'
+                  file_record: fr, remote_file_id: 'id', content_version: 'v'
     end
     let(:fr) { create :vcs_file_record }
 

--- a/spec/lib/tasks/data_migration/file_thumbnails_spec.rb
+++ b/spec/lib/tasks/data_migration/file_thumbnails_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'data_migration:file_thumbnails', :archived do
   context 'when two snapshots have the same file record id' do
     let(:new_thumbnail) do
       VCS::FileThumbnail.find_by(
-        external_id: old_thumbnail.external_id,
+        remote_file_id: old_thumbnail.remote_file_id,
         version_id: old_thumbnail.version_id,
         file_record_id: snap1.file_record_id
       )

--- a/spec/models/project/setup_spec.rb
+++ b/spec/models/project/setup_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Project::Setup, type: :model do
       allow(setup).to receive(:id_from_link).and_return 'FILE-ID'
       allow(master_branch)
         .to receive_message_chain(:staged_files, :build)
-        .with(is_root: true, external_id: 'FILE-ID')
+        .with(is_root: true, remote_file_id: 'FILE-ID')
         .and_return file
       allow(master_branch).to receive(:repository).and_return 'repo'
       allow(file).to receive(:fetch)

--- a/spec/models/providers/google_drive/link_spec.rb
+++ b/spec/models/providers/google_drive/link_spec.rb
@@ -9,22 +9,22 @@ RSpec.describe Providers::GoogleDrive::Link, type: :model do
         .to receive(:to_symbol).with('type').and_return :symbolic_type
     end
 
-    after { link.for(remote_file_id: 'external-id', mime_type: 'type') }
+    after { link.for(remote_file_id: 'remote-id', mime_type: 'type') }
 
     it 'calls #for_{symbolic_mime_type} with remote_file_id' do
       expect(link)
-        .to receive(:safe_send).with(:for_symbolic_type, 'external-id')
+        .to receive(:safe_send).with(:for_symbolic_type, 'remote-id')
     end
 
     context 'when safe_send returns nil' do
       before do
         allow(Providers::GoogleDrive::Link)
           .to receive(:safe_send)
-          .with(:for_symbolic_type, 'external-id')
+          .with(:for_symbolic_type, 'remote-id')
           .and_return nil
       end
 
-      it { expect(link).to receive(:for_other).with('external-id') }
+      it { expect(link).to receive(:for_other).with('remote-id') }
     end
   end
 

--- a/spec/models/providers/google_drive/link_spec.rb
+++ b/spec/models/providers/google_drive/link_spec.rb
@@ -3,15 +3,15 @@
 RSpec.describe Providers::GoogleDrive::Link, type: :model do
   subject(:link) { Providers::GoogleDrive::Link }
 
-  describe '.for(external_id:, mime_type:)' do
+  describe '.for(remote_file_id:, mime_type:)' do
     before do
       allow(Providers::GoogleDrive::MimeType)
         .to receive(:to_symbol).with('type').and_return :symbolic_type
     end
 
-    after { link.for(external_id: 'external-id', mime_type: 'type') }
+    after { link.for(remote_file_id: 'external-id', mime_type: 'type') }
 
-    it 'calls #for_{symbolic_mime_type} with external_id' do
+    it 'calls #for_{symbolic_mime_type} with remote_file_id' do
       expect(link)
         .to receive(:safe_send).with(:for_symbolic_type, 'external-id')
     end

--- a/spec/models/shared_examples/being_a_file_diff_change.rb
+++ b/spec/models/shared_examples/being_a_file_diff_change.rb
@@ -16,7 +16,7 @@ RSpec.shared_examples 'being a file diff change' do
       is_expected.to delegate_method(:current_or_previous_snapshot).to(:diff)
     end
     it { is_expected.to delegate_method(:file_resource_id).to(:diff) }
-    it { is_expected.to delegate_method(:external_id).to(:diff) }
+    it { is_expected.to delegate_method(:remote_file_id).to(:diff) }
     it { is_expected.to delegate_method(:icon).to(:diff) }
     it { is_expected.to delegate_method(:name).to(:diff) }
     it { is_expected.to delegate_method(:parent_id).to(:diff) }
@@ -71,7 +71,7 @@ RSpec.shared_examples 'being a file diff change' do
 
   describe '#id' do
     subject { change.id }
-    before  { allow(diff).to receive(:external_id).and_return 'extID' }
+    before  { allow(diff).to receive(:remote_file_id).and_return 'extID' }
     it      { is_expected.to eq "extID_#{type}" }
   end
 

--- a/spec/models/shared_examples/vcs/being_diffing.rb
+++ b/spec/models/shared_examples/vcs/being_diffing.rb
@@ -7,7 +7,7 @@ RSpec.shared_examples 'vcs: being diffing' do
     let(:snapshot) { :current_or_previous_snapshot }
 
     it { is_expected.to delegate_method(:id).to(snapshot).with_prefix }
-    it { is_expected.to delegate_method(:external_id).to(snapshot) }
+    it { is_expected.to delegate_method(:remote_file_id).to(snapshot) }
     it { is_expected.to delegate_method(:external_link).to(snapshot) }
     it { is_expected.to delegate_method(:folder?).to(snapshot) }
     it { is_expected.to delegate_method(:icon).to(snapshot) }

--- a/spec/models/shared_examples/vcs/being_diffing.rb
+++ b/spec/models/shared_examples/vcs/being_diffing.rb
@@ -8,7 +8,7 @@ RSpec.shared_examples 'vcs: being diffing' do
 
     it { is_expected.to delegate_method(:id).to(snapshot).with_prefix }
     it { is_expected.to delegate_method(:remote_file_id).to(snapshot) }
-    it { is_expected.to delegate_method(:external_link).to(snapshot) }
+    it { is_expected.to delegate_method(:link_to_remote).to(snapshot) }
     it { is_expected.to delegate_method(:folder?).to(snapshot) }
     it { is_expected.to delegate_method(:icon).to(snapshot) }
     it { is_expected.to delegate_method(:mime_type).to(snapshot) }

--- a/spec/models/shared_examples/vcs/being_downloadable.rb
+++ b/spec/models/shared_examples/vcs/being_downloadable.rb
@@ -80,7 +80,7 @@ RSpec.shared_examples 'vcs: being downloadable' do
       allow(ContentDownloadJob).to receive(:perform_now)
       allow(backupable).to receive(:backup).and_return backup
       allow(backupable).to receive(:content).and_return content
-      allow(backup).to receive(:external_id).and_return 'ext-id'
+      allow(backup).to receive(:remote_file_id).and_return 'ext-id'
       allow(content).to receive(:id).and_return 'content-id'
     end
 

--- a/spec/models/shared_examples/vcs/being_resourceable.rb
+++ b/spec/models/shared_examples/vcs/being_resourceable.rb
@@ -38,10 +38,10 @@ RSpec.shared_examples 'vcs: being resourceable' do
       allow(resourceable)
         .to receive(:provider_link_class).and_return link_class
       allow(resourceable).to receive(:mime_type).and_return 'type'
-      allow(resourceable).to receive(:external_id).and_return 'external-id'
+      allow(resourceable).to receive(:remote_file_id).and_return 'external-id'
       allow(link_class)
         .to receive(:for)
-        .with(external_id: 'external-id', mime_type: 'type')
+        .with(remote_file_id: 'external-id', mime_type: 'type')
         .and_return 'external-link-to-file'
     end
 

--- a/spec/models/shared_examples/vcs/being_resourceable.rb
+++ b/spec/models/shared_examples/vcs/being_resourceable.rb
@@ -31,8 +31,8 @@ RSpec.shared_examples 'vcs: being resourceable' do
     end
   end
 
-  describe '#external_link' do
-    subject { resourceable.external_link }
+  describe '#link_to_remote' do
+    subject { resourceable.link_to_remote }
 
     before do
       allow(resourceable)

--- a/spec/models/shared_examples/vcs/being_resourceable.rb
+++ b/spec/models/shared_examples/vcs/being_resourceable.rb
@@ -38,14 +38,14 @@ RSpec.shared_examples 'vcs: being resourceable' do
       allow(resourceable)
         .to receive(:provider_link_class).and_return link_class
       allow(resourceable).to receive(:mime_type).and_return 'type'
-      allow(resourceable).to receive(:remote_file_id).and_return 'external-id'
+      allow(resourceable).to receive(:remote_file_id).and_return 'remote-id'
       allow(link_class)
         .to receive(:for)
-        .with(remote_file_id: 'external-id', mime_type: 'type')
-        .and_return 'external-link-to-file'
+        .with(remote_file_id: 'remote-id', mime_type: 'type')
+        .and_return 'remote-link-to-file'
     end
 
-    it { is_expected.to eq 'external-link-to-file' }
+    it { is_expected.to eq 'remote-link-to-file' }
   end
 
   describe '#icon' do

--- a/spec/models/shared_examples/vcs/being_syncable.rb
+++ b/spec/models/shared_examples/vcs/being_syncable.rb
@@ -79,7 +79,7 @@ RSpec.shared_examples 'vcs: being syncable' do
 
     context 'when record with parent id exists' do
       let(:existing_record) { syncable.dup }
-      let(:before_hook)     { existing_record.update(external_id: parent_id) }
+      let(:before_hook) { existing_record.update(remote_file_id: parent_id) }
 
       it { expect(syncable.parent).to eq existing_record }
     end

--- a/spec/models/shared_examples/vcs/being_syncable.rb
+++ b/spec/models/shared_examples/vcs/being_syncable.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
+require_relative 'having_remote.rb'
+
 RSpec.shared_examples 'vcs: being syncable' do
+  it_should_behave_like 'vcs: having remote' do
+    let(:object) { syncable }
+  end
+
   describe '#fetch' do
     subject               { syncable }
     let(:remote)          { instance_double syncable.send(:remote_class) }

--- a/spec/models/shared_examples/vcs/being_syncable.rb
+++ b/spec/models/shared_examples/vcs/being_syncable.rb
@@ -3,18 +3,18 @@
 RSpec.shared_examples 'vcs: being syncable' do
   describe '#fetch' do
     subject               { syncable }
-    let(:sync_adapter)    { instance_double syncable.send(:sync_adapter_class) }
+    let(:remote)          { instance_double syncable.send(:remote_class) }
     let(:file_is_deleted) { false }
 
     before do
-      allow(syncable).to receive(:sync_adapter).and_return sync_adapter
-      allow(sync_adapter).to receive(:name).and_return 'name'
-      allow(sync_adapter).to receive(:mime_type).and_return 'mime_type'
-      allow(sync_adapter).to receive(:content_version).and_return 'version'
-      allow(sync_adapter).to receive(:parent_id).and_return 'parent_id'
+      allow(syncable).to receive(:remote).and_return remote
+      allow(remote).to receive(:name).and_return 'name'
+      allow(remote).to receive(:mime_type).and_return 'mime_type'
+      allow(remote).to receive(:content_version).and_return 'version'
+      allow(remote).to receive(:parent_id).and_return 'parent_id'
       allow(syncable).to receive(:external_parent_id=)
-      allow(syncable).to receive(:thumbnail_from_sync_adapter)
-      allow(sync_adapter).to receive(:deleted?).and_return false
+      allow(syncable).to receive(:thumbnail_from_remote)
+      allow(remote).to receive(:deleted?).and_return false
     end
 
     after { syncable.fetch }
@@ -23,7 +23,7 @@ RSpec.shared_examples 'vcs: being syncable' do
     it { expect(syncable).to receive(:mime_type=).with('mime_type') }
     it { expect(syncable).to receive(:content_version=).with('version') }
     it { expect(syncable).to receive(:external_parent_id=).with('parent_id') }
-    it { expect(syncable).to receive(:thumbnail_from_sync_adapter) }
+    it { expect(syncable).to receive(:thumbnail_from_remote) }
     it { expect(syncable).to receive(:is_deleted=).with(false) }
   end
 
@@ -55,7 +55,7 @@ RSpec.shared_examples 'vcs: being syncable' do
   describe '#pull_children' do
     before do
       allow(syncable)
-        .to receive(:children_from_sync_adapter).and_return 'children'
+        .to receive(:children_from_remote).and_return 'children'
     end
     after { syncable.pull_children }
     it    { expect(syncable).to receive(:staged_children=).with('children') }
@@ -64,7 +64,7 @@ RSpec.shared_examples 'vcs: being syncable' do
   describe '#reload' do
     before  { allow(described_class).to receive(:find) }
     after   { syncable.reload }
-    it      { expect(syncable).to receive(:reset_sync_adapter) }
+    it      { expect(syncable).to receive(:reset_remote) }
   end
 
   describe '#external_parent_id=(parent_id)' do
@@ -85,14 +85,14 @@ RSpec.shared_examples 'vcs: being syncable' do
     end
   end
 
-  describe '#thumbnail_from_sync_adapter' do
-    subject(:set_thumbnail) { syncable.send(:thumbnail_from_sync_adapter) }
-    let(:sync_adapter)  { instance_double syncable.send(:sync_adapter_class) }
-    let(:has_thumbnail) { true }
+  describe '#thumbnail_from_remote' do
+    subject(:set_thumbnail) { syncable.send(:thumbnail_from_remote) }
+    let(:remote)            { instance_double syncable.send(:remote_class) }
+    let(:has_thumbnail)     { true }
 
     before do
-      allow(syncable).to receive(:sync_adapter).and_return sync_adapter
-      allow(sync_adapter).to receive(:thumbnail?).and_return has_thumbnail
+      allow(syncable).to receive(:remote).and_return remote
+      allow(remote).to receive(:thumbnail?).and_return has_thumbnail
     end
 
     it 'finds or initializes thumbnail by file resource' do
@@ -108,7 +108,7 @@ RSpec.shared_examples 'vcs: being syncable' do
       set_thumbnail
     end
 
-    context 'when sync_adapter#thumbnail? is false' do
+    context 'when remote#thumbnail? is false' do
       let(:has_thumbnail) { false }
       it                  { is_expected.to be nil }
     end
@@ -116,16 +116,16 @@ RSpec.shared_examples 'vcs: being syncable' do
 
   describe '#thumbnail_version_id' do
     subject(:thumbnail_version) { syncable.thumbnail_version_id }
-    let(:sync_adapter) { nil }
+    let(:remote) { nil }
 
-    before { allow(syncable).to receive(:sync_adapter).and_return sync_adapter }
+    before { allow(syncable).to receive(:remote).and_return remote }
 
     it { is_expected.to be nil }
 
     context 'when sync adapter is present' do
-      let(:sync_adapter) { instance_double Providers::GoogleDrive::FileSync }
+      let(:remote) { instance_double Providers::GoogleDrive::FileSync }
       before do
-        allow(sync_adapter).to receive(:thumbnail_version).and_return 'version'
+        allow(remote).to receive(:thumbnail_version).and_return 'version'
       end
 
       it { is_expected.to eq 'version' }

--- a/spec/models/shared_examples/vcs/being_syncable.rb
+++ b/spec/models/shared_examples/vcs/being_syncable.rb
@@ -18,7 +18,7 @@ RSpec.shared_examples 'vcs: being syncable' do
       allow(remote).to receive(:mime_type).and_return 'mime_type'
       allow(remote).to receive(:content_version).and_return 'version'
       allow(remote).to receive(:parent_id).and_return 'parent_id'
-      allow(syncable).to receive(:external_parent_id=)
+      allow(syncable).to receive(:remote_parent_id=)
       allow(syncable).to receive(:thumbnail_from_remote)
       allow(remote).to receive(:deleted?).and_return false
     end
@@ -28,7 +28,7 @@ RSpec.shared_examples 'vcs: being syncable' do
     it { expect(syncable).to receive(:name=).with('name') }
     it { expect(syncable).to receive(:mime_type=).with('mime_type') }
     it { expect(syncable).to receive(:content_version=).with('version') }
-    it { expect(syncable).to receive(:external_parent_id=).with('parent_id') }
+    it { expect(syncable).to receive(:remote_parent_id=).with('parent_id') }
     it { expect(syncable).to receive(:thumbnail_from_remote) }
     it { expect(syncable).to receive(:is_deleted=).with(false) }
   end
@@ -73,8 +73,8 @@ RSpec.shared_examples 'vcs: being syncable' do
     it      { expect(syncable).to receive(:reset_remote) }
   end
 
-  describe '#external_parent_id=(parent_id)' do
-    subject(:set_parent_id) { syncable.send(:external_parent_id=, parent_id) }
+  describe '#remote_parent_id=(parent_id)' do
+    subject(:set_parent_id) { syncable.send(:remote_parent_id=, parent_id) }
     let(:parent_id)         { 'id-of-parent' }
     let(:before_hook)       { nil }
 

--- a/spec/models/shared_examples/vcs/having_remote.rb
+++ b/spec/models/shared_examples/vcs/having_remote.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'vcs: having remote' do
+  describe '#remote' do
+    it 'sets @remote' do
+      object.remote = 'some-value'
+      expect(object.instance_variable_get(:@remote)).to eq 'some-value'
+    end
+  end
+
+  describe '#remote' do
+    subject(:remote) { object.remote }
+
+    let(:remote_class) { object.send(:remote_class) }
+
+    before do
+      allow(object).to receive(:remote_file_id).and_return 'remote-id'
+      allow(remote_class).to receive(:new).and_return 'new-instance'
+
+      hook if defined?(hook)
+
+      object.remote
+    end
+
+    it 'returns an instance of remote class' do
+      expect(remote_class).to have_received(:new).with('remote-id')
+    end
+
+    it 'sets @remote to new instance' do
+      expect(object.instance_variable_get(:@remote)).to eq 'new-instance'
+    end
+
+    context 'when @remote is already set' do
+      let(:hook) { object.instance_variable_set(:@remote, 'existing-value') }
+
+      it { is_expected.to eq 'existing-value' }
+    end
+  end
+
+  describe '#reload' do
+    before do
+      allow(object).to receive(:reset_remote)
+      allow(object.class).to receive(:find)
+      object.reload
+    end
+
+    it { expect(object).to have_received(:reset_remote) }
+
+    it 'reloads the object from database' do
+      expect(object.class).to have_received(:find)
+    end
+  end
+
+  describe '#reset_remote' do
+    subject(:reset_remote) { object.send(:reset_remote) }
+
+    before do
+      object.instance_variable_set(:@remote, 'some-value')
+    end
+
+    it 'resets @remote to nil' do
+      reset_remote
+      expect(object.instance_variable_get(:@remote)).to eq nil
+    end
+  end
+
+  describe '#remote_class' do
+    subject { object.send(:remote_class) }
+
+    it { is_expected.to eq Providers::GoogleDrive::FileSync }
+  end
+end

--- a/spec/models/vcs/archive_spec.rb
+++ b/spec/models/vcs/archive_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe VCS::Archive, type: :model do
         .with_message('must exist')
     end
     it do
-      is_expected.to validate_presence_of(:external_id)
+      is_expected.to validate_presence_of(:remote_file_id)
     end
 
     it do
@@ -45,7 +45,7 @@ RSpec.describe VCS::Archive, type: :model do
 
     before do
       allow(archive).to receive(:default_api_connection).and_return api
-      allow(archive).to receive(:external_id).and_return 'remote-archive-id'
+      allow(archive).to receive(:remote_file_id).and_return 'remote-archive-id'
       allow(api).to receive(:share_file)
       archive.grant_read_access_to('email@email.com')
     end
@@ -62,7 +62,7 @@ RSpec.describe VCS::Archive, type: :model do
 
     before do
       allow(archive).to receive(:default_api_connection).and_return api
-      allow(archive).to receive(:external_id).and_return 'remote-archive-id'
+      allow(archive).to receive(:remote_file_id).and_return 'remote-archive-id'
       allow(api).to receive(:unshare_file)
       archive.remove_read_access_from('email@email.com')
     end

--- a/spec/models/vcs/file_backup_spec.rb
+++ b/spec/models/vcs/file_backup_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe VCS::FileBackup, type: :model do
         .with(name: 'snapshot-name', parent_id: 'archive-id')
     end
 
-    it 'sets external id' do
+    it 'sets remote id' do
       capture_backup
       expect(backup).to have_received(:remote_file_id=).with('dup-remote-id')
     end

--- a/spec/models/vcs/file_backup_spec.rb
+++ b/spec/models/vcs/file_backup_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe VCS::FileBackup, type: :model do
       is_expected
         .to validate_presence_of(:file_snapshot_id).with_message('must exist')
     end
-    it { is_expected.to validate_presence_of(:external_id) }
+    it { is_expected.to validate_presence_of(:remote_file_id) }
 
     context 'when archive is nil' do
       before { allow(backup).to receive(:archive).and_return nil }
@@ -74,7 +74,7 @@ RSpec.describe VCS::FileBackup, type: :model do
       allow(backup).to receive(:archive_folder_id).and_return 'archive-id'
       allow(remote_file)
         .to receive(:duplicate).and_return duplicated_remote_file
-      allow(backup).to receive(:external_id=)
+      allow(backup).to receive(:remote_file_id=)
     end
 
     it 'duplicates the remote file' do
@@ -86,7 +86,7 @@ RSpec.describe VCS::FileBackup, type: :model do
 
     it 'sets external id' do
       capture_backup
-      expect(backup).to have_received(:external_id=).with('dup-remote-id')
+      expect(backup).to have_received(:remote_file_id=).with('dup-remote-id')
     end
 
     context 'when backup for file snapshot already exists' do
@@ -123,9 +123,9 @@ RSpec.describe VCS::FileBackup, type: :model do
       let(:duplicated_remote_file) { nil }
 
       it { is_expected.to be false }
-      it 'does not set external_id' do
+      it 'does not set remote_file_id' do
         capture_backup
-        expect(backup).not_to have_received(:external_id=)
+        expect(backup).not_to have_received(:remote_file_id=)
       end
     end
   end

--- a/spec/models/vcs/file_diff/changes/modification_spec.rb
+++ b/spec/models/vcs/file_diff/changes/modification_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe VCS::FileDiff::Changes::Modification, type: :model do
       allow(previous_snapshot)
         .to receive(:mime_type).and_return 'previous-mime-type'
       allow(previous_snapshot)
-        .to receive(:external_id).and_return 'previous-external-id'
+        .to receive(:remote_file_id).and_return 'previous-external-id'
       allow(previous_snapshot)
         .to receive(:thumbnail_id).and_return 'previous-thumbnail-id'
     end
@@ -43,7 +43,7 @@ RSpec.describe VCS::FileDiff::Changes::Modification, type: :model do
       is_expected.to receive(:content_id=).with 'previous-content-id'
       is_expected.to receive(:content_version=).with 'previous-content-version'
       is_expected.to receive(:mime_type=).with 'previous-mime-type'
-      is_expected.to receive(:external_id=).with 'previous-external-id'
+      is_expected.to receive(:remote_file_id=).with 'previous-external-id'
       is_expected.to receive(:thumbnail_id=).with 'previous-thumbnail-id'
     end
   end

--- a/spec/models/vcs/file_diff/changes/modification_spec.rb
+++ b/spec/models/vcs/file_diff/changes/modification_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe VCS::FileDiff::Changes::Modification, type: :model do
       allow(previous_snapshot)
         .to receive(:mime_type).and_return 'previous-mime-type'
       allow(previous_snapshot)
-        .to receive(:remote_file_id).and_return 'previous-external-id'
+        .to receive(:remote_file_id).and_return 'previous-remote-id'
       allow(previous_snapshot)
         .to receive(:thumbnail_id).and_return 'previous-thumbnail-id'
     end
@@ -43,7 +43,7 @@ RSpec.describe VCS::FileDiff::Changes::Modification, type: :model do
       is_expected.to receive(:content_id=).with 'previous-content-id'
       is_expected.to receive(:content_version=).with 'previous-content-version'
       is_expected.to receive(:mime_type=).with 'previous-mime-type'
-      is_expected.to receive(:remote_file_id=).with 'previous-external-id'
+      is_expected.to receive(:remote_file_id=).with 'previous-remote-id'
       is_expected.to receive(:thumbnail_id=).with 'previous-thumbnail-id'
     end
   end

--- a/spec/models/vcs/file_snapshot_spec.rb
+++ b/spec/models/vcs/file_snapshot_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe VCS::FileSnapshot, type: :model do
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:content_version) }
     it { is_expected.to validate_presence_of(:mime_type) }
-    it { is_expected.to validate_presence_of(:external_id) }
+    it { is_expected.to validate_presence_of(:remote_file_id) }
     it do
       is_expected.to validate_presence_of(:content).with_message('must exist')
     end

--- a/spec/models/vcs/file_thumbnail_spec.rb
+++ b/spec/models/vcs/file_thumbnail_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe VCS::FileThumbnail, type: :model do
     it do
       is_expected
         .to validate_uniqueness_of(:version_id)
-        .scoped_to(%i[file_record_id external_id])
+        .scoped_to(%i[file_record_id remote_file_id])
         .with_message('with external ID already exists for this file record')
     end
   end
@@ -72,14 +72,14 @@ RSpec.describe VCS::FileThumbnail, type: :model do
 
     before do
       allow(file).to receive(:file_record_id).and_return 'FRID'
-      allow(file).to receive(:external_id).and_return 'external-id'
+      allow(file).to receive(:remote_file_id).and_return 'external-id'
       allow(file).to receive(:thumbnail_version_id).and_return 'version-id'
     end
 
     it do
       is_expected.to eq(
         file_record_id: 'FRID',
-        external_id: 'external-id',
+        remote_file_id: 'external-id',
         version_id: 'version-id'
       )
     end

--- a/spec/models/vcs/file_thumbnail_spec.rb
+++ b/spec/models/vcs/file_thumbnail_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe VCS::FileThumbnail, type: :model do
       is_expected
         .to validate_uniqueness_of(:version_id)
         .scoped_to(%i[file_record_id remote_file_id])
-        .with_message('with external ID already exists for this file record')
+        .with_message('with remote ID already exists for this file record')
     end
   end
 
@@ -72,14 +72,14 @@ RSpec.describe VCS::FileThumbnail, type: :model do
 
     before do
       allow(file).to receive(:file_record_id).and_return 'FRID'
-      allow(file).to receive(:remote_file_id).and_return 'external-id'
+      allow(file).to receive(:remote_file_id).and_return 'remote-id'
       allow(file).to receive(:thumbnail_version_id).and_return 'version-id'
     end
 
     it do
       is_expected.to eq(
         file_record_id: 'FRID',
-        remote_file_id: 'external-id',
+        remote_file_id: 'remote-id',
         version_id: 'version-id'
       )
     end

--- a/spec/models/vcs/staged_file_spec.rb
+++ b/spec/models/vcs/staged_file_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe VCS::StagedFile, type: :model do
       staged_file.valid?
     end
 
-    context 'when external id has not changed' do
+    context 'when remote id has not changed' do
       before do
         allow(staged_file).to receive(:remote_file_id_changed?).and_return false
       end

--- a/spec/models/vcs/staged_file_spec.rb
+++ b/spec/models/vcs/staged_file_spec.rb
@@ -62,14 +62,14 @@ RSpec.describe VCS::StagedFile, type: :model do
   end
 
   describe 'validations' do
-    it { is_expected.to validate_presence_of(:external_id) }
+    it { is_expected.to validate_presence_of(:remote_file_id) }
     it { is_expected.to validate_presence_of(:name) }
     it { is_expected.to validate_presence_of(:mime_type) }
     it { is_expected.to validate_presence_of(:content_version) }
     it { is_expected.to validate_presence_of(:file_record_parent_id) }
     it do
       is_expected
-        .to validate_uniqueness_of(:external_id).scoped_to(:branch_id)
+        .to validate_uniqueness_of(:remote_file_id).scoped_to(:branch_id)
     end
 
     it 'validates that file is not its own parent' do
@@ -79,10 +79,10 @@ RSpec.describe VCS::StagedFile, type: :model do
 
     context 'when external id has not changed' do
       before do
-        allow(staged_file).to receive(:external_id_changed?).and_return false
+        allow(staged_file).to receive(:remote_file_id_changed?).and_return false
       end
 
-      it { expect(staged_file).not_to validate_uniqueness_of(:external_id) }
+      it { expect(staged_file).not_to validate_uniqueness_of(:remote_file_id) }
     end
 
     context 'when file_record_parent_id has changed' do

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -31,7 +31,7 @@ RSpec.configure do |config|
       Capybara.current_driver == :rack_test
 
     unless driver_shares_db_connection_with_specs
-      # Driver is probably for an external browser with an app
+      # Driver is probably for an remote browser with an app
       # under test that does *not* share a database connection with the
       # specs, so use truncation strategy.
       DatabaseCleaner.strategy = :truncation

--- a/spec/views/file_infos/index_spec.rb
+++ b/spec/views/file_infos/index_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'file_infos/index', type: :view do
     it 'has a link to the parent folder' do
       render
       link = profile_project_folder_path(project.owner, project,
-                                         staged_parent.external_id)
+                                         staged_parent.remote_file_id)
       expect(rendered).to have_link 'Open Parent Folder', href: link
     end
 
@@ -82,7 +82,7 @@ RSpec.describe 'file_infos/index', type: :view do
       render
       sync_path =
         profile_project_force_syncs_path(project.owner, project,
-                                         staged_file_diff.external_id)
+                                         staged_file_diff.remote_file_id)
       expect(rendered).not_to have_css(
         'form'\
         "[action='#{sync_path}']"\
@@ -147,7 +147,7 @@ RSpec.describe 'file_infos/index', type: :view do
         render
         sync_path =
           profile_project_force_syncs_path(project.owner, project,
-                                           staged_file_diff.external_id)
+                                           staged_file_diff.remote_file_id)
         expect(rendered).to have_css(
           'form'\
           "[action='#{sync_path}']"\

--- a/spec/views/file_infos/index_spec.rb
+++ b/spec/views/file_infos/index_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'file_infos/index', type: :view do
     it 'has a link to the file on Google Drive' do
       render
       expect(rendered).to have_link 'Open in Drive',
-                                    href: staged_file_diff.external_link
+                                    href: staged_file_diff.link_to_remote
     end
 
     it 'renders that the file has been unchanged since the last revision' do
@@ -208,7 +208,7 @@ RSpec.describe 'file_infos/index', type: :view do
     it 'renders a link to file backup for each revision' do
       render
       committed_file_diffs.each do |diff|
-        link = diff.current_snapshot.backup.external_link
+        link = diff.current_snapshot.backup.link_to_remote
         expect(rendered).to have_link(text: diff.name, href: link)
       end
     end

--- a/spec/views/folders/show_spec.rb
+++ b/spec/views/folders/show_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'folders/show', type: :view do
       expect(rendered).to have_link(
         diff.name,
         href: profile_project_folder_path(
-          project.owner, project.slug, diff.external_id
+          project.owner, project.slug, diff.remote_file_id
         )
       )
     end
@@ -72,7 +72,7 @@ RSpec.describe 'folders/show', type: :view do
     diffs.each do |diff|
       link = profile_project_file_infos_path(project.owner,
                                              project,
-                                             diff.external_id)
+                                             diff.remote_file_id)
       expect(rendered).to have_link(text: '', href: link)
     end
   end

--- a/spec/views/folders/show_spec.rb
+++ b/spec/views/folders/show_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'folders/show', type: :view do
   it 'renders the links of files' do
     render
     staged_files.map(&:diff).each do |diff|
-      link = diff.external_link
+      link = diff.link_to_remote
       expect(rendered)
         .to have_css "a[href='#{link}'][target='_blank']"
     end

--- a/spec/views/projects/_head_spec.rb
+++ b/spec/views/projects/_head_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'projects/_head', type: :view do
     it 'renders a link to open that folder in Google Drive' do
       render
       expect(rendered).to have_link(
-        'Open in Drive', href: root.external_link
+        'Open in Drive', href: root.link_to_remote
       )
     end
   end

--- a/spec/views/revisions/folders/show_spec.rb
+++ b/spec/views/revisions/folders/show_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe 'revisions/folders/show', type: :view do
         expect(rendered).to have_link(
           child.name,
           href: profile_project_revision_folder_path(
-            project.owner, project.slug, revision.id, child.external_id
+            project.owner, project.slug, revision.id, child.remote_file_id
           )
         )
       end
@@ -119,7 +119,7 @@ RSpec.describe 'revisions/folders/show', type: :view do
     children.each do |child|
       link = profile_project_file_infos_path(project.owner,
                                              project,
-                                             child.external_id)
+                                             child.remote_file_id)
       expect(rendered).to have_link(text: '', href: link)
     end
   end

--- a/spec/views/revisions/folders/show_spec.rb
+++ b/spec/views/revisions/folders/show_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe 'revisions/folders/show', type: :view do
     it 'renders the links of file backups' do
       render
       children.each do |child|
-        link = child.backup.external_link
+        link = child.backup.link_to_remote
         expect(rendered).to have_css "a[href='#{link}'][target='_blank']"
       end
     end

--- a/spec/views/revisions/index_spec.rb
+++ b/spec/views/revisions/index_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe 'revisions/index', type: :view do
       render
       diffs.each do |diff|
         link = profile_project_revision_folder_path(
-          project.owner, project.slug, revisions.first.id, diff.external_id
+          project.owner, project.slug, revisions.first.id, diff.remote_file_id
         )
         expect(rendered).to have_link(text: diff.name, href: link)
       end
@@ -124,7 +124,7 @@ RSpec.describe 'revisions/index', type: :view do
       diffs.each do |diff|
         link = profile_project_file_infos_path(project.owner,
                                                project,
-                                               diff.external_id)
+                                               diff.remote_file_id)
         expect(rendered).to have_link(text: 'More', href: link)
       end
     end

--- a/spec/views/revisions/index_spec.rb
+++ b/spec/views/revisions/index_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe 'revisions/index', type: :view do
     it 'renders a link to each file backup' do
       render
       diffs.each do |diff|
-        link = diff.current_snapshot.backup.external_link
+        link = diff.current_snapshot.backup.link_to_remote
         expect(rendered).to have_link(text: diff.name, href: link)
       end
     end

--- a/spec/views/revisions/new_spec.rb
+++ b/spec/views/revisions/new_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe 'revisions/new', type: :view do
       end
     end
 
-    it 'marks all links as external links' do
+    it 'marks all links as remote links' do
       render
       expect(rendered).to have_css("a[target='_blank']")
       expect(rendered).not_to have_css("a:not([target='_blank'])")

--- a/spec/views/revisions/new_spec.rb
+++ b/spec/views/revisions/new_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe 'revisions/new', type: :view do
     it 'renders a link to each file backup' do
       render
       file_diffs.each do |diff|
-        link = diff.current_snapshot.backup.external_link
+        link = diff.current_snapshot.backup.link_to_remote
         expect(rendered).to have_link(text: diff.name, href: link)
       end
     end


### PR DESCRIPTION
The non-local file is called the remote, thus the reference to this
non-local file should be called remote. This change affects external_id,
sync_adapter, and external_link.