### PR TITLE
Remove code that is unused

### DIFF
--- a/app/models/vcs/commit.rb
+++ b/app/models/vcs/commit.rb
@@ -47,10 +47,6 @@ module VCS
       preload(file_diffs: { new_version: :content, old_version: :content })
     }
 
-    scope :last_per_branch, lambda {
-      select('MAX(id) id, branch_id').published.group(:branch_id)
-    }
-
     scope :published, -> { where(is_published: true) }
 
     # Validations

--- a/app/models/vcs/operations/content_differ.rb
+++ b/app/models/vcs/operations/content_differ.rb
@@ -54,16 +54,6 @@ module VCS
       def fragments
         @fragments ||= VCS::Operations::ContentChangeFragment.fragment(full)
       end
-
-      private
-
-      def file_for_new_content
-        @file_for_new_content ||= tempfile(new_content)
-      end
-
-      def file_for_old_content
-        @file_for_old_content ||= tempfile(old_content)
-      end
     end
   end
 end

--- a/app/models/vcs/version.rb
+++ b/app/models/vcs/version.rb
@@ -23,11 +23,6 @@ module VCS
     # Attributes
     alias_attribute :versionable_id, :file_id
 
-    # Scopes
-    scope :joins_current_version, lambda {
-      left_joins(file: :current_version)
-    }
-
     # TODO: Add in support for different providers set on repository level
     # # Return versions with provider ID from file resource
     # scope :with_provider_id, lambda {
@@ -123,11 +118,11 @@ module VCS
       content&.plain_text
     end
 
-    # Return provider ID of file resource, either preloaded or from file
-    # resource
-    def provider_id
-      0
-    end
+    # TODO: Support different providers at repository level
+    # Return provider ID of repository, either preloaded or from file
+    # def provider_id
+    #   0
+    # end
 
     # Create a new version from the current version's attributes and set the
     # current version to the new one


### PR DESCRIPTION
Remove dead code artifacts that have remained in VCS library from a long
time ago when we were migrating from the single-source to the
multi-source model. This will slightly increase code coverage.