### PR TITLE
Limit project setup to owner & collaborators

### DIFF
--- a/app/controllers/concerns/can_set_project_context.rb
+++ b/app/controllers/concerns/can_set_project_context.rb
@@ -24,6 +24,11 @@ module CanSetProjectContext
     render 'projects/access_unauthorized', layout: 'application', status: 403
   end
 
+  # Can the current user collaborate on this project?
+  def set_can_collaborate
+    @can_collaborate = can?(:collaborate, @project)
+  end
+
   # Find and set project. Raise 404 if project does not exist
   def set_project
     set_project_by_handle_and_slug!
@@ -35,6 +40,8 @@ module CanSetProjectContext
     @project = scope.find_by_handle_and_slug!(profile_handle, profile_slug)
     # TODO: Consider extraction
     @master_branch = @project.master_branch
+    # TODO: Consider extraction
+    set_can_collaborate
   end
   # rubocop:enable Naming/AccessorMethodName
 

--- a/app/controllers/project_setups_controller.rb
+++ b/app/controllers/project_setups_controller.rb
@@ -7,7 +7,7 @@ class ProjectSetupsController < ApplicationController
   before_action :authenticate_account!, except: :show
   before_action :set_project
   before_action :authorize_project_access
-  before_action :authorize_action, except: :show
+  before_action :authorize_action
   before_action :redirect_to_show_if_setup_started_or_done, only: %i[new create]
   before_action :redirect_to_new_if_setup_not_started,      only: :show
   before_action :redirect_to_project_if_setup_complete,     only: :show

--- a/app/views/layouts/file_changes.slim
+++ b/app/views/layouts/file_changes.slim
@@ -1,5 +1,5 @@
 = render partial: 'projects/head', object: @project, as: :project,
-         locals: { active_tab: nil }
+         locals: { active_tab: nil, can_collaborate: @can_collaborate }
 
 = render partial: 'file_infos/head', object: @file_diff, as: :file,
          locals: { project: @project }

--- a/app/views/layouts/file_infos.slim
+++ b/app/views/layouts/file_infos.slim
@@ -1,5 +1,5 @@
 = render partial: 'projects/head', object: @project, as: :project,
-         locals: { active_tab: nil }
+         locals: { active_tab: nil, can_collaborate: @can_collaborate }
 
 = render partial: 'file_infos/head', object: @file, as: :file,
          locals: { project: @project }

--- a/app/views/layouts/folders.slim
+++ b/app/views/layouts/folders.slim
@@ -1,5 +1,5 @@
 = render partial: 'projects/head', object: @project, as: :project,
-         locals: { active_tab: :files }
+         locals: { active_tab: :files, can_collaborate: @can_collaborate }
 
 = yield
 

--- a/app/views/layouts/project_overviews.slim
+++ b/app/views/layouts/project_overviews.slim
@@ -1,5 +1,5 @@
 = render partial: 'projects/head', object: @project, as: :project,
-         locals: { active_tab: :overview }
+         locals: { active_tab: :overview, can_collaborate: @can_collaborate }
 
 = yield
 

--- a/app/views/layouts/project_setups.slim
+++ b/app/views/layouts/project_setups.slim
@@ -1,5 +1,5 @@
 = render partial: 'projects/head', object: @project, as: :project,
-         locals: { active_tab: :setup }
+         locals: { active_tab: :setup, can_collaborate: @can_collaborate }
 
 = yield
 

--- a/app/views/layouts/revisions.slim
+++ b/app/views/layouts/revisions.slim
@@ -1,5 +1,8 @@
 = render partial: 'projects/head', object: @project, as: :project,
-         locals: { active_tab: [:new, :create].include?(action_name.to_sym) ? :files : :revisions }
+         locals: { \
+           active_tab: [:new, :create].include?(action_name.to_sym) ? :files : :revisions,
+           can_collaborate: @can_collaborate \
+         }
 
 = yield
 

--- a/app/views/layouts/revisions/file_changes.slim
+++ b/app/views/layouts/revisions/file_changes.slim
@@ -1,5 +1,5 @@
 = render partial: 'projects/head', object: @project, as: :project,
-         locals: { active_tab: nil }
+         locals: { active_tab: nil, can_collaborate: @can_collaborate }
 
 = render partial: 'revisions/head', object: @revision, as: :revision,
          locals: { project: @project }

--- a/app/views/layouts/revisions/folders.slim
+++ b/app/views/layouts/revisions/folders.slim
@@ -1,4 +1,5 @@
-= render partial: 'projects/head', object: @project, as: :project
+= render partial: 'projects/head', object: @project, as: :project,
+         locals: { active_tab: nil, can_collaborate: @can_collaborate }
 
 = render partial: 'revisions/head', object: @revision, as: :revision,
          locals: { project: @project }

--- a/app/views/projects/_form.slim
+++ b/app/views/projects/_form.slim
@@ -13,7 +13,7 @@
     end
 
   = render partial: 'projects/head', object: @project, as: :project,
-           locals: { active_tab: :overview }
+           locals: { active_tab: :overview, can_collaborate: @can_collaborate }
 
   .project-banner style="background-image: url(#{image_path('projects/banner.jpg')});"
 

--- a/app/views/projects/_head.slim
+++ b/app/views/projects/_head.slim
@@ -18,11 +18,11 @@
             div.tab
               = link_to 'Overview', profile_project_overview_path(project.owner, project),
                 class: ('active' if active_tab == :overview)
-            - if project.setup_not_started?
+            - if project.setup_not_started? && can_collaborate
               div.tab
                 = link_to 'Setup', new_profile_project_setup_path(project.owner, project),
                           class: ('active' if active_tab == :setup)
-            - elsif project.setup_in_progress?
+            - elsif project.setup_in_progress? && can_collaborate
               div.tab
                 = link_to 'Setup', profile_project_setup_path(project.owner, project),
                           class: ('active' if active_tab == :setup)

--- a/spec/controllers/project_setups_controller_spec.rb
+++ b/spec/controllers/project_setups_controller_spec.rb
@@ -125,6 +125,12 @@ RSpec.describe ProjectSetupsController, :delayed_job, type: :controller do
 
     it_should_behave_like 'setting project'
     it_should_behave_like 'authorizing project access'
+    it_should_behave_like 'an authorized action' do
+      let(:redirect_location) { profile_project_path(project.owner, project) }
+      let(:unauthorized_message) do
+        'You are not authorized to set up this project.'
+      end
+    end
 
     it 'returns http success' do
       run_request

--- a/spec/views/projects/_head_spec.rb
+++ b/spec/views/projects/_head_spec.rb
@@ -2,10 +2,12 @@
 
 RSpec.describe 'projects/_head', type: :view do
   let(:project) { build_stubbed(:project) }
+  let(:can_collaborate) { false }
 
   before do
     without_partial_double_verification do
       allow(view).to receive(:project) { project }
+      allow(view).to receive(:can_collaborate) { can_collaborate }
     end
   end
 
@@ -27,10 +29,19 @@ RSpec.describe 'projects/_head', type: :view do
 
     it 'renders a link to start the project setup' do
       render
-      expect(rendered).to have_link(
-        'Setup',
-        href: new_profile_project_setup_path(project.owner, project.slug)
-      )
+      expect(rendered).not_to have_link('Setup')
+    end
+
+    context 'when user can collaborate on project' do
+      let(:can_collaborate) { true }
+
+      it 'renders a link to start the project setup' do
+        render
+        expect(rendered).to have_link(
+          'Setup',
+          href: new_profile_project_setup_path(project.owner, project.slug)
+        )
+      end
     end
   end
 
@@ -38,12 +49,21 @@ RSpec.describe 'projects/_head', type: :view do
     before { allow(project).to receive(:setup_not_started?).and_return false }
     before { allow(project).to receive(:setup_in_progress?).and_return true }
 
-    it 'renders a link to the setup status' do
+    it 'does not render a link to the setup status' do
       render
-      expect(rendered).to have_link(
-        'Setup',
-        href: profile_project_setup_path(project.owner, project.slug)
-      )
+      expect(rendered).not_to have_link('Setup')
+    end
+
+    context 'when user can collaborate on project' do
+      let(:can_collaborate) { true }
+
+      it 'renders a link to the setup status' do
+        render
+        expect(rendered).to have_link(
+          'Setup',
+          href: profile_project_setup_path(project.owner, project.slug)
+        )
+      end
     end
   end
 


### PR DESCRIPTION
When requesting to see a project's setup status, only collaborators are
granted access. Visitors are denied.

Previously, visitors were granted access as well. We change this because
there is no reason for visitors to need access to the setup status.

This resolves [#255](https://github.com/OpenlyOne/openly/issues/255).