### PR TITLE
Hotfix v0.30.1: Fix RenameFileThumbnailsToThumbnailsMigration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v0.30.1 (Dec 6, 2018)
+
+**Fixes:**
+- Fix the latest database migration that was accidentally modified while doing
+  a find-and-replace operation
+
 ## v0.30 (Dec 6, 2018)
 
 **New Features:**

--- a/db/migrate/20181204165449_rename_file_thumbnails_to_thumbnails.rb
+++ b/db/migrate/20181204165449_rename_file_thumbnails_to_thumbnails.rb
@@ -1,6 +1,6 @@
 class RenameFileThumbnailsToThumbnails < ActiveRecord::Migration[5.2]
   def up
-    rename_table :vcs_thumbnails, :vcs_thumbnails
+    rename_table :vcs_file_thumbnails, :vcs_thumbnails
 
     # rename attachment directory
     FileUtils.mv(
@@ -10,7 +10,7 @@ class RenameFileThumbnailsToThumbnails < ActiveRecord::Migration[5.2]
   end
 
   def down
-    rename_table :vcs_thumbnails, :vcs_thumbnails
+    rename_table :vcs_thumbnails, :vcs_file_thumbnails
 
     # rename attachment directory
     FileUtils.mv(
@@ -22,7 +22,7 @@ class RenameFileThumbnailsToThumbnails < ActiveRecord::Migration[5.2]
   private
 
   def old_path_for_file_thumbnail_storage
-    Rails.root.join(Settings.attachment_storage, 'vcs', 'thumbnails')
+    Rails.root.join(Settings.attachment_storage, 'vcs', 'file_thumbnails')
   end
 
   def new_path_for_file_thumbnail_storage


### PR DESCRIPTION
We accidentally modified the migration while doing a find-and-replace
for `file_thumbnails`. This fixes that by reverting the original table
name back to `file_thumbnails`.