### PR TITLE
Add support for public projects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ cache:
 services:
   - postgresql
 
+# Install bundler to avoid 'The program bundle is currently not installed'
+before_install:
+  - "travis_retry gem update --system"
+  - "travis_retry gem install bundler"
+
 before_script:
   - psql -c 'create database openly_test;' -U postgres
 

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -11,6 +11,21 @@ module Admin
   class ApplicationController < Administrate::ApplicationController
     before_action :authenticate_admin
 
+    # HACK: Overwrite #redirect_to, so that we can force-pass ID
+    # =>    This is necessary because the Project resource uses a
+    # =>    non-identifying #to_param method. A project's slug alone is not
+    # =>    sufficient to identify it. Routes in administrate are generated
+    # =>    using the polymorphic_path helper which - by default - relies on
+    # =>    the #to_param method. By explicitly passing the id: and format:
+    # =>    parameters, we can overwrite this behavior.
+    def redirect_to(path, options = {})
+      # Force pass id and format parameters if the path is an array of objects
+      path.push(id: path.last.id, format: nil) if path.is_a?(Array)
+
+      # Simply pass everything forward
+      super(path, options)
+    end
+
     private
 
     def authenticate_admin

--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Admin
+  # Administration controller for managing projects
+  class ProjectsController < Admin::ApplicationController
+  end
+end

--- a/app/controllers/file_infos_controller.rb
+++ b/app/controllers/file_infos_controller.rb
@@ -10,6 +10,7 @@ class FileInfosController < ApplicationController
   before_action :set_committed_file_diffs
   before_action :set_file
   before_action :set_parent_in_branch, if: :uncaptured_file_diff_present?
+  before_action :set_user_can_view_file_in_branch
   before_action :set_user_can_force_sync_files
   before_action :preload_backups_for_committed_file_diffs
 
@@ -76,6 +77,10 @@ class FileInfosController < ApplicationController
 
   def set_user_can_force_sync_files
     @user_can_force_sync_files = can?(:force_sync, @project)
+  end
+
+  def set_user_can_view_file_in_branch
+    @user_can_view_file_in_branch = can?(:show, :file_in_branch, @project)
   end
 
   def uncaptured_file_diff_present?

--- a/app/controllers/file_infos_controller.rb
+++ b/app/controllers/file_infos_controller.rb
@@ -12,6 +12,7 @@ class FileInfosController < ApplicationController
   before_action :set_parent_in_branch, if: :uncaptured_file_diff_present?
   before_action :set_user_can_view_file_in_branch
   before_action :set_user_can_force_sync_files
+  before_action :set_user_can_restore_files
   before_action :preload_backups_for_committed_file_diffs
 
   def index; end
@@ -77,6 +78,10 @@ class FileInfosController < ApplicationController
 
   def set_user_can_force_sync_files
     @user_can_force_sync_files = can?(:force_sync, @project)
+  end
+
+  def set_user_can_restore_files
+    @user_can_restore_files = can?(:restore_file, @project)
   end
 
   def set_user_can_view_file_in_branch

--- a/app/controllers/revisions/folders_controller.rb
+++ b/app/controllers/revisions/folders_controller.rb
@@ -12,6 +12,7 @@ module Revisions
     before_action :set_folder_from_param, only: :show
     before_action :set_children, only: %i[root show]
     before_action :set_ancestors, only: %i[root show]
+    before_action :set_user_can_restore_revision
 
     def root
       render 'show'
@@ -60,6 +61,10 @@ module Revisions
 
     def set_revision
       @revision = @master_branch.commits.find(params[:revision_id])
+    end
+
+    def set_user_can_restore_revision
+      @user_can_restore_revision = can?(:restore_revision, @project)
     end
   end
 end

--- a/app/dashboards/project_dashboard.rb
+++ b/app/dashboards/project_dashboard.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'administrate/base_dashboard'
+
+# Describe attributes of Account model
+class ProjectDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    owner: Field::BelongsTo.with_options(class_name: 'Profiles::User'),
+    id: Field::Number,
+    title: Field::String,
+    slug: Field::String,
+    description: Field::Text,
+    tag_list: Field::String,
+    is_public: Field::Boolean,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    title
+    owner
+    is_public
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    title
+    owner
+    slug
+    description
+    tag_list
+    is_public
+    created_at
+    updated_at
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    title
+    owner
+    slug
+    description
+    tag_list
+    is_public
+  ].freeze
+
+  # Overwrite this method to customize how accounts are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(account)
+  #   "Account ##{account.id}"
+  # end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -28,6 +28,11 @@ class Ability
       can? :manage, project.owner
     end
 
+    # User can view files in branchc for projects in which they collaborate
+    can :show, :file_in_branch do |_file_in_branch, project|
+      can?(:collaborate, project)
+    end
+
     # User can force sync and restore files & setup for projects in which they
     # collaborate
     can %i[force_sync restore_file restore_revision setup], Project do |project|

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -164,6 +164,9 @@ class Project < ApplicationRecord
   end
 
   # Set up the archive folder for this project
+  # TODO: Needs refactoring. Method is overloaded.
+  # =>    Consider extracting first couple lines into #build_archive method.
+  # rubocop:disable Metrics/AbcSize
   def setup_archive
     return unless repository.present?
 
@@ -172,7 +175,10 @@ class Project < ApplicationRecord
 
     return if repository_archive.setup_completed?
 
-    repository_archive.tap(&:setup).tap(&:save)
+    repository_archive.setup
+    repository_archive.grant_public_access if public?
+    repository_archive.save
   end
+  # rubocop:enable Metrics/AbcSize
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/vcs/archive.rb
+++ b/app/models/vcs/archive.rb
@@ -19,6 +19,12 @@ module VCS
       api_connection_class.default
     end
 
+    # Makes the archive publicly accessible
+    def grant_public_access
+      # TODO: Call method #share on remote_archive
+      default_api_connection.share_file_with_anyone(remote_file_id, :reader)
+    end
+
     # Add the given email address as a viewer to the archive folder
     def grant_read_access_to(email)
       # TODO: Call method #share on remote_archive

--- a/app/models/vcs/archive.rb
+++ b/app/models/vcs/archive.rb
@@ -31,6 +31,12 @@ module VCS
       default_api_connection.share_file(remote_file_id, email, :reader)
     end
 
+    # Removes public access to the archive
+    def remove_public_access
+      # TODO: Call method #unshare on remote_archive
+      default_api_connection.unshare_file_with_anyone(remote_file_id)
+    end
+
     # Remove the given email address as a viewer from the archive folder
     def remove_read_access_from(email)
       # TODO: Call method #unshare on remote_archive

--- a/app/views/admin/application/_collection.html.erb
+++ b/app/views/admin/application/_collection.html.erb
@@ -1,0 +1,96 @@
+<%#
+# Collection
+
+This partial is used on the `index` and `show` pages
+to display a collection of resources in an HTML table.
+
+## Local variables:
+
+- `collection_presenter`:
+  An instance of [Administrate::Page::Collection][1].
+  The table presenter uses `ResourceDashboard::COLLECTION_ATTRIBUTES` to determine
+  the columns displayed in the table
+- `resources`:
+  An ActiveModel::Relation collection of resources to be displayed in the table.
+  By default, the number of resources is limited by pagination
+  or by a hard limit to prevent excessive page load times
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
+%>
+
+<table aria-labelledby="<%= table_title %>">
+  <thead>
+    <tr>
+      <% collection_presenter.attribute_types.each do |attr_name, attr_type| %>
+        <th class="cell-label
+        cell-label--<%= attr_type.html_class %>
+        cell-label--<%= collection_presenter.ordered_html_class(attr_name) %>"
+        scope="col"
+        role="columnheader"
+        aria-sort="<%= sort_order(collection_presenter.ordered_html_class(attr_name)) %>">
+        <%= link_to(sanitized_order_params.merge(
+          collection_presenter.order_params_for(attr_name)
+        )) do %>
+        <%= t(
+          "helpers.label.#{collection_presenter.resource_name}.#{attr_name}",
+          default: attr_name.to_s,
+        ).titleize %>
+
+            <% if collection_presenter.ordered_by?(attr_name) %>
+              <span class="cell-label__sort-indicator cell-label__sort-indicator--<%= collection_presenter.ordered_html_class(attr_name) %>">
+                <svg aria-hidden="true">
+                  <use xlink:href="#icon-up-caret" />
+                </svg>
+              </span>
+            <% end %>
+          <% end %>
+        </th>
+      <% end %>
+      <% [valid_action?(:edit, collection_presenter.resource_name),
+          valid_action?(:destroy, collection_presenter.resource_name)].count(true).times do %>
+        <th scope="col"></th>
+      <% end %>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% resources.each do |resource| %>
+      <tr class="js-table-row"
+          tabindex="0"
+          <% if valid_action? :show, collection_presenter.resource_name %>
+            <%= %(role=link data-url=#{polymorphic_path([namespace, resource], id: resource.id, format: nil)}) %>
+          <% end %>
+          >
+        <% collection_presenter.attributes_for(resource).each do |attribute| %>
+          <td class="cell-data cell-data--<%= attribute.html_class %>">
+            <% if show_action? :show, resource -%>
+              <a href="<%= polymorphic_path([namespace, resource], id: resource.id, format: nil) -%>"
+                 class="action-show"
+                 >
+                <%= render_field attribute %>
+              </a>
+            <% end -%>
+          </td>
+        <% end %>
+
+        <% if valid_action? :edit, collection_presenter.resource_name %>
+          <td><%= link_to(
+            t("administrate.actions.edit"),
+            [:edit, namespace, resource, id: resource.id, format: nil],
+            class: "action-edit",
+          ) if show_action? :edit, resource%></td>
+        <% end %>
+
+        <% if valid_action? :destroy, collection_presenter.resource_name %>
+          <td><%= link_to(
+            t("administrate.actions.destroy"),
+            [namespace, resource, id: resource.id, format: nil],
+            class: "text-color-red",
+            method: :delete,
+            data: { confirm: t("administrate.actions.confirm") }
+          ) if show_action? :destroy, resource %></td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/application/_form.html.erb
+++ b/app/views/admin/application/_form.html.erb
@@ -1,0 +1,47 @@
+<%#
+# Form Partial
+
+This partial is rendered on a resource's `new` and `edit` pages,
+and renders all form fields for a resource's editable attributes.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Form][1].
+  Contains helper methods to display a form,
+  and knows which attributes should be displayed in the resource's form.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
+%>
+
+<%= form_for([namespace, page.resource],
+             url: polymorphic_path([namespace, page.resource], id: page.resource.id, format: nil),
+             html: { class: "form" }) do |f| %>
+  <% if page.resource.errors.any? %>
+    <div id="error_explanation">
+      <h2>
+        <%= t(
+          "administrate.form.errors",
+          pluralized_errors: pluralize(page.resource.errors.count, t("administrate.form.error")),
+          resource_name: display_resource_name(page.resource_name)
+        ) %>
+      </h2>
+
+      <ul>
+        <% page.resource.errors.full_messages.each do |message| %>
+          <li class="flash-error"><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <% page.attributes.each do |attribute| -%>
+    <div class="field-unit field-unit--<%= attribute.html_class %>">
+      <%= render_field attribute, f: f %>
+    </div>
+  <% end -%>
+
+  <div class="form-actions">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/admin/application/edit.html.erb
+++ b/app/views/admin/application/edit.html.erb
@@ -1,0 +1,36 @@
+<%#
+# Edit
+
+This view is the template for the edit page.
+
+It displays a header, and renders the `_form` partial to do the heavy lifting.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Form][1].
+  Contains helper methods to help display a form,
+  and knows which attributes should be displayed in the resource's form.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
+%>
+
+<% content_for(:title) { t("administrate.actions.edit_resource", name: page.page_title) } %>
+
+<header class="main-content__header" role="banner">
+  <h1 class="main-content__page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <div>
+    <%= link_to(
+      t("administrate.actions.show_resource", name: page.page_title),
+      [namespace, page.resource, id: page.resource.id, format: nil],
+      class: "button",
+    ) if valid_action?(:show) && show_action?(:show, page.resource) %>
+  </div>
+</header>
+
+<section class="main-content__body">
+  <%= render "form", page: page %>
+</section>

--- a/app/views/admin/application/show.html.erb
+++ b/app/views/admin/application/show.html.erb
@@ -1,0 +1,49 @@
+<%#
+# Show
+
+This view is the template for the show page.
+It renders the attributes of a resource,
+as well as a link to its edit page.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Show][1].
+  Contains methods for accessing the resource to be displayed on the page,
+  as well as helpers for describing how each attribute of the resource
+  should be displayed.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Show
+%>
+
+<% content_for(:title) { t("administrate.actions.show_resource", name: page.page_title) } %>
+
+<header class="main-content__header" role="banner">
+  <h1 class="main-content__page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <div>
+    <%= link_to(
+      t("administrate.actions.edit_resource", name: page.page_title),
+      [:edit, namespace, page.resource, id: page.resource.id, format: nil],
+      class: "button",
+    ) if valid_action?(:edit) && show_action?(:edit, page.resource) %>
+  </div>
+</header>
+
+<section class="main-content__body">
+  <dl>
+    <% page.attributes.each do |attribute| %>
+      <dt class="attribute-label" id="<%= attribute.name %>">
+      <%= t(
+        "helpers.label.#{resource_name}.#{attribute.name}",
+        default: attribute.name.titleize,
+      ) %>
+      </dt>
+
+      <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
+          ><%= render_field attribute %></dd>
+    <% end %>
+  </dl>
+</section>

--- a/app/views/file_infos/_file_version_history.slim
+++ b/app/views/file_infos/_file_version_history.slim
@@ -4,12 +4,16 @@ h3.with-separator.no-margin-bottom: span File History
 
 - committed_file_diffs.each do |diff|
 
+  / only show show restore button if user is permitted to perform restoration
+  - path_to_restore_action = \
+    user_can_restore_files ? restore_action_path(@project, diff) : nil
+
   = render partial: 'revisions/revision',
            object: diff.commit,
            locals: { project: project,
                      file_changes: diff.changes,
                      show_link_to_file_info: false,
-                     path_to_restore_action: restore_action_path(@project, diff) }
+                     path_to_restore_action: path_to_restore_action }
 
 - if committed_file_diffs.none?
 

--- a/app/views/file_infos/index.slim
+++ b/app/views/file_infos/index.slim
@@ -1,9 +1,11 @@
 .container
 
-  = render partial: 'file_status',
-           locals: { uncaptured_file_diff: @uncaptured_file_diff,
-                     user_can_force_sync_files: @user_can_force_sync_files,
-                     project: @project }
+  / render file status only if user can view files in branch / work-in-progress
+  - if @user_can_view_file_in_branch
+    = render partial: 'file_status',
+             locals: { uncaptured_file_diff: @uncaptured_file_diff,
+                       user_can_force_sync_files: @user_can_force_sync_files,
+                       project: @project }
 
   = render partial: 'file_version_history',
            locals: { project: @project,

--- a/app/views/file_infos/index.slim
+++ b/app/views/file_infos/index.slim
@@ -9,6 +9,7 @@
 
   = render partial: 'file_version_history',
            locals: { project: @project,
-                     committed_file_diffs: @committed_file_diffs }
+                     committed_file_diffs: @committed_file_diffs,
+                     user_can_restore_files: @user_can_restore_files }
 
   .spacing.v48px

--- a/app/views/projects/_head.slim
+++ b/app/views/projects/_head.slim
@@ -28,8 +28,11 @@
                           class: ('active' if active_tab == :setup)
             - elsif project.setup_completed?
               div.tab
-                = link_to 'Files', profile_project_root_folder_path(project.owner, project),
-                          class: ('active' if active_tab == :files)
+                - if can_collaborate
+                  = link_to 'Files', profile_project_root_folder_path(project.owner, project),
+                            class: ('active' if active_tab == :files)
+                - else
+                  = link_to 'Files', profile_project_revision_root_folder_path(project.owner, project, project.revisions.last)
               div.tab
                 = link_to 'Revisions', profile_project_revisions_path(project.owner, project),
                           class: ('active' if active_tab == :revisions)

--- a/app/views/projects/_head.slim
+++ b/app/views/projects/_head.slim
@@ -33,9 +33,10 @@
               div.tab
                 = link_to 'Revisions', profile_project_revisions_path(project.owner, project),
                           class: ('active' if active_tab == :revisions)
-              div.tab
-                = link_to project.master_branch.root.link_to_remote, target: '_blank' do
-                  svg style="width:24px;height:24px" viewBox="0 0 24 24" class="left"
-                    path fill="currentColor" d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
-                  | Open in Drive
-                end
+              - if can_collaborate
+                div.tab
+                  = link_to project.master_branch.root.link_to_remote, target: '_blank' do
+                    svg style="width:24px;height:24px" viewBox="0 0 24 24" class="left"
+                      path fill="currentColor" d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
+                    | Open in Drive
+                  end

--- a/app/views/revisions/folders/show.slim
+++ b/app/views/revisions/folders/show.slim
@@ -16,8 +16,7 @@
                       revision: @revision}
 
 / button for restoring commit
-/ TODO: Implement check
-- if true || @user_can_restore_revision
+- if @user_can_restore_revision
   .fixed-action-btn
     =<> button_to profile_project_revision_restores_path(@project.owner, @project, @revision),
                   method: :post,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,6 +26,9 @@ en:
     create:
       revision: "You are not authorized to commit changes for this project."
       all: "You are not authorized to create a new %{subject}."
+    show:
+      file_in_branch:
+        You are not authorized to view work in progress for this project.
     setup:
       project: "You are not authorized to set up this project."
     force_sync:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   # Admin panel routing, return 404 unless account is admin
   authenticated :account, ->(account) { account.admin? } do
     namespace :admin do
-      resources :accounts
+      resources :accounts, :projects
 
       # Analytics Dashboard
       mount Blazer::Engine, at: 'analytics', as: :analytics

--- a/spec/controllers/folders_controller_spec.rb
+++ b/spec/controllers/folders_controller_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'controllers/shared_examples/an_authenticated_action.rb'
+require 'controllers/shared_examples/an_authorized_action.rb'
 require 'controllers/shared_examples/authorizing_project_access.rb'
 require 'controllers/shared_examples/raise_404_if_non_existent.rb'
 require 'controllers/shared_examples/setting_project.rb'
@@ -25,11 +27,20 @@ RSpec.describe FoldersController, type: :controller do
     let(:params)          { default_params.except :id }
     let(:run_request)     { get :root, params: params }
 
+    it_should_behave_like 'an authenticated action'
     it_should_behave_like 'setting project where setup is complete'
     it_should_behave_like 'raise 404 if non-existent', nil do
       before { VCS::FileInBranch.delete_all }
     end
     it_should_behave_like 'authorizing project access'
+    it_should_behave_like 'an authorized action' do
+      let(:redirect_location) do
+        profile_project_path(project.owner, project)
+      end
+      let(:unauthorized_message) do
+        'You are not authorized to view work in progress for this project.'
+      end
+    end
 
     it 'returns http success' do
       run_request

--- a/spec/features/admin_panel_spec.rb
+++ b/spec/features/admin_panel_spec.rb
@@ -20,6 +20,8 @@ feature 'Admin Panel' do
     expect(page).to have_text 'Accounts'
     expect(page).to have_link 'New account'
     expect(page).to have_text admin.email
+
+    click_on 'Projects'
   end
 end
 

--- a/spec/features/project_spec.rb
+++ b/spec/features/project_spec.rb
@@ -41,18 +41,23 @@ feature 'Project' do
   end
 
   scenario 'User can view project' do
-    # given there is a public project
-    project = create(:project, :public, :skip_archive_setup)
+    # given there is a project
+    project = create(:project, :skip_archive_setup, :setup_complete)
+    create :vcs_file_in_branch, :root, branch: project.master_branch
     # with two collaborators
     collaborators = create_list :user, 2
     project.collaborators << collaborators
+
+    sign_in_as project.owner.account
 
     # when I visit the project's owner
     visit "/#{project.owner.to_param}"
     # and click on the project title
     click_on project.title
+    # and click on Overview
+    click_on 'Overview'
 
-    # then I should be on the project's overview page
+    # then I should be on the project's files page
     expect(page).to have_current_path(
       profile_project_overview_path(project.owner, project)
     )

--- a/spec/features/visitor_spec.rb
+++ b/spec/features/visitor_spec.rb
@@ -53,7 +53,7 @@ feature 'Visitors: As a guest/non-collaborator' do
 
     let(:guest_account) { create :account, email: guest_acct }
     let(:owner_account) { create :account, email: owner_acct }
-    let(:project) { create :project, owner: owner_account.user }
+    let(:project) { create :project, :public, owner: owner_account.user }
     let(:link_to_folder) do
       "https://drive.google.com/drive/folders/#{google_drive_test_folder_id}"
     end

--- a/spec/features/visitor_spec.rb
+++ b/spec/features/visitor_spec.rb
@@ -110,6 +110,7 @@ feature 'Visitors: As a guest/non-collaborator' do
     project
     # with completed setup
     create :project_setup, :completed, project: project
+    create :vcs_file_in_branch, :root, branch: project.master_branch
     create :vcs_commit, :published, branch: project.master_branch
 
     # when I visit the project page
@@ -124,6 +125,6 @@ feature 'Visitors: As a guest/non-collaborator' do
       "revisions/#{project.revisions.last.to_param}/files"
     )
     # and see the last commit text
-    expect(page).to have_text 'Import Files'
+    expect(page).to have_text project.revisions.last.title
   end
 end

--- a/spec/features/visitor_spec.rb
+++ b/spec/features/visitor_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+feature 'Visitors: As a guest/non-collaborator' do
+  let(:project) { create(:project, :public, :skip_archive_setup) }
+
+  scenario 'I can view a public project' do
+    # given there is a project
+    project
+
+    # when I visit the project's owner
+    visit "/#{project.owner.to_param}"
+    # and click on the project title
+    click_on project.title
+
+    # then I should be on the project's overview page
+    expect(page).to have_current_path(
+      profile_project_overview_path(project.owner, project)
+    )
+    # and I should see the project's title
+    expect(page).to have_text project.title
+  end
+
+  context 'when project has an archive', :vcr do
+    let(:api_connection) do
+      Providers::GoogleDrive::ApiConnection.new(owner_acct)
+    end
+    let(:guest_api_connection) do
+      Providers::GoogleDrive::ApiConnection.new(guest_acct)
+    end
+    let(:owner_acct)    { ENV['GOOGLE_DRIVE_USER_ACCOUNT'] }
+    let(:guest_acct)    { ENV['GOOGLE_DRIVE_COLLABORATOR_ACCOUNT'] }
+    let(:tracking_acct) { ENV['GOOGLE_DRIVE_TRACKING_ACCOUNT'] }
+
+    # create test folder
+    before { prepare_google_drive_test(api_connection) }
+    before { refresh_google_drive_authorization(guest_api_connection) }
+    # with remote file
+    let!(:remote_file) do
+      Providers::GoogleDrive::FileSync.create(
+        name: 'My Google Drive File',
+        parent_id: google_drive_test_folder_id,
+        mime_type: Providers::GoogleDrive::MimeType.document,
+        api_connection: api_connection
+      )
+    end
+    # share test folder
+    before do
+      api_connection
+        .share_file(google_drive_test_folder_id, tracking_acct, :writer)
+    end
+    # delete test folder
+    after { tear_down_google_drive_test(api_connection) }
+
+    let(:guest_account) { create :account, email: guest_acct }
+    let(:owner_account) { create :account, email: owner_acct }
+    let(:project) { create :project, owner: owner_account.user }
+    let(:link_to_folder) do
+      "https://drive.google.com/drive/folders/#{google_drive_test_folder_id}"
+    end
+
+    before do
+      # and I wait 5 seconds for Google Drive to propagate the sharing settings
+      # to the folder's files
+      sleep 5 if VCR.current_cassette.recording?
+      create :project_setup, link: link_to_folder, project: project
+    end
+
+    scenario 'I have view access to the archive' do
+      # when I visit the project page
+      visit "#{project.owner.to_param}/#{project.to_param}"
+
+      # and go to Revisions
+      click_on 'Revisions'
+
+      # then I should be able to see the committed files
+      anchor_to_archived_file = page.find('a', text: 'My Google Drive File')
+      link_to_archived_file = anchor_to_archived_file['href']
+      archived_file_id = link_to_archived_file.match(/[-\w]{25,}/)[0]
+
+      # and fetch the committed file
+      file =
+        Providers::GoogleDrive::FileSync
+        .new(archived_file_id, api_connection: guest_api_connection)
+      expect(file.name).to eq 'My Google Drive File'
+    end
+
+    context 'when project is made private' do
+      before do
+        project.update!(is_public: false)
+
+        # and I wait 5 seconds for Google Drive to propagate the sharing
+        # settings to the folder's files
+        sleep 5 if VCR.current_cassette.recording?
+      end
+
+      scenario 'I no longer have read access to the archive' do
+        # and fetch a file that has been backed up
+        backup_id = project.repository.file_backups.first.remote_file_id
+        expect { guest_api_connection.find_file!(backup_id) }
+          .to raise_error(
+            Google::Apis::ClientError,
+            "notFound: File not found: #{backup_id}."
+          )
+      end
+    end
+  end
+
+  scenario 'I can see the files of the project at its last revision' do
+    # given there is a project
+    project
+    # with completed setup
+    create :project_setup, :completed, project: project
+    create :vcs_commit, :published, branch: project.master_branch
+
+    # when I visit the project page
+    visit "#{project.owner.to_param}/#{project.to_param}"
+
+    # and click on 'Files'
+    click_on 'Files'
+
+    # then I should be on the page for the files of the project's last revision
+    expect(page).to have_current_path(
+      "/#{project.owner.to_param}/#{project.to_param}/" \
+      "revisions/#{project.revisions.last.to_param}/files"
+    )
+    # and see the last commit text
+    expect(page).to have_text 'Import Files'
+  end
+end

--- a/spec/integrations/project_spec.rb
+++ b/spec/integrations/project_spec.rb
@@ -1,14 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Project, type: :model do
-  subject(:project)         { create :project }
-  let(:skip_archive_setup)  { true }
-
-  before do
-    next unless skip_archive_setup
-
-    allow_any_instance_of(VCS::Archive).to receive(:setup)
-  end
+  subject(:project) { create :project, :skip_archive_setup }
 
   describe 'deleteable', :delayed_job do
     before do
@@ -60,9 +53,11 @@ RSpec.describe Project, type: :model do
   describe 'scope: :where_profile_is_owner_or_collaborator(profile)' do
     subject(:method) { Project.where_profile_is_owner_or_collaborator(profile) }
     let(:profile)         { create :user }
-    let!(:owned_projects) { create_list :project, 3, owner: profile }
-    let!(:collaborations) { create_list :project, 3 }
-    let!(:other_projects) { create_list :project, 3 }
+    let!(:owned_projects) do
+      create_list :project, 3, :skip_archive_setup, owner: profile
+    end
+    let!(:collaborations) { create_list :project, 3, :skip_archive_setup }
+    let!(:other_projects) { create_list :project, 3, :skip_archive_setup }
 
     before do
       # add profile as a collaborator
@@ -99,10 +94,12 @@ RSpec.describe Project, type: :model do
   end
 
   describe 'scope: :where_setup_is_complete' do
-    subject(:method)             { Project.where_setup_is_complete }
-    let!(:with_complete_setup)   { create_list :project, 2 }
-    let!(:with_incomplete_setup) { create_list :project, 2 }
-    let!(:with_no_setup)         { create_list :project, 2 }
+    subject(:method)            { Project.where_setup_is_complete }
+    let!(:with_complete_setup)  { create_list :project, 2, :skip_archive_setup }
+    let!(:with_incomplete_setup) do
+      create_list :project, 2, :skip_archive_setup
+    end
+    let!(:with_no_setup) { create_list :project, 2, :skip_archive_setup }
 
     before do
       with_complete_setup.each do |project|
@@ -123,7 +120,7 @@ RSpec.describe Project, type: :model do
     subject(:method)  { Project.find_by_handle_and_slug!(handle, slug) }
     let(:handle)      { project.owner.handle }
     let(:slug)        { project.slug }
-    let(:project)     { create :project }
+    let(:project)     { create :project, :skip_archive_setup }
 
     it { is_expected.to eq project }
 
@@ -135,6 +132,29 @@ RSpec.describe Project, type: :model do
     context 'when slug does not exist' do
       let(:slug) { 'does-not-exist' }
       it { expect { method }.to raise_error ActiveRecord::RecordNotFound }
+    end
+  end
+
+  describe '.create with is_public: true' do
+    let(:project) do
+      create :project, :public, owner_account_email: owner_email_address
+    end
+    let(:archive) { project.archive }
+
+    let(:guest_api_connection) do
+      Providers::GoogleDrive::ApiConnection.new(guest_email_address)
+    end
+    let(:owner_email_address) { ENV['GOOGLE_DRIVE_USER_ACCOUNT'] }
+    let(:guest_email_address) { ENV['GOOGLE_DRIVE_COLLABORATOR_ACCOUNT'] }
+
+    it 'shares view access to the archive with anyone (e.g. guest)', :vcr do
+      remote_archive =
+        Providers::GoogleDrive::FileSync.new(
+          archive.remote_file_id,
+          api_connection: guest_api_connection
+        )
+
+      expect(remote_archive.name).to be_present
     end
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -81,6 +81,28 @@ RSpec.describe Ability, type: :model do
     end
   end
 
+  context 'File in Branch' do
+    actions = %i[show]
+    let(:object)  { [:file_in_branch, project] }
+    let(:project) { build_stubbed(:project) }
+
+    context 'when user is project owner' do
+      before { project.owner = user }
+      it_should_behave_like 'having authorization', actions
+    end
+
+    context 'when user is collaborator' do
+      before { project.collaborators << user }
+      it_should_behave_like 'having authorization', actions
+    end
+
+    context 'when user is not project owner or collaborator' do
+      before { project.owner = build_stubbed(:user) }
+      before { project.collaborators = [] }
+      it_should_behave_like 'not having authorization', actions
+    end
+  end
+
   describe 'Collaborators of projects' do
     actions = %i[force_sync restore_file restore_revision setup]
     let(:object)  { project }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -398,6 +398,7 @@ RSpec.describe Project, type: :model do
       allow(project).to receive(:repository_archive).and_return(archive)
       allow(archive).to receive(:setup)
       allow(archive).to receive(:setup_completed?).and_return setup_completed
+      allow(archive).to receive(:grant_public_access)
       allow(archive).to receive(:save)
 
       project.send(:setup_archive)
@@ -406,6 +407,10 @@ RSpec.describe Project, type: :model do
     it 'builds archive, sets it up, and saves' do
       expect(archive).to have_received(:setup)
       expect(archive).to have_received(:save)
+    end
+
+    it 'does not grant public access to the archive' do
+      expect(archive).not_to have_received(:grant_public_access)
     end
 
     context 'when repository is not present' do
@@ -423,6 +428,14 @@ RSpec.describe Project, type: :model do
       it 'does not call #setup' do
         expect(archive).not_to have_received(:setup)
         expect(archive).not_to have_received(:save)
+      end
+    end
+
+    context 'when project is public' do
+      subject(:project) { build_stubbed(:project, :public) }
+
+      it 'makes archive publicly accessible' do
+        expect(archive).to have_received(:grant_public_access)
       end
     end
   end

--- a/spec/models/vcs/archive_spec.rb
+++ b/spec/models/vcs/archive_spec.rb
@@ -74,6 +74,23 @@ RSpec.describe VCS::Archive, type: :model do
     end
   end
 
+  describe '#remove_public_access' do
+    let(:api) { instance_double Providers::GoogleDrive::ApiConnection }
+
+    before do
+      allow(archive).to receive(:default_api_connection).and_return api
+      allow(archive).to receive(:remote_file_id).and_return 'remote-archive-id'
+      allow(api).to receive(:unshare_file_with_anyone)
+    end
+
+    it 'shares the remote archive publicly' do
+      archive.remove_public_access
+      expect(api)
+        .to have_received(:unshare_file_with_anyone)
+        .with('remote-archive-id')
+    end
+  end
+
   describe '#remove_read_access_from(email)' do
     let(:api) { instance_double Providers::GoogleDrive::ApiConnection }
 

--- a/spec/models/vcs/archive_spec.rb
+++ b/spec/models/vcs/archive_spec.rb
@@ -40,6 +40,23 @@ RSpec.describe VCS::Archive, type: :model do
     end
   end
 
+  describe '#grant_public_access' do
+    let(:api) { instance_double Providers::GoogleDrive::ApiConnection }
+
+    before do
+      allow(archive).to receive(:default_api_connection).and_return api
+      allow(archive).to receive(:remote_file_id).and_return 'remote-archive-id'
+      allow(api).to receive(:share_file_with_anyone)
+    end
+
+    it 'shares the remote archive publicly' do
+      archive.grant_public_access
+      expect(api)
+        .to have_received(:share_file_with_anyone)
+        .with('remote-archive-id', :reader)
+    end
+  end
+
   describe '#grant_read_access_to(email)' do
     let(:api) { instance_double Providers::GoogleDrive::ApiConnection }
 

--- a/spec/support/fixtures/vcr_cassettes/Collaborators_As_a_collaborator/when_project_has_an_archive/when_I_am_removed_as_a_collaborator/I_no_longer_have_read_access_to_the_archive.yml
+++ b/spec/support/fixtures/vcr_cassettes/Collaborators_As_a_collaborator/when_project_has_an_archive/when_I_am_removed_as_a_collaborator/I_no_longer_have_read_access_to_the_archive.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Sat, 01 Dec 2018 08:03:08 GMT
+      - Wed, 02 Jan 2019 14:01:42 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 08:03:08 GMT
+  recorded_at: Wed, 02 Jan 2019 14:01:42 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Sat, 01 Dec 2018 08:03:08 GMT
+      - Wed, 02 Jan 2019 14:01:45 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 08:03:08 GMT
+  recorded_at: Wed, 02 Jan 2019 14:01:46 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-12-01
-        08:03:08 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2019-01-02
+        14:01:46 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 08:03:08 GMT
+      - Wed, 02 Jan 2019 14:01:46 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 01 Dec 2018 08:03:09 GMT
+      - Wed, 02 Jan 2019 14:01:48 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1E7SSt7LGxL4fG71xI8b2eoBFuNTaUPpl",
-         "name": "Test @ 2018-12-01 08:03:08 UTC",
+         "id": "122RVS2vkdjhOdYU1I1kz_Ee-6KQuyfzF",
+         "name": "Test @ 2019-01-02 14:01:46 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,7 +185,7 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 08:03:09 GMT
+  recorded_at: Wed, 02 Jan 2019 14:01:48 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -214,7 +214,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Sat, 01 Dec 2018 08:03:09 GMT
+      - Wed, 02 Jan 2019 14:01:48 GMT
       Server:
       - ESF
       Cache-Control:
@@ -239,14 +239,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 08:03:09 GMT
+  recorded_at: Wed, 02 Jan 2019 14:01:48 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.document","name":"My Google
-        Drive File","parents":["1E7SSt7LGxL4fG71xI8b2eoBFuNTaUPpl"]}'
+        Drive File","parents":["122RVS2vkdjhOdYU1I1kz_Ee-6KQuyfzF"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -255,7 +255,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 08:03:09 GMT
+      - Wed, 02 Jan 2019 14:01:48 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -272,7 +272,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 01 Dec 2018 08:03:11 GMT
+      - Wed, 02 Jan 2019 14:01:50 GMT
       Vary:
       - Origin
       - X-Origin
@@ -296,12 +296,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1g_4Ns23WJXi2Y9RyBtlFJykxLGTVy4i9D_6l79euhlw",
+         "id": "1OKt17Rx1TlN1f906QBerWbvc96qQl1cUwtY2hs1xkDA",
          "name": "My Google Drive File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1E7SSt7LGxL4fG71xI8b2eoBFuNTaUPpl"
+          "122RVS2vkdjhOdYU1I1kz_Ee-6KQuyfzF"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -317,10 +317,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 08:03:11 GMT
+  recorded_at: Wed, 02 Jan 2019 14:01:51 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1E7SSt7LGxL4fG71xI8b2eoBFuNTaUPpl/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/122RVS2vkdjhOdYU1I1kz_Ee-6KQuyfzF/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -332,7 +332,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 08:03:11 GMT
+      - Wed, 02 Jan 2019 14:01:51 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -349,7 +349,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 01 Dec 2018 08:03:11 GMT
+      - Wed, 02 Jan 2019 14:01:52 GMT
       Vary:
       - Origin
       - X-Origin
@@ -379,14 +379,14 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 08:03:12 GMT
+  recorded_at: Wed, 02 Jan 2019 14:01:52 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"54 Krikkit
-        One (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"127 Vogon
+        Constructor Fleet (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -395,7 +395,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 08:03:17 GMT
+      - Wed, 02 Jan 2019 14:01:57 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -412,7 +412,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 01 Dec 2018 08:03:17 GMT
+      - Wed, 02 Jan 2019 14:01:58 GMT
       Vary:
       - Origin
       - X-Origin
@@ -436,8 +436,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1wESZ6QX6_m8TvPWFLGJNtybJa-13YL6o",
-         "name": "54 Krikkit One (Archive)",
+         "id": "1C_ALJHWThIlUMi798dgZURbcCgWcmoYF",
+         "name": "127 Vogon Constructor Fleet (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -457,10 +457,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 08:03:17 GMT
+  recorded_at: Wed, 02 Jan 2019 14:01:58 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1wESZ6QX6_m8TvPWFLGJNtybJa-13YL6o/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1C_ALJHWThIlUMi798dgZURbcCgWcmoYF/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -472,7 +472,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 08:03:17 GMT
+      - Wed, 02 Jan 2019 14:01:58 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -489,7 +489,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 01 Dec 2018 08:03:18 GMT
+      - Wed, 02 Jan 2019 14:01:59 GMT
       Vary:
       - Origin
       - X-Origin
@@ -519,10 +519,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 08:03:18 GMT
+  recorded_at: Wed, 02 Jan 2019 14:01:59 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1E7SSt7LGxL4fG71xI8b2eoBFuNTaUPpl?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/122RVS2vkdjhOdYU1I1kz_Ee-6KQuyfzF?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -534,7 +534,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 08:03:18 GMT
+      - Wed, 02 Jan 2019 14:01:59 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -545,9 +545,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 01 Dec 2018 08:03:18 GMT
+      - Wed, 02 Jan 2019 14:01:59 GMT
       Date:
-      - Sat, 01 Dec 2018 08:03:18 GMT
+      - Wed, 02 Jan 2019 14:01:59 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -573,8 +573,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1E7SSt7LGxL4fG71xI8b2eoBFuNTaUPpl",
-         "name": "Test @ 2018-12-01 08:03:08 UTC",
+         "id": "122RVS2vkdjhOdYU1I1kz_Ee-6KQuyfzF",
+         "name": "Test @ 2019-01-02 14:01:46 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -600,10 +600,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 08:03:19 GMT
+  recorded_at: Wed, 02 Jan 2019 14:01:59 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1E7SSt7LGxL4fG71xI8b2eoBFuNTaUPpl/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/122RVS2vkdjhOdYU1I1kz_Ee-6KQuyfzF/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -615,7 +615,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 08:03:19 GMT
+      - Wed, 02 Jan 2019 14:01:59 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -633,9 +633,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 01 Dec 2018 08:03:19 GMT
+      - Wed, 02 Jan 2019 14:01:59 GMT
       Expires:
-      - Sat, 01 Dec 2018 08:03:19 GMT
+      - Wed, 02 Jan 2019 14:01:59 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -667,10 +667,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 08:03:19 GMT
+  recorded_at: Wed, 02 Jan 2019 14:01:59 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271E7SSt7LGxL4fG71xI8b2eoBFuNTaUPpl%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%27122RVS2vkdjhOdYU1I1kz_Ee-6KQuyfzF%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -682,7 +682,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 08:03:19 GMT
+      - Wed, 02 Jan 2019 14:01:59 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -693,9 +693,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 01 Dec 2018 08:03:19 GMT
+      - Wed, 02 Jan 2019 14:02:00 GMT
       Date:
-      - Sat, 01 Dec 2018 08:03:19 GMT
+      - Wed, 02 Jan 2019 14:02:00 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -723,14 +723,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1g_4Ns23WJXi2Y9RyBtlFJykxLGTVy4i9D_6l79euhlw",
+           "id": "1OKt17Rx1TlN1f906QBerWbvc96qQl1cUwtY2hs1xkDA",
            "name": "My Google Drive File",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1E7SSt7LGxL4fG71xI8b2eoBFuNTaUPpl"
+            "122RVS2vkdjhOdYU1I1kz_Ee-6KQuyfzF"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1g_4Ns23WJXi2Y9RyBtlFJykxLGTVy4i9D_6l79euhlw&v=1&s=AMedNnoAAAAAXAJcZ7reIEPYdsOdKL3HqM1DMMZ7_i8q&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1OKt17Rx1TlN1f906QBerWbvc96qQl1cUwtY2hs1xkDA&v=1&s=AMedNnoAAAAAXCzgePlv6xbiIZupdxKU19pgANYebOyZ&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -756,10 +756,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 08:03:19 GMT
+  recorded_at: Wed, 02 Jan 2019 14:02:00 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1g_4Ns23WJXi2Y9RyBtlFJykxLGTVy4i9D_6l79euhlw/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1OKt17Rx1TlN1f906QBerWbvc96qQl1cUwtY2hs1xkDA/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -771,7 +771,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 08:03:19 GMT
+      - Wed, 02 Jan 2019 14:02:00 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -782,9 +782,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 01 Dec 2018 08:03:19 GMT
+      - Wed, 02 Jan 2019 14:02:00 GMT
       Date:
-      - Sat, 01 Dec 2018 08:03:19 GMT
+      - Wed, 02 Jan 2019 14:02:00 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -813,13 +813,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-12-01T08:03:10.306Z"
+         "modifiedTime": "2019-01-02T14:01:49.854Z"
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 08:03:19 GMT
+  recorded_at: Wed, 02 Jan 2019 14:02:00 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1g_4Ns23WJXi2Y9RyBtlFJykxLGTVy4i9D_6l79euhlw&s=AMedNnoAAAAAXAJcZ7reIEPYdsOdKL3HqM1DMMZ7_i8q&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1OKt17Rx1TlN1f906QBerWbvc96qQl1cUwtY2hs1xkDA&s=AMedNnoAAAAAXCzgePlv6xbiIZupdxKU19pgANYebOyZ&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -831,7 +831,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 08:03:19 GMT
+      - Wed, 02 Jan 2019 14:02:00 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -862,7 +862,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Sat, 01 Dec 2018 08:03:19 GMT
+      - Wed, 02 Jan 2019 14:02:01 GMT
       Server:
       - fife
       Content-Length:
@@ -876,13 +876,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 08:03:20 GMT
+  recorded_at: Wed, 02 Jan 2019 14:02:01 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1g_4Ns23WJXi2Y9RyBtlFJykxLGTVy4i9D_6l79euhlw/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1OKt17Rx1TlN1f906QBerWbvc96qQl1cUwtY2hs1xkDA/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"My Google Drive File","parents":["1wESZ6QX6_m8TvPWFLGJNtybJa-13YL6o"]}'
+      string: '{"name":"My Google Drive File","parents":["1C_ALJHWThIlUMi798dgZURbcCgWcmoYF"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -891,7 +891,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 08:03:20 GMT
+      - Wed, 02 Jan 2019 14:02:01 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -908,7 +908,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 01 Dec 2018 08:03:21 GMT
+      - Wed, 02 Jan 2019 14:02:03 GMT
       Vary:
       - Origin
       - X-Origin
@@ -932,12 +932,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1FnB13qL9wH2Nvnca0pppesP3Ih4JMTdzIhiHe6ZgwY4",
+         "id": "1D-uzOGD9rwAc5y6nXrEj0DRtH6ITkwhUcnfU-GoPks4",
          "name": "My Google Drive File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1wESZ6QX6_m8TvPWFLGJNtybJa-13YL6o"
+          "1C_ALJHWThIlUMi798dgZURbcCgWcmoYF"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -962,10 +962,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 08:03:21 GMT
+  recorded_at: Wed, 02 Jan 2019 14:02:03 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1FnB13qL9wH2Nvnca0pppesP3Ih4JMTdzIhiHe6ZgwY4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1D-uzOGD9rwAc5y6nXrEj0DRtH6ITkwhUcnfU-GoPks4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -977,7 +977,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 08:03:21 GMT
+      - Wed, 02 Jan 2019 14:02:03 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -988,9 +988,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 01 Dec 2018 08:03:22 GMT
+      - Wed, 02 Jan 2019 14:02:03 GMT
       Date:
-      - Sat, 01 Dec 2018 08:03:22 GMT
+      - Wed, 02 Jan 2019 14:02:03 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1016,12 +1016,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1FnB13qL9wH2Nvnca0pppesP3Ih4JMTdzIhiHe6ZgwY4",
+         "id": "1D-uzOGD9rwAc5y6nXrEj0DRtH6ITkwhUcnfU-GoPks4",
          "name": "My Google Drive File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1wESZ6QX6_m8TvPWFLGJNtybJa-13YL6o"
+          "1C_ALJHWThIlUMi798dgZURbcCgWcmoYF"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1046,10 +1046,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 08:03:22 GMT
+  recorded_at: Wed, 02 Jan 2019 14:02:03 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1FnB13qL9wH2Nvnca0pppesP3Ih4JMTdzIhiHe6ZgwY4/export?alt=media&mimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document
+    uri: https://www.googleapis.com/drive/v3/files/1D-uzOGD9rwAc5y6nXrEj0DRtH6ITkwhUcnfU-GoPks4/export?alt=media&mimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document
     body:
       encoding: UTF-8
       string: ''
@@ -1061,7 +1061,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 08:03:22 GMT
+      - Wed, 02 Jan 2019 14:02:03 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
   response:
@@ -1070,9 +1070,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 01 Dec 2018 08:03:22 GMT
+      - Wed, 02 Jan 2019 14:02:04 GMT
       Date:
-      - Sat, 01 Dec 2018 08:03:22 GMT
+      - Wed, 02 Jan 2019 14:02:04 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Disposition:
@@ -1089,7 +1089,7 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       Content-Length:
-      - '6092'
+      - '6061'
       Server:
       - GSE
       Alt-Svc:
@@ -1097,16 +1097,16 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        UEsDBBQACAgIAGsAgU0AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICABrAIFNAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAawCBTQAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAawCBTQAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkOotKpadZs0ddPaXcDBMcSqY1u2A2VXPzufkIQpDZXo4Af42Od9ncfHsa9uXhM62mCpCGcLZ3zpOSPMEI8IWy+c388PFzNnpDSwCChneOHssHJurj9dbedK7yhWI5PP1DxBCyfWWsxdV6EYJ6AuucDMdK64TECbply7CciXVFwgngjQZEko0TvX97ypU8jwhZNKNi8kLhKCJFd8pW3KnK9WBOHip8yQfXzzlHuO0gQznTm6ElMzB85UTIQq1ZKhaqYzLkU2/3qITULLcVvRxy2SsDWLkdDcaMtlJCRHWCkTvc87K8Wx1wOglagy+kzh0LOcSQKEVTK2NBpClfel8S6gZVL1g9QsFO0zkbzrO1lKkLv2LGAAz/18QXpVcUPBZOlUVgU5RALFIHUpQIcoUI5ecHQHbANVMUfrXuXcUIoIrCUkdZGqN63s2GuUy1MMAtdq69PUvkieirrcwyFqeztwPHmbgF8KXJsXYMTRPV5BSrWyTflTFs2ilf08cKbVaDsHhQhZOLeSgLHfzpHaa2BQ+lYR2AvFt0xV410rpf6Y8AbMRvH9MnKnmjEKbF3GMLMxt5iM25yiaLYyTQGIZBKU2E3tf546ReNXSk0AUs1zK2QeDb/qFOhTlZT5jgtbUdjuG7ktbtk5YlL1Thh5AdLWn4ita9b1LVo4j7ZeMy5RnmlNbDKDBJe2LB+Ue2epbXkNS4oPpJ9tpJd+NnL02MOl+yG+YrDHals4zjtG45zrEhSOfrCytzY0WYZ3V7xYvBeMxePekELQhr+bBVSNeL3WsNLYnKRj37MzXmLzfjCPEXpe99q7lWNR5nVthl67NvPYXh0OweYfxeZ/MGzBtC+2ZansNbd40LHF89iJGIOjGINzY5wdUvSHUkScclnVXmC/rTforOMNOnsHvOFRvOHHwuvP+uI9wDnNPi2cYQfO8B1wTo7inHwwnOF74jx6vp+Ic3oU5/R/xUkawmfB+0y0uVW07gtZ9Mxcpwdc336eTzpgTU6C9ZQudSevquPMyAJ/ELN3vOpXRd11onUXddBx7wqO3LvKf+r6L1BLBwidKXMALAMAAP8RAABQSwMEFAAICAgAawCBTQAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWV227bMAyGn2DvEPg+sR2kW2HU6cWCDQO2IWi6B2Ak2RaqEyg5afb0k+JTDkXhZrkhSIoff8mM9PD4KsVkx9ByrfIonSXRhCmiKVdlHv15/ja9jybWgaIgtGJ5dGA2elx+ethnVJNaMuUmnqBsJkkeVc6ZLI4tqZgEO9OGKZ8sNEpw3sUyloAvtZkSLQ04vuWCu0M8T5LPUYvReVSjylrEVHKC2urChZJMFwUnrDVdBY7p25SsWsnHjjEy4TVoZStubEeTt9J8suogu/c2sZOiW7c3Y7pRhL3/HFI0jfYaqUFNmLU+umqSPTFNRhxgQPQVYySc9+yUSOCqx4ThuAD1vWe+d3toR9SwkeEsrBgjpEn95FsEPFyrgBvO87Te8FFTfEHwVa7GfiBvQZAK0HUAcQtBaPLC6FdQO+iHmZajxvmCRDmUCHIYUvuhL5smF+OyqcCwgVb+H+076toM4764hXbyD0zvPgaYd4ClvwK3mh6CNZN95m9Q+pRHSfuL2tCKievg+jr0tGIF1MK9kVnjWTBdZAYQftCT6FHEGoMhWjn26moQGwPEH5jH7CCIiOKQxzV6G/fr8T2hb2zoXE5LPBonzlrFbSbYpmFYZRlxzXpTbv76gsq/Onf3iyPf30XpfL5olZryFwR1W+2c9oOcLppVTpvBEaxwg4e8rE7cigFlQW5wCq1dcL7Me/7vWj4fDPNJ/8RhKGyFdyrj7hvHw3u3/AdQSwcIvnBuHiYCAAA0BwAAUEsDBBQACAgIAGsAgU0AAAAAAAAAAAAAAAAcAAAAd29yZC9fcmVscy9kb2N1bWVudC54bWwucmVsc62STWrDMBCFT9A7iNnXstMfSomcTQhkW9wDKPL4h1ojIU1KffuKlCQOBNOFl++JefPNjNabHzuIbwyxd6SgyHIQSMbVPbUKPqvd4xuIyJpqPThCBSNG2JQP6w8cNKea2PU+ihRCUUHH7N+ljKZDq2PmPFJ6aVywmpMMrfTafOkW5SrPX2WYZkB5kyn2tYKwrwsQ1ejxP9muaXqDW2eOFonvtJCcajEF6tAiKzjJP7PIUhjI+wyrJRkiMqflxivG2ZlDeFoSoXHElT4Mk1VcrDmI5yUh6GgPGNLcV4iLNQfxsugxeBxweoqTPreXN5+8/AVQSwcIkACr6/EAAAAsAwAAUEsDBBQACAgIAGsAgU0AAAAAAAAAAAAAAAALAAAAX3JlbHMvLnJlbHONzzsOwjAMBuATcIfIO03LgBBq0gUhdUXlAFHiphHNQ0l49PZkYADEwGj792e57R52JjeMyXjHoKlqIOikV8ZpBufhuN4BSVk4JWbvkMGCCTq+ak84i1x20mRCIgVxicGUc9hTmuSEVqTKB3RlMvpoRS5l1DQIeREa6aautzS+G8A/TNIrBrFXDZBhCfiP7cfRSDx4ebXo8o8TX4kii6gxM7j7qKh6tavCAuUt/XiRPwFQSwcILWjPIrEAAAAqAQAAUEsDBBQACAgIAGsAgU0AAAAAAAAAAAAAAAAVAAAAd29yZC90aGVtZS90aGVtZTEueG1s7VlLb9s2HL8P2HcgdG9l2VbqBHWK2LHbrU0bJG6HHmmJlthQokDSSXwb2uOAAcO6YYcV2G2HYVuBFtil+zTZOmwd0K+wvx6WKZvOo023Dq0PNkn9/u8HSfnylcOIoX0iJOVx23Iu1ixEYo/7NA7a1u1B/0LLQlLh2MeMx6RtTYi0rqx/+MFlvKZCEhEE9LFcw20rVCpZs23pwTKWF3lCYng24iLCCqYisH2BD4BvxOx6rbZiR5jGFopxBGxvjUbUI2iQsrTWp8x7DL5iJdMFj4ldL5OoU2RYf89Jf+REdplA+5i1LZDj84MBOVQWYlgqeNC2atnHstcv2yURU0toNbp+9inoCgJ/r57RiWBYEjr95uqlzZJ/Pee/iOv1et2eU/LLANjzwFJnAdvst5zOlKcGyoeLvLs1t9as4jX+jQX8aqfTcVcr+MYM31zAt2orzY16Bd+c4d1F/Tsb3e5KBe/O8CsL+P6l1ZVmFZ+BQkbjvQV0Gs8yMiVkxNk1I7wF8NY0AWYoW8uunD5Wy3Itwve46AMgCy5WNEZqkpAR9gDXxYwOBU0F4DWCtSf5kicXllJZSHqCJqptfZxgqIgZ5OWzH18+e4KO7j89uv/L0YMHR/d/NlBdw3GgU734/ou/H32K/nry3YuHX5nxUsf//tNnv/36pRmodODzrx//8fTx828+//OHhwb4hsBDHT6gEZHoJjlAOzwCwwwCyFCcjWIQYqpTbMSBxDFOaQzongor6JsTzLAB1yFVD94R0AJMwKvjexWFd0MxVtQAvB5GFeAW56zDhdGm66ks3QvjODALF2Mdt4Pxvkl2dy6+vXECuUxNLLshqai5zSDkOCAxUSh9xvcIMZDdpbTi1y3qCS75SKG7FHUwNbpkQIfKTHSNRhCXiUlBiHfFN1t3UIczE/tNsl9FQlVgZmJJWMWNV/FY4cioMY6YjryBVWhScncivIrDpYJIB4Rx1POJlCaaW2JSUfc6tA5z2LfYJKoihaJ7JuQNzLmO3OR73RBHiVFnGoc69iO5BymK0TZXRiV4tULSOcQBx0vDfYcSdbbavk2D0Jwg6ZOxMJUE4dV6nLARJnHR4Su9OqLxcY07gr6Nz7txQ6t8/u2j/1HL3gAnmGpmvlEvw8235y4XPn37u/MmHsfbBArifXN+35zfxea8rJ7PvyXPurCtH7QzNtHSU/eIMrarJozckFn/lmCe34fFbJIRlYf8JIRhIa6CCwTOxkhw9QlV4W6IExDjZBICWbAOJEq4hKuFtZR3dj+lYHO25k4vlYDGaov7+XJDv2yWbLJZIHVBjZTBaYU1Lr2eMCcHnlKa45qlucdKszVvQt0gnL5KcFbquWhIFMyIn/o9ZzANyxsMkVPTYhRinxiWNfucxhvxpnsmJc7HybUFJ9uL1cTi6gwdtK1Vt+5ayMNJ2xrBaQmGUQL8ZNppMAvituWp3MCTa3HO4lVzVjk1d5nBFRGJkGoTyzCnyh5NX6XEM/3rbjP1w/kYYGgmp9Oi0XL+Qy3s+dCS0Yh4asnKbFo842NFxG7oH6AhG4sdDHo38+zyqYROX59OBOR2s0i8auEWtTH/yqaoGcySEBfZ3tJin8OzcalDNtPUs5fo/oqmNM7RFPfdNSXNXDifNvzs0gS7uMAozdG2xYUKOXShJKReX8C+n8kCvRCURaoSYukL6FRXsj/rWzmPvMkFodqhARIUOp0KBSHbqrDzBGZOXd8ep4yKPlOqK5P8d0j2CRuk1buS2m+hcNpNCkdkuPmg2abqGgb9t/jg0nyljWcmqHmWza+pNX1tK1h9PRVOswFr4upmi+vu0p1nfqtN4JaB0i9o3FR4bHY8HfAdiD4q93kEiXihVZRfuTgEnVuacSmrf+sU1FoS7/M8O2rObixx9vHiXt3ZrsHX7vGuthdL1NbuIdls4Y8oPrwHsjfhejNm+YpMYJYPtkVm8JD7k2LIZN4SckdMWzqLd8gIUf9wGtY5jxb/9JSb+U4uILW9JGycTFjgZ5tISVw/mbikmN7xSuLsFmdiwGaSc3we5bJFlp5i8eu47BTKm11mzN7TuuwUgXoFl6nD411WeMo2JR45VAJ3p39dQf7as5Rd/wdQSwcIIVqihCwGAADbHQAAUEsDBBQACAgIAGsAgU0AAAAAAAAAAAAAAAATAAAAW0NvbnRlbnRfVHlwZXNdLnhtbLWTTW7CMBCFT9A7RN5WxNBFVVUEFv1Ztl3QAwzOBKz6T56Bwu07CZAFAqmVmo1l+82893kkT+c774otZrIxVGpSjlWBwcTahlWlPhevowdVEEOowcWAldojqfnsZrrYJ6RCmgNVas2cHrUms0YPVMaEQZQmZg8sx7zSCcwXrFDfjcf32sTAGHjErYeaTZ+xgY3j4ulw31pXClJy1gALlxYzVbzsRDxgtmf9i75tqM9gRkeQMqPramhtE92eB4hKbcK7TCbbGv8UEZvGGqyj2XhpKb9jrlOOBolkqN6VhMyyO6Z+QOY38GKr20p9UsvjI4dB4L3DawCdNmh8I14LWDq8TNDLg0KEjV9ilv1liF4eFKJXPNhwGaQv+UcOlo96ZfiddFgnp0jd/fbZD1BLBwgzrw+3LAEAAC0EAABQSwECFAAUAAgICABrAIFNSRNDf2gBAAA9BQAAEgAAAAAAAAAAAAAAAAAAAAAAd29yZC9udW1iZXJpbmcueG1sUEsBAhQAFAAICAgAawCBTY/2kL8FAgAA6gYAABEAAAAAAAAAAAAAAAAAqAEAAHdvcmQvc2V0dGluZ3MueG1sUEsBAhQAFAAICAgAawCBTa2HbQB5AQAAWgUAABIAAAAAAAAAAAAAAAAA7AMAAHdvcmQvZm9udFRhYmxlLnhtbFBLAQIUABQACAgIAGsAgU2dKXMALAMAAP8RAAAPAAAAAAAAAAAAAAAAAKUFAAB3b3JkL3N0eWxlcy54bWxQSwECFAAUAAgICABrAIFNvnBuHiYCAAA0BwAAEQAAAAAAAAAAAAAAAAAOCQAAd29yZC9kb2N1bWVudC54bWxQSwECFAAUAAgICABrAIFNkACr6/EAAAAsAwAAHAAAAAAAAAAAAAAAAABzCwAAd29yZC9fcmVscy9kb2N1bWVudC54bWwucmVsc1BLAQIUABQACAgIAGsAgU0taM8isQAAACoBAAALAAAAAAAAAAAAAAAAAK4MAABfcmVscy8ucmVsc1BLAQIUABQACAgIAGsAgU0hWqKELAYAANsdAAAVAAAAAAAAAAAAAAAAAJgNAAB3b3JkL3RoZW1lL3RoZW1lMS54bWxQSwECFAAUAAgICABrAIFNM68PtywBAAAtBAAAEwAAAAAAAAAAAAAAAAAHFAAAW0NvbnRlbnRfVHlwZXNdLnhtbFBLBQYAAAAACQAJAEICAAB0FQAAAAA=
+        UEsDBBQACAgIAEIwIk4AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICABCMCJOAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAQjAiTgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAQjAiTgAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgAQjAiTgAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgAQjAiTgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgAQjAiTgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgAQjAiTgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgAQjAiTgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIAEIwIk5JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICABCMCJOj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICABCMCJOrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAQjAiTojORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAEIwIk4B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIAEIwIk6QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgAQjAiTi1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgAQjAiTiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIAEIwIk4zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 08:03:22 GMT
+  recorded_at: Wed, 02 Jan 2019 14:02:04 GMT
 - request:
     method: put
     uri: http://localhost:9998/tika
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        UEsDBBQACAgIAGsAgU0AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICABrAIFNAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAawCBTQAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAawCBTQAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkOotKpadZs0ddPaXcDBMcSqY1u2A2VXPzufkIQpDZXo4Af42Od9ncfHsa9uXhM62mCpCGcLZ3zpOSPMEI8IWy+c388PFzNnpDSwCChneOHssHJurj9dbedK7yhWI5PP1DxBCyfWWsxdV6EYJ6AuucDMdK64TECbply7CciXVFwgngjQZEko0TvX97ypU8jwhZNKNi8kLhKCJFd8pW3KnK9WBOHip8yQfXzzlHuO0gQznTm6ElMzB85UTIQq1ZKhaqYzLkU2/3qITULLcVvRxy2SsDWLkdDcaMtlJCRHWCkTvc87K8Wx1wOglagy+kzh0LOcSQKEVTK2NBpClfel8S6gZVL1g9QsFO0zkbzrO1lKkLv2LGAAz/18QXpVcUPBZOlUVgU5RALFIHUpQIcoUI5ecHQHbANVMUfrXuXcUIoIrCUkdZGqN63s2GuUy1MMAtdq69PUvkieirrcwyFqeztwPHmbgF8KXJsXYMTRPV5BSrWyTflTFs2ilf08cKbVaDsHhQhZOLeSgLHfzpHaa2BQ+lYR2AvFt0xV410rpf6Y8AbMRvH9MnKnmjEKbF3GMLMxt5iM25yiaLYyTQGIZBKU2E3tf546ReNXSk0AUs1zK2QeDb/qFOhTlZT5jgtbUdjuG7ktbtk5YlL1Thh5AdLWn4ita9b1LVo4j7ZeMy5RnmlNbDKDBJe2LB+Ue2epbXkNS4oPpJ9tpJd+NnL02MOl+yG+YrDHals4zjtG45zrEhSOfrCytzY0WYZ3V7xYvBeMxePekELQhr+bBVSNeL3WsNLYnKRj37MzXmLzfjCPEXpe99q7lWNR5nVthl67NvPYXh0OweYfxeZ/MGzBtC+2ZansNbd40LHF89iJGIOjGINzY5wdUvSHUkScclnVXmC/rTforOMNOnsHvOFRvOHHwuvP+uI9wDnNPi2cYQfO8B1wTo7inHwwnOF74jx6vp+Ic3oU5/R/xUkawmfB+0y0uVW07gtZ9Mxcpwdc336eTzpgTU6C9ZQudSevquPMyAJ/ELN3vOpXRd11onUXddBx7wqO3LvKf+r6L1BLBwidKXMALAMAAP8RAABQSwMEFAAICAgAawCBTQAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWV227bMAyGn2DvEPg+sR2kW2HU6cWCDQO2IWi6B2Ak2RaqEyg5afb0k+JTDkXhZrkhSIoff8mM9PD4KsVkx9ByrfIonSXRhCmiKVdlHv15/ja9jybWgaIgtGJ5dGA2elx+ethnVJNaMuUmnqBsJkkeVc6ZLI4tqZgEO9OGKZ8sNEpw3sUyloAvtZkSLQ04vuWCu0M8T5LPUYvReVSjylrEVHKC2urChZJMFwUnrDVdBY7p25SsWsnHjjEy4TVoZStubEeTt9J8suogu/c2sZOiW7c3Y7pRhL3/HFI0jfYaqUFNmLU+umqSPTFNRhxgQPQVYySc9+yUSOCqx4ThuAD1vWe+d3toR9SwkeEsrBgjpEn95FsEPFyrgBvO87Te8FFTfEHwVa7GfiBvQZAK0HUAcQtBaPLC6FdQO+iHmZajxvmCRDmUCHIYUvuhL5smF+OyqcCwgVb+H+076toM4764hXbyD0zvPgaYd4ClvwK3mh6CNZN95m9Q+pRHSfuL2tCKievg+jr0tGIF1MK9kVnjWTBdZAYQftCT6FHEGoMhWjn26moQGwPEH5jH7CCIiOKQxzV6G/fr8T2hb2zoXE5LPBonzlrFbSbYpmFYZRlxzXpTbv76gsq/Onf3iyPf30XpfL5olZryFwR1W+2c9oOcLppVTpvBEaxwg4e8rE7cigFlQW5wCq1dcL7Me/7vWj4fDPNJ/8RhKGyFdyrj7hvHw3u3/AdQSwcIvnBuHiYCAAA0BwAAUEsDBBQACAgIAGsAgU0AAAAAAAAAAAAAAAAcAAAAd29yZC9fcmVscy9kb2N1bWVudC54bWwucmVsc62STWrDMBCFT9A7iNnXstMfSomcTQhkW9wDKPL4h1ojIU1KffuKlCQOBNOFl++JefPNjNabHzuIbwyxd6SgyHIQSMbVPbUKPqvd4xuIyJpqPThCBSNG2JQP6w8cNKea2PU+ihRCUUHH7N+ljKZDq2PmPFJ6aVywmpMMrfTafOkW5SrPX2WYZkB5kyn2tYKwrwsQ1ejxP9muaXqDW2eOFonvtJCcajEF6tAiKzjJP7PIUhjI+wyrJRkiMqflxivG2ZlDeFoSoXHElT4Mk1VcrDmI5yUh6GgPGNLcV4iLNQfxsugxeBxweoqTPreXN5+8/AVQSwcIkACr6/EAAAAsAwAAUEsDBBQACAgIAGsAgU0AAAAAAAAAAAAAAAALAAAAX3JlbHMvLnJlbHONzzsOwjAMBuATcIfIO03LgBBq0gUhdUXlAFHiphHNQ0l49PZkYADEwGj792e57R52JjeMyXjHoKlqIOikV8ZpBufhuN4BSVk4JWbvkMGCCTq+ak84i1x20mRCIgVxicGUc9hTmuSEVqTKB3RlMvpoRS5l1DQIeREa6aautzS+G8A/TNIrBrFXDZBhCfiP7cfRSDx4ebXo8o8TX4kii6gxM7j7qKh6tavCAuUt/XiRPwFQSwcILWjPIrEAAAAqAQAAUEsDBBQACAgIAGsAgU0AAAAAAAAAAAAAAAAVAAAAd29yZC90aGVtZS90aGVtZTEueG1s7VlLb9s2HL8P2HcgdG9l2VbqBHWK2LHbrU0bJG6HHmmJlthQokDSSXwb2uOAAcO6YYcV2G2HYVuBFtil+zTZOmwd0K+wvx6WKZvOo023Dq0PNkn9/u8HSfnylcOIoX0iJOVx23Iu1ixEYo/7NA7a1u1B/0LLQlLh2MeMx6RtTYi0rqx/+MFlvKZCEhEE9LFcw20rVCpZs23pwTKWF3lCYng24iLCCqYisH2BD4BvxOx6rbZiR5jGFopxBGxvjUbUI2iQsrTWp8x7DL5iJdMFj4ldL5OoU2RYf89Jf+REdplA+5i1LZDj84MBOVQWYlgqeNC2atnHstcv2yURU0toNbp+9inoCgJ/r57RiWBYEjr95uqlzZJ/Pee/iOv1et2eU/LLANjzwFJnAdvst5zOlKcGyoeLvLs1t9as4jX+jQX8aqfTcVcr+MYM31zAt2orzY16Bd+c4d1F/Tsb3e5KBe/O8CsL+P6l1ZVmFZ+BQkbjvQV0Gs8yMiVkxNk1I7wF8NY0AWYoW8uunD5Wy3Itwve46AMgCy5WNEZqkpAR9gDXxYwOBU0F4DWCtSf5kicXllJZSHqCJqptfZxgqIgZ5OWzH18+e4KO7j89uv/L0YMHR/d/NlBdw3GgU734/ou/H32K/nry3YuHX5nxUsf//tNnv/36pRmodODzrx//8fTx828+//OHhwb4hsBDHT6gEZHoJjlAOzwCwwwCyFCcjWIQYqpTbMSBxDFOaQzongor6JsTzLAB1yFVD94R0AJMwKvjexWFd0MxVtQAvB5GFeAW56zDhdGm66ks3QvjODALF2Mdt4Pxvkl2dy6+vXECuUxNLLshqai5zSDkOCAxUSh9xvcIMZDdpbTi1y3qCS75SKG7FHUwNbpkQIfKTHSNRhCXiUlBiHfFN1t3UIczE/tNsl9FQlVgZmJJWMWNV/FY4cioMY6YjryBVWhScncivIrDpYJIB4Rx1POJlCaaW2JSUfc6tA5z2LfYJKoihaJ7JuQNzLmO3OR73RBHiVFnGoc69iO5BymK0TZXRiV4tULSOcQBx0vDfYcSdbbavk2D0Jwg6ZOxMJUE4dV6nLARJnHR4Su9OqLxcY07gr6Nz7txQ6t8/u2j/1HL3gAnmGpmvlEvw8235y4XPn37u/MmHsfbBArifXN+35zfxea8rJ7PvyXPurCtH7QzNtHSU/eIMrarJozckFn/lmCe34fFbJIRlYf8JIRhIa6CCwTOxkhw9QlV4W6IExDjZBICWbAOJEq4hKuFtZR3dj+lYHO25k4vlYDGaov7+XJDv2yWbLJZIHVBjZTBaYU1Lr2eMCcHnlKa45qlucdKszVvQt0gnL5KcFbquWhIFMyIn/o9ZzANyxsMkVPTYhRinxiWNfucxhvxpnsmJc7HybUFJ9uL1cTi6gwdtK1Vt+5ayMNJ2xrBaQmGUQL8ZNppMAvituWp3MCTa3HO4lVzVjk1d5nBFRGJkGoTyzCnyh5NX6XEM/3rbjP1w/kYYGgmp9Oi0XL+Qy3s+dCS0Yh4asnKbFo842NFxG7oH6AhG4sdDHo38+zyqYROX59OBOR2s0i8auEWtTH/yqaoGcySEBfZ3tJin8OzcalDNtPUs5fo/oqmNM7RFPfdNSXNXDifNvzs0gS7uMAozdG2xYUKOXShJKReX8C+n8kCvRCURaoSYukL6FRXsj/rWzmPvMkFodqhARIUOp0KBSHbqrDzBGZOXd8ep4yKPlOqK5P8d0j2CRuk1buS2m+hcNpNCkdkuPmg2abqGgb9t/jg0nyljWcmqHmWza+pNX1tK1h9PRVOswFr4upmi+vu0p1nfqtN4JaB0i9o3FR4bHY8HfAdiD4q93kEiXihVZRfuTgEnVuacSmrf+sU1FoS7/M8O2rObixx9vHiXt3ZrsHX7vGuthdL1NbuIdls4Y8oPrwHsjfhejNm+YpMYJYPtkVm8JD7k2LIZN4SckdMWzqLd8gIUf9wGtY5jxb/9JSb+U4uILW9JGycTFjgZ5tISVw/mbikmN7xSuLsFmdiwGaSc3we5bJFlp5i8eu47BTKm11mzN7TuuwUgXoFl6nD411WeMo2JR45VAJ3p39dQf7as5Rd/wdQSwcIIVqihCwGAADbHQAAUEsDBBQACAgIAGsAgU0AAAAAAAAAAAAAAAATAAAAW0NvbnRlbnRfVHlwZXNdLnhtbLWTTW7CMBCFT9A7RN5WxNBFVVUEFv1Ztl3QAwzOBKz6T56Bwu07CZAFAqmVmo1l+82893kkT+c774otZrIxVGpSjlWBwcTahlWlPhevowdVEEOowcWAldojqfnsZrrYJ6RCmgNVas2cHrUms0YPVMaEQZQmZg8sx7zSCcwXrFDfjcf32sTAGHjErYeaTZ+xgY3j4ulw31pXClJy1gALlxYzVbzsRDxgtmf9i75tqM9gRkeQMqPramhtE92eB4hKbcK7TCbbGv8UEZvGGqyj2XhpKb9jrlOOBolkqN6VhMyyO6Z+QOY38GKr20p9UsvjI4dB4L3DawCdNmh8I14LWDq8TNDLg0KEjV9ilv1liF4eFKJXPNhwGaQv+UcOlo96ZfiddFgnp0jd/fbZD1BLBwgzrw+3LAEAAC0EAABQSwECFAAUAAgICABrAIFNSRNDf2gBAAA9BQAAEgAAAAAAAAAAAAAAAAAAAAAAd29yZC9udW1iZXJpbmcueG1sUEsBAhQAFAAICAgAawCBTY/2kL8FAgAA6gYAABEAAAAAAAAAAAAAAAAAqAEAAHdvcmQvc2V0dGluZ3MueG1sUEsBAhQAFAAICAgAawCBTa2HbQB5AQAAWgUAABIAAAAAAAAAAAAAAAAA7AMAAHdvcmQvZm9udFRhYmxlLnhtbFBLAQIUABQACAgIAGsAgU2dKXMALAMAAP8RAAAPAAAAAAAAAAAAAAAAAKUFAAB3b3JkL3N0eWxlcy54bWxQSwECFAAUAAgICABrAIFNvnBuHiYCAAA0BwAAEQAAAAAAAAAAAAAAAAAOCQAAd29yZC9kb2N1bWVudC54bWxQSwECFAAUAAgICABrAIFNkACr6/EAAAAsAwAAHAAAAAAAAAAAAAAAAABzCwAAd29yZC9fcmVscy9kb2N1bWVudC54bWwucmVsc1BLAQIUABQACAgIAGsAgU0taM8isQAAACoBAAALAAAAAAAAAAAAAAAAAK4MAABfcmVscy8ucmVsc1BLAQIUABQACAgIAGsAgU0hWqKELAYAANsdAAAVAAAAAAAAAAAAAAAAAJgNAAB3b3JkL3RoZW1lL3RoZW1lMS54bWxQSwECFAAUAAgICABrAIFNM68PtywBAAAtBAAAEwAAAAAAAAAAAAAAAAAHFAAAW0NvbnRlbnRfVHlwZXNdLnhtbFBLBQYAAAAACQAJAEICAAB0FQAAAAA=
+        UEsDBBQACAgIAEIwIk4AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICABCMCJOAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAQjAiTgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAQjAiTgAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgAQjAiTgAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgAQjAiTgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgAQjAiTgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgAQjAiTgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgAQjAiTgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIAEIwIk5JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICABCMCJOj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICABCMCJOrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAQjAiTojORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAEIwIk4B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIAEIwIk6QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgAQjAiTi1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgAQjAiTiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIAEIwIk4zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -1124,7 +1124,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 01 Dec 2018 08:03:22 GMT
+      - Wed, 02 Jan 2019 14:02:04 GMT
       Content-Type:
       - text/html
       Transfer-Encoding:
@@ -1147,10 +1147,10 @@ http_interactions:
         </body>
         </html>
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 08:03:22 GMT
+  recorded_at: Wed, 02 Jan 2019 14:02:04 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1wESZ6QX6_m8TvPWFLGJNtybJa-13YL6o/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1C_ALJHWThIlUMi798dgZURbcCgWcmoYF/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR COLLABORATOR ACCOUNT>","role":"reader","type":"user"}'
@@ -1162,7 +1162,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 08:03:22 GMT
+      - Wed, 02 Jan 2019 14:02:04 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1179,7 +1179,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 01 Dec 2018 08:03:23 GMT
+      - Wed, 02 Jan 2019 14:02:05 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1209,10 +1209,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 08:03:23 GMT
+  recorded_at: Wed, 02 Jan 2019 14:02:05 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1wESZ6QX6_m8TvPWFLGJNtybJa-13YL6o/permissions?fields=permissions/id,%20permissions/emailAddress
+    uri: https://www.googleapis.com/drive/v3/files/1C_ALJHWThIlUMi798dgZURbcCgWcmoYF/permissions?fields=permissions/id,%20permissions/emailAddress,%20permissions/type
     body:
       encoding: UTF-8
       string: ''
@@ -1224,7 +1224,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 08:03:28 GMT
+      - Wed, 02 Jan 2019 14:02:10 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1235,9 +1235,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 01 Dec 2018 08:03:28 GMT
+      - Wed, 02 Jan 2019 14:02:11 GMT
       Date:
-      - Sat, 01 Dec 2018 08:03:28 GMT
+      - Wed, 02 Jan 2019 14:02:11 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1266,23 +1266,26 @@ http_interactions:
          "permissions": [
           {
            "id": "13193959451567607887",
+           "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>"
           },
           {
            "id": "05663488528055015696",
+           "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR COLLABORATOR ACCOUNT>"
           },
           {
            "id": "11673017242486491425",
+           "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>"
           }
          ]
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 08:03:28 GMT
+  recorded_at: Wed, 02 Jan 2019 14:02:11 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1wESZ6QX6_m8TvPWFLGJNtybJa-13YL6o/permissions/05663488528055015696
+    uri: https://www.googleapis.com/drive/v3/files/1C_ALJHWThIlUMi798dgZURbcCgWcmoYF/permissions/05663488528055015696
     body:
       encoding: UTF-8
       string: ''
@@ -1294,7 +1297,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 08:03:28 GMT
+      - Wed, 02 Jan 2019 14:02:11 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1311,7 +1314,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 01 Dec 2018 08:03:29 GMT
+      - Wed, 02 Jan 2019 14:02:12 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1323,10 +1326,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 08:03:29 GMT
+  recorded_at: Wed, 02 Jan 2019 14:02:12 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1FnB13qL9wH2Nvnca0pppesP3Ih4JMTdzIhiHe6ZgwY4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1D-uzOGD9rwAc5y6nXrEj0DRtH6ITkwhUcnfU-GoPks4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1338,7 +1341,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 08:03:34 GMT
+      - Wed, 02 Jan 2019 14:02:17 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR COLLABORATOR ACCOUNT>
       Content-Type:
@@ -1356,9 +1359,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 01 Dec 2018 08:03:34 GMT
+      - Wed, 02 Jan 2019 14:02:25 GMT
       Expires:
-      - Sat, 01 Dec 2018 08:03:34 GMT
+      - Wed, 02 Jan 2019 14:02:25 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1382,20 +1385,20 @@ http_interactions:
            {
             "domain": "global",
             "reason": "notFound",
-            "message": "File not found: 1FnB13qL9wH2Nvnca0pppesP3Ih4JMTdzIhiHe6ZgwY4.",
+            "message": "File not found: 1D-uzOGD9rwAc5y6nXrEj0DRtH6ITkwhUcnfU-GoPks4.",
             "locationType": "parameter",
             "location": "fileId"
            }
           ],
           "code": 404,
-          "message": "File not found: 1FnB13qL9wH2Nvnca0pppesP3Ih4JMTdzIhiHe6ZgwY4."
+          "message": "File not found: 1D-uzOGD9rwAc5y6nXrEj0DRtH6ITkwhUcnfU-GoPks4."
          }
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 08:03:34 GMT
+  recorded_at: Wed, 02 Jan 2019 14:02:25 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1E7SSt7LGxL4fG71xI8b2eoBFuNTaUPpl
+    uri: https://www.googleapis.com/drive/v3/files/122RVS2vkdjhOdYU1I1kz_Ee-6KQuyfzF
     body:
       encoding: UTF-8
       string: ''
@@ -1407,7 +1410,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 08:03:34 GMT
+      - Wed, 02 Jan 2019 14:02:25 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1424,7 +1427,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 01 Dec 2018 08:03:35 GMT
+      - Wed, 02 Jan 2019 14:02:26 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1436,5 +1439,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 08:03:35 GMT
+  recorded_at: Wed, 02 Jan 2019 14:02:26 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_stops_sharing_file.yml
+++ b/spec/support/fixtures/vcr_cassettes/File_Update/In_Google_Drive_user_stops_sharing_file.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Sat, 01 Dec 2018 07:55:02 GMT
+      - Wed, 02 Jan 2019 13:59:36 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 07:55:02 GMT
+  recorded_at: Wed, 02 Jan 2019 13:59:37 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Sat, 01 Dec 2018 07:55:02 GMT
+      - Wed, 02 Jan 2019 13:59:37 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 07:55:02 GMT
+  recorded_at: Wed, 02 Jan 2019 13:59:37 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-12-01
-        07:55:02 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2019-01-02
+        13:59:37 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 07:55:02 GMT
+      - Wed, 02 Jan 2019 13:59:37 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 01 Dec 2018 07:55:02 GMT
+      - Wed, 02 Jan 2019 13:59:38 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1VMlc2G7hBAj1o2ecMsK0XMoNXlQxznEr",
-         "name": "Test @ 2018-12-01 07:55:02 UTC",
+         "id": "1A8DM9eUSFl3a3FolBCUTO-RdMEgaQs6R",
+         "name": "Test @ 2019-01-02 13:59:37 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 07:55:02 GMT
+  recorded_at: Wed, 02 Jan 2019 13:59:38 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1VMlc2G7hBAj1o2ecMsK0XMoNXlQxznEr/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1A8DM9eUSFl3a3FolBCUTO-RdMEgaQs6R/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 07:55:02 GMT
+      - Wed, 02 Jan 2019 13:59:38 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 01 Dec 2018 07:55:03 GMT
+      - Wed, 02 Jan 2019 13:59:39 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,7 +247,7 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 07:55:03 GMT
+  recorded_at: Wed, 02 Jan 2019 13:59:39 GMT
 - request:
     method: get
     uri: https://www.googleapis.com/drive/v3/changes/startPageToken
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 07:55:03 GMT
+      - Wed, 02 Jan 2019 13:59:39 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -273,9 +273,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 01 Dec 2018 07:55:03 GMT
+      - Wed, 02 Jan 2019 13:59:40 GMT
       Date:
-      - Sat, 01 Dec 2018 07:55:03 GMT
+      - Wed, 02 Jan 2019 13:59:40 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -302,16 +302,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#startPageToken",
-         "startPageToken": "21858"
+         "startPageToken": "24259"
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 07:55:03 GMT
+  recorded_at: Wed, 02 Jan 2019 13:59:40 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1VMlc2G7hBAj1o2ecMsK0XMoNXlQxznEr"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File","parents":["1A8DM9eUSFl3a3FolBCUTO-RdMEgaQs6R"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -320,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 07:55:03 GMT
+      - Wed, 02 Jan 2019 13:59:40 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -337,7 +337,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 01 Dec 2018 07:55:04 GMT
+      - Wed, 02 Jan 2019 13:59:41 GMT
       Vary:
       - Origin
       - X-Origin
@@ -361,12 +361,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1Z8v6Ab-SvWdYqpJy-f3seAh1HFFRUU3aZ_N5D3MIfI0",
+         "id": "1TmyMZSXuxqEPrJQFd7BuURezKEHl71MMGlLLA_KzSrA",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1VMlc2G7hBAj1o2ecMsK0XMoNXlQxznEr"
+          "1A8DM9eUSFl3a3FolBCUTO-RdMEgaQs6R"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -391,14 +391,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 07:55:04 GMT
+  recorded_at: Wed, 02 Jan 2019 13:59:41 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"16 Golgafrinchan
-        Ark Fleet Ship B (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"49 Heart of
+        Gold (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -407,7 +407,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 07:55:04 GMT
+      - Wed, 02 Jan 2019 13:59:41 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -424,7 +424,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 01 Dec 2018 07:55:05 GMT
+      - Wed, 02 Jan 2019 13:59:42 GMT
       Vary:
       - Origin
       - X-Origin
@@ -448,8 +448,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1xk-ziZ6PftIftx2A-IDTVy0n4mw3o6fl",
-         "name": "16 Golgafrinchan Ark Fleet Ship B (Archive)",
+         "id": "1TibOzWQ9HfhmXxT-Ap6oDUgrP--NwmOW",
+         "name": "49 Heart of Gold (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -469,10 +469,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 07:55:05 GMT
+  recorded_at: Wed, 02 Jan 2019 13:59:42 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1xk-ziZ6PftIftx2A-IDTVy0n4mw3o6fl/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1TibOzWQ9HfhmXxT-Ap6oDUgrP--NwmOW/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -484,7 +484,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 07:55:05 GMT
+      - Wed, 02 Jan 2019 13:59:42 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -501,7 +501,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 01 Dec 2018 07:55:06 GMT
+      - Wed, 02 Jan 2019 13:59:43 GMT
       Vary:
       - Origin
       - X-Origin
@@ -531,10 +531,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 07:55:06 GMT
+  recorded_at: Wed, 02 Jan 2019 13:59:43 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1VMlc2G7hBAj1o2ecMsK0XMoNXlQxznEr?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1A8DM9eUSFl3a3FolBCUTO-RdMEgaQs6R?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -546,7 +546,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 07:55:06 GMT
+      - Wed, 02 Jan 2019 13:59:43 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -557,9 +557,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 01 Dec 2018 07:55:06 GMT
+      - Wed, 02 Jan 2019 13:59:43 GMT
       Date:
-      - Sat, 01 Dec 2018 07:55:06 GMT
+      - Wed, 02 Jan 2019 13:59:43 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -585,8 +585,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1VMlc2G7hBAj1o2ecMsK0XMoNXlQxznEr",
-         "name": "Test @ 2018-12-01 07:55:02 UTC",
+         "id": "1A8DM9eUSFl3a3FolBCUTO-RdMEgaQs6R",
+         "name": "Test @ 2019-01-02 13:59:37 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -612,10 +612,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 07:55:06 GMT
+  recorded_at: Wed, 02 Jan 2019 13:59:43 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1VMlc2G7hBAj1o2ecMsK0XMoNXlQxznEr/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1A8DM9eUSFl3a3FolBCUTO-RdMEgaQs6R/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -627,7 +627,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 07:55:06 GMT
+      - Wed, 02 Jan 2019 13:59:43 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -645,9 +645,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 01 Dec 2018 07:55:06 GMT
+      - Wed, 02 Jan 2019 13:59:43 GMT
       Expires:
-      - Sat, 01 Dec 2018 07:55:06 GMT
+      - Wed, 02 Jan 2019 13:59:43 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -679,10 +679,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 07:55:06 GMT
+  recorded_at: Wed, 02 Jan 2019 13:59:44 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271VMlc2G7hBAj1o2ecMsK0XMoNXlQxznEr%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271A8DM9eUSFl3a3FolBCUTO-RdMEgaQs6R%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -694,7 +694,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 07:55:06 GMT
+      - Wed, 02 Jan 2019 13:59:44 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -705,9 +705,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 01 Dec 2018 07:55:07 GMT
+      - Wed, 02 Jan 2019 13:59:44 GMT
       Date:
-      - Sat, 01 Dec 2018 07:55:07 GMT
+      - Wed, 02 Jan 2019 13:59:44 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -735,15 +735,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1Z8v6Ab-SvWdYqpJy-f3seAh1HFFRUU3aZ_N5D3MIfI0",
+           "id": "1TmyMZSXuxqEPrJQFd7BuURezKEHl71MMGlLLA_KzSrA",
            "name": "File",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1VMlc2G7hBAj1o2ecMsK0XMoNXlQxznEr"
+            "1A8DM9eUSFl3a3FolBCUTO-RdMEgaQs6R"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Z8v6Ab-SvWdYqpJy-f3seAh1HFFRUU3aZ_N5D3MIfI0&v=1&s=AMedNnoAAAAAXAJae09tA0sgjyFvlZgd_7oMdIcoKe2A&sz=s220",
-           "thumbnailVersion": "1",
+           "thumbnailVersion": "0",
            "permissions": [
             {
              "kind": "drive#permission",
@@ -768,10 +767,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 07:55:07 GMT
+  recorded_at: Wed, 02 Jan 2019 13:59:44 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Z8v6Ab-SvWdYqpJy-f3seAh1HFFRUU3aZ_N5D3MIfI0/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1TmyMZSXuxqEPrJQFd7BuURezKEHl71MMGlLLA_KzSrA/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -783,7 +782,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 07:55:07 GMT
+      - Wed, 02 Jan 2019 13:59:44 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -794,9 +793,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 01 Dec 2018 07:55:07 GMT
+      - Wed, 02 Jan 2019 13:59:44 GMT
       Date:
-      - Sat, 01 Dec 2018 07:55:07 GMT
+      - Wed, 02 Jan 2019 13:59:44 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -825,76 +824,16 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-12-01T07:55:03.890Z"
+         "modifiedTime": "2019-01-02T13:59:40.945Z"
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 07:55:07 GMT
-- request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1Z8v6Ab-SvWdYqpJy-f3seAh1HFFRUU3aZ_N5D3MIfI0&s=AMedNnoAAAAAXAJae09tA0sgjyFvlZgd_7oMdIcoKe2A&sz=s350&v=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 01 Dec 2018 07:55:07 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Expose-Headers:
-      - Content-Length
-      Etag:
-      - '"v1"'
-      Expires:
-      - Fri, 01 Jan 1990 00:00:00 GMT
-      Cache-Control:
-      - private, max-age=86400, no-transform
-      Content-Disposition:
-      - inline;filename="unnamed.png"
-      Content-Type:
-      - image/png
-      Vary:
-      - Origin
-      Access-Control-Allow-Origin:
-      - "*"
-      Timing-Allow-Origin:
-      - "*"
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Sat, 01 Dec 2018 07:55:07 GMT
-      Server:
-      - fife
-      Content-Length:
-      - '1022'
-      X-Xss-Protection:
-      - 1; mode=block
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
-    http_version: 
-  recorded_at: Sat, 01 Dec 2018 07:55:07 GMT
+  recorded_at: Wed, 02 Jan 2019 13:59:44 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1Z8v6Ab-SvWdYqpJy-f3seAh1HFFRUU3aZ_N5D3MIfI0/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1TmyMZSXuxqEPrJQFd7BuURezKEHl71MMGlLLA_KzSrA/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"File","parents":["1xk-ziZ6PftIftx2A-IDTVy0n4mw3o6fl"]}'
+      string: '{"name":"File","parents":["1TibOzWQ9HfhmXxT-Ap6oDUgrP--NwmOW"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -903,7 +842,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 07:55:07 GMT
+      - Wed, 02 Jan 2019 13:59:44 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -920,7 +859,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 01 Dec 2018 07:55:09 GMT
+      - Wed, 02 Jan 2019 13:59:46 GMT
       Vary:
       - Origin
       - X-Origin
@@ -944,12 +883,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1WsQ_POsJeLb0-PfnDAk-hN6y8jLMC5smqknyK8s1y0o",
+         "id": "1VeUtfVEh6DI0do2O7H6YFm35VwxLsNt62U4c2vAvEoE",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1xk-ziZ6PftIftx2A-IDTVy0n4mw3o6fl"
+          "1TibOzWQ9HfhmXxT-Ap6oDUgrP--NwmOW"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -974,10 +913,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 07:55:09 GMT
+  recorded_at: Wed, 02 Jan 2019 13:59:47 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1WsQ_POsJeLb0-PfnDAk-hN6y8jLMC5smqknyK8s1y0o?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1VeUtfVEh6DI0do2O7H6YFm35VwxLsNt62U4c2vAvEoE?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -989,7 +928,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 07:55:09 GMT
+      - Wed, 02 Jan 2019 13:59:47 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1000,9 +939,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 01 Dec 2018 07:55:09 GMT
+      - Wed, 02 Jan 2019 13:59:47 GMT
       Date:
-      - Sat, 01 Dec 2018 07:55:09 GMT
+      - Wed, 02 Jan 2019 13:59:47 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1028,12 +967,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1WsQ_POsJeLb0-PfnDAk-hN6y8jLMC5smqknyK8s1y0o",
+         "id": "1VeUtfVEh6DI0do2O7H6YFm35VwxLsNt62U4c2vAvEoE",
          "name": "File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1xk-ziZ6PftIftx2A-IDTVy0n4mw3o6fl"
+          "1TibOzWQ9HfhmXxT-Ap6oDUgrP--NwmOW"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1058,10 +997,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 07:55:09 GMT
+  recorded_at: Wed, 02 Jan 2019 13:59:47 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1WsQ_POsJeLb0-PfnDAk-hN6y8jLMC5smqknyK8s1y0o/export?alt=media&mimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document
+    uri: https://www.googleapis.com/drive/v3/files/1VeUtfVEh6DI0do2O7H6YFm35VwxLsNt62U4c2vAvEoE/export?alt=media&mimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document
     body:
       encoding: UTF-8
       string: ''
@@ -1073,7 +1012,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 07:55:09 GMT
+      - Wed, 02 Jan 2019 13:59:47 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
   response:
@@ -1082,9 +1021,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 01 Dec 2018 07:55:10 GMT
+      - Wed, 02 Jan 2019 13:59:48 GMT
       Date:
-      - Sat, 01 Dec 2018 07:55:10 GMT
+      - Wed, 02 Jan 2019 13:59:48 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Disposition:
@@ -1101,7 +1040,7 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       Content-Length:
-      - '6092'
+      - '6061'
       Server:
       - GSE
       Alt-Svc:
@@ -1109,16 +1048,16 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        UEsDBBQACAgIAOW+fk0AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICADlvn5NAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgA5b5+TQAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgA5b5+TQAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkOotKpadZs0ddPaXcDBMcSqY1u2A2VXPzufkIQpDZXo4Af42Od9ncfHsa9uXhM62mCpCGcLZ3zpOSPMEI8IWy+c388PFzNnpDSwCChneOHssHJurj9dbedK7yhWI5PP1DxBCyfWWsxdV6EYJ6AuucDMdK64TECbply7CciXVFwgngjQZEko0TvX97ypU8jwhZNKNi8kLhKCJFd8pW3KnK9WBOHip8yQfXzzlHuO0gQznTm6ElMzB85UTIQq1ZKhaqYzLkU2/3qITULLcVvRxy2SsDWLkdDcaMtlJCRHWCkTvc87K8Wx1wOglagy+kzh0LOcSQKEVTK2NBpClfel8S6gZVL1g9QsFO0zkbzrO1lKkLv2LGAAz/18QXpVcUPBZOlUVgU5RALFIHUpQIcoUI5ecHQHbANVMUfrXuXcUIoIrCUkdZGqN63s2GuUy1MMAtdq69PUvkieirrcwyFqeztwPHmbgF8KXJsXYMTRPV5BSrWyTflTFs2ilf08cKbVaDsHhQhZOLeSgLHfzpHaa2BQ+lYR2AvFt0xV410rpf6Y8AbMRvH9MnKnmjEKbF3GMLMxt5iM25yiaLYyTQGIZBKU2E3tf546ReNXSk0AUs1zK2QeDb/qFOhTlZT5jgtbUdjuG7ktbtk5YlL1Thh5AdLWn4ita9b1LVo4j7ZeMy5RnmlNbDKDBJe2LB+Ue2epbXkNS4oPpJ9tpJd+NnL02MOl+yG+YrDHals4zjtG45zrEhSOfrCytzY0WYZ3V7xYvBeMxePekELQhr+bBVSNeL3WsNLYnKRj37MzXmLzfjCPEXpe99q7lWNR5nVthl67NvPYXh0OweYfxeZ/MGzBtC+2ZansNbd40LHF89iJGIOjGINzY5wdUvSHUkScclnVXmC/rTforOMNOnsHvOFRvOHHwuvP+uI9wDnNPi2cYQfO8B1wTo7inHwwnOF74jx6vp+Ic3oU5/R/xUkawmfB+0y0uVW07gtZ9Mxcpwdc336eTzpgTU6C9ZQudSevquPMyAJ/ELN3vOpXRd11onUXddBx7wqO3LvKf+r6L1BLBwidKXMALAMAAP8RAABQSwMEFAAICAgA5b5+TQAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWV227bMAyGn2DvEPg+sR2kW2HU6cWCDQO2IWi6B2Ak2RaqEyg5afb0k+JTDkXhZrkhSIoff8mM9PD4KsVkx9ByrfIonSXRhCmiKVdlHv15/ja9jybWgaIgtGJ5dGA2elx+ethnVJNaMuUmnqBsJkkeVc6ZLI4tqZgEO9OGKZ8sNEpw3sUyloAvtZkSLQ04vuWCu0M8T5LPUYvReVSjylrEVHKC2urChZJMFwUnrDVdBY7p25SsWsnHjjEy4TVoZStubEeTt9J8suogu/c2sZOiW7c3Y7pRhL3/HFI0jfYaqUFNmLU+umqSPTFNRhxgQPQVYySc9+yUSOCqx4ThuAD1vWe+d3toR9SwkeEsrBgjpEn95FsEPFyrgBvO87Te8FFTfEHwVa7GfiBvQZAK0HUAcQtBaPLC6FdQO+iHmZajxvmCRDmUCHIYUvuhL5smF+OyqcCwgVb+H+076toM4764hXbyD0zvPgaYd4ClvwK3mh6CNZN95m9Q+pRHSfuL2tCKievg+jr0tGIF1MK9kVnjWTBdZAYQftCT6FHEGoMhWjn26moQGwPEH5jH7CCIiOKQxzV6G/fr8T2hb2zoXE5LPBonzlrFbSbYpmFYZRlxzXpTbv76gsq/Onf3iyPf30XpfL5olZryFwR1W+2c9oOcLppVTpvBEaxwg4e8rE7cigFlQW5wCq1dcL7Me/7vWj4fDPNJ/8RhKGyFdyrj7hvHw3u3/AdQSwcIvnBuHiYCAAA0BwAAUEsDBBQACAgIAOW+fk0AAAAAAAAAAAAAAAAcAAAAd29yZC9fcmVscy9kb2N1bWVudC54bWwucmVsc62STWrDMBCFT9A7iNnXstMfSomcTQhkW9wDKPL4h1ojIU1KffuKlCQOBNOFl++JefPNjNabHzuIbwyxd6SgyHIQSMbVPbUKPqvd4xuIyJpqPThCBSNG2JQP6w8cNKea2PU+ihRCUUHH7N+ljKZDq2PmPFJ6aVywmpMMrfTafOkW5SrPX2WYZkB5kyn2tYKwrwsQ1ejxP9muaXqDW2eOFonvtJCcajEF6tAiKzjJP7PIUhjI+wyrJRkiMqflxivG2ZlDeFoSoXHElT4Mk1VcrDmI5yUh6GgPGNLcV4iLNQfxsugxeBxweoqTPreXN5+8/AVQSwcIkACr6/EAAAAsAwAAUEsDBBQACAgIAOW+fk0AAAAAAAAAAAAAAAALAAAAX3JlbHMvLnJlbHONzzsOwjAMBuATcIfIO03LgBBq0gUhdUXlAFHiphHNQ0l49PZkYADEwGj792e57R52JjeMyXjHoKlqIOikV8ZpBufhuN4BSVk4JWbvkMGCCTq+ak84i1x20mRCIgVxicGUc9hTmuSEVqTKB3RlMvpoRS5l1DQIeREa6aautzS+G8A/TNIrBrFXDZBhCfiP7cfRSDx4ebXo8o8TX4kii6gxM7j7qKh6tavCAuUt/XiRPwFQSwcILWjPIrEAAAAqAQAAUEsDBBQACAgIAOW+fk0AAAAAAAAAAAAAAAAVAAAAd29yZC90aGVtZS90aGVtZTEueG1s7VlLb9s2HL8P2HcgdG9l2VbqBHWK2LHbrU0bJG6HHmmJlthQokDSSXwb2uOAAcO6YYcV2G2HYVuBFtil+zTZOmwd0K+wvx6WKZvOo023Dq0PNkn9/u8HSfnylcOIoX0iJOVx23Iu1ixEYo/7NA7a1u1B/0LLQlLh2MeMx6RtTYi0rqx/+MFlvKZCEhEE9LFcw20rVCpZs23pwTKWF3lCYng24iLCCqYisH2BD4BvxOx6rbZiR5jGFopxBGxvjUbUI2iQsrTWp8x7DL5iJdMFj4ldL5OoU2RYf89Jf+REdplA+5i1LZDj84MBOVQWYlgqeNC2atnHstcv2yURU0toNbp+9inoCgJ/r57RiWBYEjr95uqlzZJ/Pee/iOv1et2eU/LLANjzwFJnAdvst5zOlKcGyoeLvLs1t9as4jX+jQX8aqfTcVcr+MYM31zAt2orzY16Bd+c4d1F/Tsb3e5KBe/O8CsL+P6l1ZVmFZ+BQkbjvQV0Gs8yMiVkxNk1I7wF8NY0AWYoW8uunD5Wy3Itwve46AMgCy5WNEZqkpAR9gDXxYwOBU0F4DWCtSf5kicXllJZSHqCJqptfZxgqIgZ5OWzH18+e4KO7j89uv/L0YMHR/d/NlBdw3GgU734/ou/H32K/nry3YuHX5nxUsf//tNnv/36pRmodODzrx//8fTx828+//OHhwb4hsBDHT6gEZHoJjlAOzwCwwwCyFCcjWIQYqpTbMSBxDFOaQzongor6JsTzLAB1yFVD94R0AJMwKvjexWFd0MxVtQAvB5GFeAW56zDhdGm66ks3QvjODALF2Mdt4Pxvkl2dy6+vXECuUxNLLshqai5zSDkOCAxUSh9xvcIMZDdpbTi1y3qCS75SKG7FHUwNbpkQIfKTHSNRhCXiUlBiHfFN1t3UIczE/tNsl9FQlVgZmJJWMWNV/FY4cioMY6YjryBVWhScncivIrDpYJIB4Rx1POJlCaaW2JSUfc6tA5z2LfYJKoihaJ7JuQNzLmO3OR73RBHiVFnGoc69iO5BymK0TZXRiV4tULSOcQBx0vDfYcSdbbavk2D0Jwg6ZOxMJUE4dV6nLARJnHR4Su9OqLxcY07gr6Nz7txQ6t8/u2j/1HL3gAnmGpmvlEvw8235y4XPn37u/MmHsfbBArifXN+35zfxea8rJ7PvyXPurCtH7QzNtHSU/eIMrarJozckFn/lmCe34fFbJIRlYf8JIRhIa6CCwTOxkhw9QlV4W6IExDjZBICWbAOJEq4hKuFtZR3dj+lYHO25k4vlYDGaov7+XJDv2yWbLJZIHVBjZTBaYU1Lr2eMCcHnlKa45qlucdKszVvQt0gnL5KcFbquWhIFMyIn/o9ZzANyxsMkVPTYhRinxiWNfucxhvxpnsmJc7HybUFJ9uL1cTi6gwdtK1Vt+5ayMNJ2xrBaQmGUQL8ZNppMAvituWp3MCTa3HO4lVzVjk1d5nBFRGJkGoTyzCnyh5NX6XEM/3rbjP1w/kYYGgmp9Oi0XL+Qy3s+dCS0Yh4asnKbFo842NFxG7oH6AhG4sdDHo38+zyqYROX59OBOR2s0i8auEWtTH/yqaoGcySEBfZ3tJin8OzcalDNtPUs5fo/oqmNM7RFPfdNSXNXDifNvzs0gS7uMAozdG2xYUKOXShJKReX8C+n8kCvRCURaoSYukL6FRXsj/rWzmPvMkFodqhARIUOp0KBSHbqrDzBGZOXd8ep4yKPlOqK5P8d0j2CRuk1buS2m+hcNpNCkdkuPmg2abqGgb9t/jg0nyljWcmqHmWza+pNX1tK1h9PRVOswFr4upmi+vu0p1nfqtN4JaB0i9o3FR4bHY8HfAdiD4q93kEiXihVZRfuTgEnVuacSmrf+sU1FoS7/M8O2rObixx9vHiXt3ZrsHX7vGuthdL1NbuIdls4Y8oPrwHsjfhejNm+YpMYJYPtkVm8JD7k2LIZN4SckdMWzqLd8gIUf9wGtY5jxb/9JSb+U4uILW9JGycTFjgZ5tISVw/mbikmN7xSuLsFmdiwGaSc3we5bJFlp5i8eu47BTKm11mzN7TuuwUgXoFl6nD411WeMo2JR45VAJ3p39dQf7as5Rd/wdQSwcIIVqihCwGAADbHQAAUEsDBBQACAgIAOW+fk0AAAAAAAAAAAAAAAATAAAAW0NvbnRlbnRfVHlwZXNdLnhtbLWTTW7CMBCFT9A7RN5WxNBFVVUEFv1Ztl3QAwzOBKz6T56Bwu07CZAFAqmVmo1l+82893kkT+c774otZrIxVGpSjlWBwcTahlWlPhevowdVEEOowcWAldojqfnsZrrYJ6RCmgNVas2cHrUms0YPVMaEQZQmZg8sx7zSCcwXrFDfjcf32sTAGHjErYeaTZ+xgY3j4ulw31pXClJy1gALlxYzVbzsRDxgtmf9i75tqM9gRkeQMqPramhtE92eB4hKbcK7TCbbGv8UEZvGGqyj2XhpKb9jrlOOBolkqN6VhMyyO6Z+QOY38GKr20p9UsvjI4dB4L3DawCdNmh8I14LWDq8TNDLg0KEjV9ilv1liF4eFKJXPNhwGaQv+UcOlo96ZfiddFgnp0jd/fbZD1BLBwgzrw+3LAEAAC0EAABQSwECFAAUAAgICADlvn5NSRNDf2gBAAA9BQAAEgAAAAAAAAAAAAAAAAAAAAAAd29yZC9udW1iZXJpbmcueG1sUEsBAhQAFAAICAgA5b5+TY/2kL8FAgAA6gYAABEAAAAAAAAAAAAAAAAAqAEAAHdvcmQvc2V0dGluZ3MueG1sUEsBAhQAFAAICAgA5b5+Ta2HbQB5AQAAWgUAABIAAAAAAAAAAAAAAAAA7AMAAHdvcmQvZm9udFRhYmxlLnhtbFBLAQIUABQACAgIAOW+fk2dKXMALAMAAP8RAAAPAAAAAAAAAAAAAAAAAKUFAAB3b3JkL3N0eWxlcy54bWxQSwECFAAUAAgICADlvn5NvnBuHiYCAAA0BwAAEQAAAAAAAAAAAAAAAAAOCQAAd29yZC9kb2N1bWVudC54bWxQSwECFAAUAAgICADlvn5NkACr6/EAAAAsAwAAHAAAAAAAAAAAAAAAAABzCwAAd29yZC9fcmVscy9kb2N1bWVudC54bWwucmVsc1BLAQIUABQACAgIAOW+fk0taM8isQAAACoBAAALAAAAAAAAAAAAAAAAAK4MAABfcmVscy8ucmVsc1BLAQIUABQACAgIAOW+fk0hWqKELAYAANsdAAAVAAAAAAAAAAAAAAAAAJgNAAB3b3JkL3RoZW1lL3RoZW1lMS54bWxQSwECFAAUAAgICADlvn5NM68PtywBAAAtBAAAEwAAAAAAAAAAAAAAAAAHFAAAW0NvbnRlbnRfVHlwZXNdLnhtbFBLBQYAAAAACQAJAEICAAB0FQAAAAA=
+        UEsDBBQACAgIAHcvIk4AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICAB3LyJOAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAdy8iTgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAdy8iTgAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgAdy8iTgAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgAdy8iTgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgAdy8iTgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgAdy8iTgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgAdy8iTgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIAHcvIk5JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICAB3LyJOj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICAB3LyJOrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAdy8iTojORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAHcvIk4B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIAHcvIk6QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgAdy8iTi1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgAdy8iTiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIAHcvIk4zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 07:55:10 GMT
+  recorded_at: Wed, 02 Jan 2019 13:59:48 GMT
 - request:
     method: put
     uri: http://localhost:9998/tika
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        UEsDBBQACAgIAOW+fk0AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICADlvn5NAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgA5b5+TQAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgA5b5+TQAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkOotKpadZs0ddPaXcDBMcSqY1u2A2VXPzufkIQpDZXo4Af42Od9ncfHsa9uXhM62mCpCGcLZ3zpOSPMEI8IWy+c388PFzNnpDSwCChneOHssHJurj9dbedK7yhWI5PP1DxBCyfWWsxdV6EYJ6AuucDMdK64TECbply7CciXVFwgngjQZEko0TvX97ypU8jwhZNKNi8kLhKCJFd8pW3KnK9WBOHip8yQfXzzlHuO0gQznTm6ElMzB85UTIQq1ZKhaqYzLkU2/3qITULLcVvRxy2SsDWLkdDcaMtlJCRHWCkTvc87K8Wx1wOglagy+kzh0LOcSQKEVTK2NBpClfel8S6gZVL1g9QsFO0zkbzrO1lKkLv2LGAAz/18QXpVcUPBZOlUVgU5RALFIHUpQIcoUI5ecHQHbANVMUfrXuXcUIoIrCUkdZGqN63s2GuUy1MMAtdq69PUvkieirrcwyFqeztwPHmbgF8KXJsXYMTRPV5BSrWyTflTFs2ilf08cKbVaDsHhQhZOLeSgLHfzpHaa2BQ+lYR2AvFt0xV410rpf6Y8AbMRvH9MnKnmjEKbF3GMLMxt5iM25yiaLYyTQGIZBKU2E3tf546ReNXSk0AUs1zK2QeDb/qFOhTlZT5jgtbUdjuG7ktbtk5YlL1Thh5AdLWn4ita9b1LVo4j7ZeMy5RnmlNbDKDBJe2LB+Ue2epbXkNS4oPpJ9tpJd+NnL02MOl+yG+YrDHals4zjtG45zrEhSOfrCytzY0WYZ3V7xYvBeMxePekELQhr+bBVSNeL3WsNLYnKRj37MzXmLzfjCPEXpe99q7lWNR5nVthl67NvPYXh0OweYfxeZ/MGzBtC+2ZansNbd40LHF89iJGIOjGINzY5wdUvSHUkScclnVXmC/rTforOMNOnsHvOFRvOHHwuvP+uI9wDnNPi2cYQfO8B1wTo7inHwwnOF74jx6vp+Ic3oU5/R/xUkawmfB+0y0uVW07gtZ9Mxcpwdc336eTzpgTU6C9ZQudSevquPMyAJ/ELN3vOpXRd11onUXddBx7wqO3LvKf+r6L1BLBwidKXMALAMAAP8RAABQSwMEFAAICAgA5b5+TQAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWV227bMAyGn2DvEPg+sR2kW2HU6cWCDQO2IWi6B2Ak2RaqEyg5afb0k+JTDkXhZrkhSIoff8mM9PD4KsVkx9ByrfIonSXRhCmiKVdlHv15/ja9jybWgaIgtGJ5dGA2elx+ethnVJNaMuUmnqBsJkkeVc6ZLI4tqZgEO9OGKZ8sNEpw3sUyloAvtZkSLQ04vuWCu0M8T5LPUYvReVSjylrEVHKC2urChZJMFwUnrDVdBY7p25SsWsnHjjEy4TVoZStubEeTt9J8suogu/c2sZOiW7c3Y7pRhL3/HFI0jfYaqUFNmLU+umqSPTFNRhxgQPQVYySc9+yUSOCqx4ThuAD1vWe+d3toR9SwkeEsrBgjpEn95FsEPFyrgBvO87Te8FFTfEHwVa7GfiBvQZAK0HUAcQtBaPLC6FdQO+iHmZajxvmCRDmUCHIYUvuhL5smF+OyqcCwgVb+H+076toM4764hXbyD0zvPgaYd4ClvwK3mh6CNZN95m9Q+pRHSfuL2tCKievg+jr0tGIF1MK9kVnjWTBdZAYQftCT6FHEGoMhWjn26moQGwPEH5jH7CCIiOKQxzV6G/fr8T2hb2zoXE5LPBonzlrFbSbYpmFYZRlxzXpTbv76gsq/Onf3iyPf30XpfL5olZryFwR1W+2c9oOcLppVTpvBEaxwg4e8rE7cigFlQW5wCq1dcL7Me/7vWj4fDPNJ/8RhKGyFdyrj7hvHw3u3/AdQSwcIvnBuHiYCAAA0BwAAUEsDBBQACAgIAOW+fk0AAAAAAAAAAAAAAAAcAAAAd29yZC9fcmVscy9kb2N1bWVudC54bWwucmVsc62STWrDMBCFT9A7iNnXstMfSomcTQhkW9wDKPL4h1ojIU1KffuKlCQOBNOFl++JefPNjNabHzuIbwyxd6SgyHIQSMbVPbUKPqvd4xuIyJpqPThCBSNG2JQP6w8cNKea2PU+ihRCUUHH7N+ljKZDq2PmPFJ6aVywmpMMrfTafOkW5SrPX2WYZkB5kyn2tYKwrwsQ1ejxP9muaXqDW2eOFonvtJCcajEF6tAiKzjJP7PIUhjI+wyrJRkiMqflxivG2ZlDeFoSoXHElT4Mk1VcrDmI5yUh6GgPGNLcV4iLNQfxsugxeBxweoqTPreXN5+8/AVQSwcIkACr6/EAAAAsAwAAUEsDBBQACAgIAOW+fk0AAAAAAAAAAAAAAAALAAAAX3JlbHMvLnJlbHONzzsOwjAMBuATcIfIO03LgBBq0gUhdUXlAFHiphHNQ0l49PZkYADEwGj792e57R52JjeMyXjHoKlqIOikV8ZpBufhuN4BSVk4JWbvkMGCCTq+ak84i1x20mRCIgVxicGUc9hTmuSEVqTKB3RlMvpoRS5l1DQIeREa6aautzS+G8A/TNIrBrFXDZBhCfiP7cfRSDx4ebXo8o8TX4kii6gxM7j7qKh6tavCAuUt/XiRPwFQSwcILWjPIrEAAAAqAQAAUEsDBBQACAgIAOW+fk0AAAAAAAAAAAAAAAAVAAAAd29yZC90aGVtZS90aGVtZTEueG1s7VlLb9s2HL8P2HcgdG9l2VbqBHWK2LHbrU0bJG6HHmmJlthQokDSSXwb2uOAAcO6YYcV2G2HYVuBFtil+zTZOmwd0K+wvx6WKZvOo023Dq0PNkn9/u8HSfnylcOIoX0iJOVx23Iu1ixEYo/7NA7a1u1B/0LLQlLh2MeMx6RtTYi0rqx/+MFlvKZCEhEE9LFcw20rVCpZs23pwTKWF3lCYng24iLCCqYisH2BD4BvxOx6rbZiR5jGFopxBGxvjUbUI2iQsrTWp8x7DL5iJdMFj4ldL5OoU2RYf89Jf+REdplA+5i1LZDj84MBOVQWYlgqeNC2atnHstcv2yURU0toNbp+9inoCgJ/r57RiWBYEjr95uqlzZJ/Pee/iOv1et2eU/LLANjzwFJnAdvst5zOlKcGyoeLvLs1t9as4jX+jQX8aqfTcVcr+MYM31zAt2orzY16Bd+c4d1F/Tsb3e5KBe/O8CsL+P6l1ZVmFZ+BQkbjvQV0Gs8yMiVkxNk1I7wF8NY0AWYoW8uunD5Wy3Itwve46AMgCy5WNEZqkpAR9gDXxYwOBU0F4DWCtSf5kicXllJZSHqCJqptfZxgqIgZ5OWzH18+e4KO7j89uv/L0YMHR/d/NlBdw3GgU734/ou/H32K/nry3YuHX5nxUsf//tNnv/36pRmodODzrx//8fTx828+//OHhwb4hsBDHT6gEZHoJjlAOzwCwwwCyFCcjWIQYqpTbMSBxDFOaQzongor6JsTzLAB1yFVD94R0AJMwKvjexWFd0MxVtQAvB5GFeAW56zDhdGm66ks3QvjODALF2Mdt4Pxvkl2dy6+vXECuUxNLLshqai5zSDkOCAxUSh9xvcIMZDdpbTi1y3qCS75SKG7FHUwNbpkQIfKTHSNRhCXiUlBiHfFN1t3UIczE/tNsl9FQlVgZmJJWMWNV/FY4cioMY6YjryBVWhScncivIrDpYJIB4Rx1POJlCaaW2JSUfc6tA5z2LfYJKoihaJ7JuQNzLmO3OR73RBHiVFnGoc69iO5BymK0TZXRiV4tULSOcQBx0vDfYcSdbbavk2D0Jwg6ZOxMJUE4dV6nLARJnHR4Su9OqLxcY07gr6Nz7txQ6t8/u2j/1HL3gAnmGpmvlEvw8235y4XPn37u/MmHsfbBArifXN+35zfxea8rJ7PvyXPurCtH7QzNtHSU/eIMrarJozckFn/lmCe34fFbJIRlYf8JIRhIa6CCwTOxkhw9QlV4W6IExDjZBICWbAOJEq4hKuFtZR3dj+lYHO25k4vlYDGaov7+XJDv2yWbLJZIHVBjZTBaYU1Lr2eMCcHnlKa45qlucdKszVvQt0gnL5KcFbquWhIFMyIn/o9ZzANyxsMkVPTYhRinxiWNfucxhvxpnsmJc7HybUFJ9uL1cTi6gwdtK1Vt+5ayMNJ2xrBaQmGUQL8ZNppMAvituWp3MCTa3HO4lVzVjk1d5nBFRGJkGoTyzCnyh5NX6XEM/3rbjP1w/kYYGgmp9Oi0XL+Qy3s+dCS0Yh4asnKbFo842NFxG7oH6AhG4sdDHo38+zyqYROX59OBOR2s0i8auEWtTH/yqaoGcySEBfZ3tJin8OzcalDNtPUs5fo/oqmNM7RFPfdNSXNXDifNvzs0gS7uMAozdG2xYUKOXShJKReX8C+n8kCvRCURaoSYukL6FRXsj/rWzmPvMkFodqhARIUOp0KBSHbqrDzBGZOXd8ep4yKPlOqK5P8d0j2CRuk1buS2m+hcNpNCkdkuPmg2abqGgb9t/jg0nyljWcmqHmWza+pNX1tK1h9PRVOswFr4upmi+vu0p1nfqtN4JaB0i9o3FR4bHY8HfAdiD4q93kEiXihVZRfuTgEnVuacSmrf+sU1FoS7/M8O2rObixx9vHiXt3ZrsHX7vGuthdL1NbuIdls4Y8oPrwHsjfhejNm+YpMYJYPtkVm8JD7k2LIZN4SckdMWzqLd8gIUf9wGtY5jxb/9JSb+U4uILW9JGycTFjgZ5tISVw/mbikmN7xSuLsFmdiwGaSc3we5bJFlp5i8eu47BTKm11mzN7TuuwUgXoFl6nD411WeMo2JR45VAJ3p39dQf7as5Rd/wdQSwcIIVqihCwGAADbHQAAUEsDBBQACAgIAOW+fk0AAAAAAAAAAAAAAAATAAAAW0NvbnRlbnRfVHlwZXNdLnhtbLWTTW7CMBCFT9A7RN5WxNBFVVUEFv1Ztl3QAwzOBKz6T56Bwu07CZAFAqmVmo1l+82893kkT+c774otZrIxVGpSjlWBwcTahlWlPhevowdVEEOowcWAldojqfnsZrrYJ6RCmgNVas2cHrUms0YPVMaEQZQmZg8sx7zSCcwXrFDfjcf32sTAGHjErYeaTZ+xgY3j4ulw31pXClJy1gALlxYzVbzsRDxgtmf9i75tqM9gRkeQMqPramhtE92eB4hKbcK7TCbbGv8UEZvGGqyj2XhpKb9jrlOOBolkqN6VhMyyO6Z+QOY38GKr20p9UsvjI4dB4L3DawCdNmh8I14LWDq8TNDLg0KEjV9ilv1liF4eFKJXPNhwGaQv+UcOlo96ZfiddFgnp0jd/fbZD1BLBwgzrw+3LAEAAC0EAABQSwECFAAUAAgICADlvn5NSRNDf2gBAAA9BQAAEgAAAAAAAAAAAAAAAAAAAAAAd29yZC9udW1iZXJpbmcueG1sUEsBAhQAFAAICAgA5b5+TY/2kL8FAgAA6gYAABEAAAAAAAAAAAAAAAAAqAEAAHdvcmQvc2V0dGluZ3MueG1sUEsBAhQAFAAICAgA5b5+Ta2HbQB5AQAAWgUAABIAAAAAAAAAAAAAAAAA7AMAAHdvcmQvZm9udFRhYmxlLnhtbFBLAQIUABQACAgIAOW+fk2dKXMALAMAAP8RAAAPAAAAAAAAAAAAAAAAAKUFAAB3b3JkL3N0eWxlcy54bWxQSwECFAAUAAgICADlvn5NvnBuHiYCAAA0BwAAEQAAAAAAAAAAAAAAAAAOCQAAd29yZC9kb2N1bWVudC54bWxQSwECFAAUAAgICADlvn5NkACr6/EAAAAsAwAAHAAAAAAAAAAAAAAAAABzCwAAd29yZC9fcmVscy9kb2N1bWVudC54bWwucmVsc1BLAQIUABQACAgIAOW+fk0taM8isQAAACoBAAALAAAAAAAAAAAAAAAAAK4MAABfcmVscy8ucmVsc1BLAQIUABQACAgIAOW+fk0hWqKELAYAANsdAAAVAAAAAAAAAAAAAAAAAJgNAAB3b3JkL3RoZW1lL3RoZW1lMS54bWxQSwECFAAUAAgICADlvn5NM68PtywBAAAtBAAAEwAAAAAAAAAAAAAAAAAHFAAAW0NvbnRlbnRfVHlwZXNdLnhtbFBLBQYAAAAACQAJAEICAAB0FQAAAAA=
+        UEsDBBQACAgIAHcvIk4AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICAB3LyJOAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAdy8iTgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAdy8iTgAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgAdy8iTgAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgAdy8iTgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgAdy8iTgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgAdy8iTgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgAdy8iTgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIAHcvIk5JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICAB3LyJOj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICAB3LyJOrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAdy8iTojORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAHcvIk4B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIAHcvIk6QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgAdy8iTi1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgAdy8iTiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIAHcvIk4zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -1136,7 +1075,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 01 Dec 2018 07:55:10 GMT
+      - Wed, 02 Jan 2019 13:59:48 GMT
       Content-Type:
       - text/html
       Transfer-Encoding:
@@ -1159,10 +1098,10 @@ http_interactions:
         </body>
         </html>
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 07:55:10 GMT
+  recorded_at: Wed, 02 Jan 2019 13:59:49 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Z8v6Ab-SvWdYqpJy-f3seAh1HFFRUU3aZ_N5D3MIfI0/permissions?fields=permissions/id,%20permissions/emailAddress
+    uri: https://www.googleapis.com/drive/v3/files/1TmyMZSXuxqEPrJQFd7BuURezKEHl71MMGlLLA_KzSrA/permissions?fields=permissions/id,%20permissions/emailAddress,%20permissions/type
     body:
       encoding: UTF-8
       string: ''
@@ -1174,7 +1113,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 07:55:10 GMT
+      - Wed, 02 Jan 2019 13:59:49 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1185,9 +1124,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 01 Dec 2018 07:55:10 GMT
+      - Wed, 02 Jan 2019 13:59:49 GMT
       Date:
-      - Sat, 01 Dec 2018 07:55:10 GMT
+      - Wed, 02 Jan 2019 13:59:49 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1216,19 +1155,21 @@ http_interactions:
          "permissions": [
           {
            "id": "11673017242486491425",
+           "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>"
           },
           {
            "id": "13193959451567607887",
+           "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>"
           }
          ]
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 07:55:10 GMT
+  recorded_at: Wed, 02 Jan 2019 13:59:49 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1Z8v6Ab-SvWdYqpJy-f3seAh1HFFRUU3aZ_N5D3MIfI0/permissions/11673017242486491425
+    uri: https://www.googleapis.com/drive/v3/files/1TmyMZSXuxqEPrJQFd7BuURezKEHl71MMGlLLA_KzSrA/permissions/11673017242486491425
     body:
       encoding: UTF-8
       string: ''
@@ -1240,7 +1181,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 07:55:10 GMT
+      - Wed, 02 Jan 2019 13:59:49 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1257,7 +1198,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 01 Dec 2018 07:55:11 GMT
+      - Wed, 02 Jan 2019 13:59:50 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1269,10 +1210,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 07:55:11 GMT
+  recorded_at: Wed, 02 Jan 2019 13:59:50 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId,changes/file/parents&pageSize=100&pageToken=21858
+    uri: https://www.googleapis.com/drive/v3/changes?fields=nextPageToken,newStartPageToken,changes/fileId,changes/file/parents&pageSize=100&pageToken=24259
     body:
       encoding: UTF-8
       string: ''
@@ -1284,7 +1225,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 07:56:11 GMT
+      - Wed, 02 Jan 2019 14:00:50 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1295,9 +1236,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 01 Dec 2018 07:56:11 GMT
+      - Wed, 02 Jan 2019 14:00:52 GMT
       Date:
-      - Sat, 01 Dec 2018 07:56:11 GMT
+      - Wed, 02 Jan 2019 14:00:52 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1323,13 +1264,10 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "newStartPageToken": "21870",
+         "newStartPageToken": "24268",
          "changes": [
           {
-           "fileId": "1uFBOuYAg4kN9ppBuNY5UYoPurkQQvzhnVpoQEzX-x6E"
-          },
-          {
-           "fileId": "1xk-ziZ6PftIftx2A-IDTVy0n4mw3o6fl",
+           "fileId": "1TibOzWQ9HfhmXxT-Ap6oDUgrP--NwmOW",
            "file": {
             "parents": [
              "0AIeK5UAEPQfeUk9PVA"
@@ -1337,29 +1275,26 @@ http_interactions:
            }
           },
           {
-           "fileId": "1Z8v6Ab-SvWdYqpJy-f3seAh1HFFRUU3aZ_N5D3MIfI0"
-          },
-          {
-           "fileId": "1WsQ_POsJeLb0-PfnDAk-hN6y8jLMC5smqknyK8s1y0o",
+           "fileId": "1VeUtfVEh6DI0do2O7H6YFm35VwxLsNt62U4c2vAvEoE",
            "file": {
             "parents": [
-             "1xk-ziZ6PftIftx2A-IDTVy0n4mw3o6fl"
+             "1TibOzWQ9HfhmXxT-Ap6oDUgrP--NwmOW"
             ]
            }
           },
           {
-           "fileId": "1VMlc2G7hBAj1o2ecMsK0XMoNXlQxznEr"
+           "fileId": "1A8DM9eUSFl3a3FolBCUTO-RdMEgaQs6R"
           },
           {
-           "fileId": "1ZpQ419A8UFS1o18vdYcrGNIYfeR7CnbK5tKSECLyX2w"
+           "fileId": "1TmyMZSXuxqEPrJQFd7BuURezKEHl71MMGlLLA_KzSrA"
           }
          ]
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 07:56:11 GMT
+  recorded_at: Wed, 02 Jan 2019 14:00:52 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Z8v6Ab-SvWdYqpJy-f3seAh1HFFRUU3aZ_N5D3MIfI0?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1A8DM9eUSFl3a3FolBCUTO-RdMEgaQs6R?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1371,76 +1306,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 07:56:11 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Sat, 01 Dec 2018 07:56:11 GMT
-      Expires:
-      - Sat, 01 Dec 2018 07:56:11 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "notFound",
-            "message": "File not found: 1Z8v6Ab-SvWdYqpJy-f3seAh1HFFRUU3aZ_N5D3MIfI0.",
-            "locationType": "parameter",
-            "location": "fileId"
-           }
-          ],
-          "code": 404,
-          "message": "File not found: 1Z8v6Ab-SvWdYqpJy-f3seAh1HFFRUU3aZ_N5D3MIfI0."
-         }
-        }
-    http_version: 
-  recorded_at: Sat, 01 Dec 2018 07:56:11 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1VMlc2G7hBAj1o2ecMsK0XMoNXlQxznEr?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Sat, 01 Dec 2018 07:56:11 GMT
+      - Wed, 02 Jan 2019 14:00:52 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1451,9 +1317,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Sat, 01 Dec 2018 07:56:11 GMT
+      - Wed, 02 Jan 2019 14:00:52 GMT
       Date:
-      - Sat, 01 Dec 2018 07:56:11 GMT
+      - Wed, 02 Jan 2019 14:00:52 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1479,8 +1345,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1VMlc2G7hBAj1o2ecMsK0XMoNXlQxznEr",
-         "name": "Test @ 2018-12-01 07:55:02 UTC",
+         "id": "1A8DM9eUSFl3a3FolBCUTO-RdMEgaQs6R",
+         "name": "Test @ 2019-01-02 13:59:37 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -1506,10 +1372,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 07:56:11 GMT
+  recorded_at: Wed, 02 Jan 2019 14:00:52 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1VMlc2G7hBAj1o2ecMsK0XMoNXlQxznEr/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1A8DM9eUSFl3a3FolBCUTO-RdMEgaQs6R/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1521,7 +1387,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 07:56:11 GMT
+      - Wed, 02 Jan 2019 14:00:52 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1539,9 +1405,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Sat, 01 Dec 2018 07:56:12 GMT
+      - Wed, 02 Jan 2019 14:00:53 GMT
       Expires:
-      - Sat, 01 Dec 2018 07:56:12 GMT
+      - Wed, 02 Jan 2019 14:00:53 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1573,10 +1439,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 07:56:12 GMT
+  recorded_at: Wed, 02 Jan 2019 14:00:53 GMT
 - request:
-    method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1VMlc2G7hBAj1o2ecMsK0XMoNXlQxznEr
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1TmyMZSXuxqEPrJQFd7BuURezKEHl71MMGlLLA_KzSrA?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1588,7 +1454,76 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Sat, 01 Dec 2018 07:56:12 GMT
+      - Wed, 02 Jan 2019 14:00:53 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Wed, 02 Jan 2019 14:00:53 GMT
+      Expires:
+      - Wed, 02 Jan 2019 14:00:53 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "notFound",
+            "message": "File not found: 1TmyMZSXuxqEPrJQFd7BuURezKEHl71MMGlLLA_KzSrA.",
+            "locationType": "parameter",
+            "location": "fileId"
+           }
+          ],
+          "code": 404,
+          "message": "File not found: 1TmyMZSXuxqEPrJQFd7BuURezKEHl71MMGlLLA_KzSrA."
+         }
+        }
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 14:00:55 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1A8DM9eUSFl3a3FolBCUTO-RdMEgaQs6R
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 02 Jan 2019 14:00:55 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1605,7 +1540,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Sat, 01 Dec 2018 07:56:12 GMT
+      - Wed, 02 Jan 2019 14:01:00 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1617,5 +1552,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Sat, 01 Dec 2018 07:56:12 GMT
+  recorded_at: Wed, 02 Jan 2019 14:01:01 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Project/_create_with_is_public_true/shares_view_access_to_the_archive_with_anyone_e_g_guest_.yml
+++ b/spec/support/fixtures/vcr_cassettes/Project/_create_with_is_public_true/shares_view_access_to_the_archive_with_anyone_e_g_guest_.yml
@@ -1,0 +1,267 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"1 Billion
+        Year Bunker (Archive)","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 02 Jan 2019 16:07:33 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 02 Jan 2019 16:07:37 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "10j94c--DXcBYoFqxD4qYot39PsuTOLv3",
+         "name": "1 Billion Year Bunker (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 16:07:36 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/10j94c--DXcBYoFqxD4qYot39PsuTOLv3/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 02 Jan 2019 16:07:36 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 02 Jan 2019 16:07:37 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "13193959451567607887",
+         "type": "user",
+         "role": "reader"
+        }
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 16:07:37 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/10j94c--DXcBYoFqxD4qYot39PsuTOLv3/permissions
+    body:
+      encoding: UTF-8
+      string: '{"role":"reader","type":"anyone"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 02 Jan 2019 16:07:37 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 02 Jan 2019 16:07:38 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "anyoneWithLink",
+         "type": "anyone",
+         "role": "reader",
+         "allowFileDiscovery": false
+        }
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 16:07:38 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/10j94c--DXcBYoFqxD4qYot39PsuTOLv3?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 02 Jan 2019 16:07:38 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR COLLABORATOR ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Wed, 02 Jan 2019 16:07:40 GMT
+      Date:
+      - Wed, 02 Jan 2019 16:07:40 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "10j94c--DXcBYoFqxD4qYot39PsuTOLv3",
+         "name": "1 Billion Year Bunker (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0"
+        }
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 16:07:40 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Project/_update/when_private_project_is_made_public/grants_view_access_to_the_archive_to_anyone_e_g_guest_.yml
+++ b/spec/support/fixtures/vcr_cassettes/Project/_update/when_private_project_is_made_public/grants_view_access_to_the_archive_to_anyone_e_g_guest_.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Wed, 02 Jan 2019 22:57:46 GMT
+      - Wed, 02 Jan 2019 22:57:55 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 22:57:46 GMT
+  recorded_at: Wed, 02 Jan 2019 22:57:55 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Wed, 02 Jan 2019 22:57:46 GMT
+      - Wed, 02 Jan 2019 22:57:56 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 22:57:46 GMT
+  recorded_at: Wed, 02 Jan 2019 22:57:56 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"43 Heart of
-        Gold (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"46 Vogon Constructor
+        Fleet (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 22:57:46 GMT
+      - Wed, 02 Jan 2019 22:57:56 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 22:57:47 GMT
+      - Wed, 02 Jan 2019 22:57:56 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1-JbLSH-xzJROrIsldA78JRQjxMTG2wnr",
-         "name": "43 Heart of Gold (Archive)",
+         "id": "1-fNMZ5B_Ikf2Cl-0NNijgpD-cpX1RXFF",
+         "name": "46 Vogon Constructor Fleet (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 22:57:47 GMT
+  recorded_at: Wed, 02 Jan 2019 22:57:56 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1-JbLSH-xzJROrIsldA78JRQjxMTG2wnr/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1-fNMZ5B_Ikf2Cl-0NNijgpD-cpX1RXFF/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 22:57:47 GMT
+      - Wed, 02 Jan 2019 22:57:56 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 22:57:47 GMT
+      - Wed, 02 Jan 2019 22:57:57 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,10 +247,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 22:57:47 GMT
+  recorded_at: Wed, 02 Jan 2019 22:57:57 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1-JbLSH-xzJROrIsldA78JRQjxMTG2wnr/permissions
+    uri: https://www.googleapis.com/drive/v3/files/1-fNMZ5B_Ikf2Cl-0NNijgpD-cpX1RXFF/permissions
     body:
       encoding: UTF-8
       string: '{"role":"reader","type":"anyone"}'
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 22:57:47 GMT
+      - Wed, 02 Jan 2019 22:57:57 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -279,7 +279,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 22:57:48 GMT
+      - Wed, 02 Jan 2019 22:57:57 GMT
       Vary:
       - Origin
       - X-Origin
@@ -310,10 +310,10 @@ http_interactions:
          "allowFileDiscovery": false
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 22:57:48 GMT
+  recorded_at: Wed, 02 Jan 2019 22:57:57 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1-JbLSH-xzJROrIsldA78JRQjxMTG2wnr?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1-fNMZ5B_Ikf2Cl-0NNijgpD-cpX1RXFF?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -325,7 +325,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 22:57:48 GMT
+      - Wed, 02 Jan 2019 22:57:57 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR COLLABORATOR ACCOUNT>
       Content-Type:
@@ -336,9 +336,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 02 Jan 2019 22:57:48 GMT
+      - Wed, 02 Jan 2019 22:57:58 GMT
       Date:
-      - Wed, 02 Jan 2019 22:57:48 GMT
+      - Wed, 02 Jan 2019 22:57:58 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -364,12 +364,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1-JbLSH-xzJROrIsldA78JRQjxMTG2wnr",
-         "name": "43 Heart of Gold (Archive)",
+         "id": "1-fNMZ5B_Ikf2Cl-0NNijgpD-cpX1RXFF",
+         "name": "46 Vogon Constructor Fleet (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0"
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 22:57:48 GMT
+  recorded_at: Wed, 02 Jan 2019 22:57:58 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Project/_update/when_public_project_is_made_private/continues_to_be_accessible_to_the_owner.yml
+++ b/spec/support/fixtures/vcr_cassettes/Project/_update/when_public_project_is_made_private/continues_to_be_accessible_to_the_owner.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Wed, 02 Jan 2019 22:57:46 GMT
+      - Wed, 02 Jan 2019 22:57:52 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,61 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 22:57:46 GMT
+  recorded_at: Wed, 02 Jan 2019 22:57:52 GMT
+- request:
+    method: post
+    uri: https://oauth2.googleapis.com/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR USER ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Wed, 02 Jan 2019 22:57:52 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 22:57:52 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +136,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Wed, 02 Jan 2019 22:57:46 GMT
+      - Wed, 02 Jan 2019 22:57:52 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +161,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 22:57:46 GMT
+  recorded_at: Wed, 02 Jan 2019 22:57:52 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"43 Heart of
-        Gold (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"45 Golgafrinchan
+        Ark Fleet Ship B (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +177,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 22:57:46 GMT
+      - Wed, 02 Jan 2019 22:57:52 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +194,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 22:57:47 GMT
+      - Wed, 02 Jan 2019 22:57:53 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +218,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1-JbLSH-xzJROrIsldA78JRQjxMTG2wnr",
-         "name": "43 Heart of Gold (Archive)",
+         "id": "1qQiQ00LE7TndVli6eDHeakC01ETbAUXJ",
+         "name": "45 Golgafrinchan Ark Fleet Ship B (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +239,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 22:57:47 GMT
+  recorded_at: Wed, 02 Jan 2019 22:57:53 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1-JbLSH-xzJROrIsldA78JRQjxMTG2wnr/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1qQiQ00LE7TndVli6eDHeakC01ETbAUXJ/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -200,7 +254,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 22:57:47 GMT
+      - Wed, 02 Jan 2019 22:57:53 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +271,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 22:57:47 GMT
+      - Wed, 02 Jan 2019 22:57:53 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,10 +301,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 22:57:47 GMT
+  recorded_at: Wed, 02 Jan 2019 22:57:53 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1-JbLSH-xzJROrIsldA78JRQjxMTG2wnr/permissions
+    uri: https://www.googleapis.com/drive/v3/files/1qQiQ00LE7TndVli6eDHeakC01ETbAUXJ/permissions
     body:
       encoding: UTF-8
       string: '{"role":"reader","type":"anyone"}'
@@ -262,7 +316,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 22:57:47 GMT
+      - Wed, 02 Jan 2019 22:57:53 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -279,7 +333,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 22:57:48 GMT
+      - Wed, 02 Jan 2019 22:57:54 GMT
       Vary:
       - Origin
       - X-Origin
@@ -310,10 +364,10 @@ http_interactions:
          "allowFileDiscovery": false
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 22:57:48 GMT
+  recorded_at: Wed, 02 Jan 2019 22:57:54 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1-JbLSH-xzJROrIsldA78JRQjxMTG2wnr?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1qQiQ00LE7TndVli6eDHeakC01ETbAUXJ/permissions?fields=permissions/id,%20permissions/emailAddress,%20permissions/type
     body:
       encoding: UTF-8
       string: ''
@@ -325,9 +379,9 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 22:57:48 GMT
+      - Wed, 02 Jan 2019 22:57:54 GMT
       Authorization:
-      - Bearer <ACCESS TOKEN FOR COLLABORATOR ACCOUNT>
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
       - application/x-www-form-urlencoded
   response:
@@ -336,9 +390,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 02 Jan 2019 22:57:48 GMT
+      - Wed, 02 Jan 2019 22:57:54 GMT
       Date:
-      - Wed, 02 Jan 2019 22:57:48 GMT
+      - Wed, 02 Jan 2019 22:57:54 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -364,12 +418,128 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1-JbLSH-xzJROrIsldA78JRQjxMTG2wnr",
-         "name": "43 Heart of Gold (Archive)",
+         "permissions": [
+          {
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>"
+          },
+          {
+           "id": "anyoneWithLink",
+           "type": "anyone"
+          },
+          {
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>"
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 22:57:54 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1qQiQ00LE7TndVli6eDHeakC01ETbAUXJ/permissions/anyoneWithLink
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 02 Jan 2019 22:57:54 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 02 Jan 2019 22:57:55 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 22:57:55 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1qQiQ00LE7TndVli6eDHeakC01ETbAUXJ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 02 Jan 2019 22:57:55 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Wed, 02 Jan 2019 22:57:55 GMT
+      Date:
+      - Wed, 02 Jan 2019 22:57:55 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1qQiQ00LE7TndVli6eDHeakC01ETbAUXJ",
+         "name": "45 Golgafrinchan Ark Fleet Ship B (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0"
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 22:57:48 GMT
+  recorded_at: Wed, 02 Jan 2019 22:57:55 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Project/_update/when_public_project_is_made_private/removes_view_access_to_the_archive_from_non-collaborators.yml
+++ b/spec/support/fixtures/vcr_cassettes/Project/_update/when_public_project_is_made_private/removes_view_access_to_the_archive_from_non-collaborators.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Wed, 02 Jan 2019 22:57:46 GMT
+      - Wed, 02 Jan 2019 22:57:49 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,61 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 22:57:46 GMT
+  recorded_at: Wed, 02 Jan 2019 22:57:49 GMT
+- request:
+    method: post
+    uri: https://oauth2.googleapis.com/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR USER ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Wed, 02 Jan 2019 22:57:49 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 22:57:49 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +136,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Wed, 02 Jan 2019 22:57:46 GMT
+      - Wed, 02 Jan 2019 22:57:49 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +161,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 22:57:46 GMT
+  recorded_at: Wed, 02 Jan 2019 22:57:49 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"43 Heart of
-        Gold (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"44 Vogon Constructor
+        Fleet (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +177,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 22:57:46 GMT
+      - Wed, 02 Jan 2019 22:57:49 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +194,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 22:57:47 GMT
+      - Wed, 02 Jan 2019 22:57:49 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +218,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1-JbLSH-xzJROrIsldA78JRQjxMTG2wnr",
-         "name": "43 Heart of Gold (Archive)",
+         "id": "1mSMS2FdBgj9E7hfXLoJKMOJ-WK56Na0V",
+         "name": "44 Vogon Constructor Fleet (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +239,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 22:57:47 GMT
+  recorded_at: Wed, 02 Jan 2019 22:57:49 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1-JbLSH-xzJROrIsldA78JRQjxMTG2wnr/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1mSMS2FdBgj9E7hfXLoJKMOJ-WK56Na0V/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -200,7 +254,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 22:57:47 GMT
+      - Wed, 02 Jan 2019 22:57:49 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +271,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 22:57:47 GMT
+      - Wed, 02 Jan 2019 22:57:50 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,10 +301,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 22:57:47 GMT
+  recorded_at: Wed, 02 Jan 2019 22:57:50 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1-JbLSH-xzJROrIsldA78JRQjxMTG2wnr/permissions
+    uri: https://www.googleapis.com/drive/v3/files/1mSMS2FdBgj9E7hfXLoJKMOJ-WK56Na0V/permissions
     body:
       encoding: UTF-8
       string: '{"role":"reader","type":"anyone"}'
@@ -262,7 +316,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 22:57:47 GMT
+      - Wed, 02 Jan 2019 22:57:50 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -279,7 +333,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 22:57:48 GMT
+      - Wed, 02 Jan 2019 22:57:51 GMT
       Vary:
       - Origin
       - X-Origin
@@ -310,10 +364,10 @@ http_interactions:
          "allowFileDiscovery": false
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 22:57:48 GMT
+  recorded_at: Wed, 02 Jan 2019 22:57:51 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1-JbLSH-xzJROrIsldA78JRQjxMTG2wnr?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1mSMS2FdBgj9E7hfXLoJKMOJ-WK56Na0V/permissions?fields=permissions/id,%20permissions/emailAddress,%20permissions/type
     body:
       encoding: UTF-8
       string: ''
@@ -325,9 +379,9 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 22:57:48 GMT
+      - Wed, 02 Jan 2019 22:57:51 GMT
       Authorization:
-      - Bearer <ACCESS TOKEN FOR COLLABORATOR ACCOUNT>
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
       - application/x-www-form-urlencoded
   response:
@@ -336,9 +390,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 02 Jan 2019 22:57:48 GMT
+      - Wed, 02 Jan 2019 22:57:51 GMT
       Date:
-      - Wed, 02 Jan 2019 22:57:48 GMT
+      - Wed, 02 Jan 2019 22:57:51 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -364,12 +418,136 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1-JbLSH-xzJROrIsldA78JRQjxMTG2wnr",
-         "name": "43 Heart of Gold (Archive)",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "thumbnailVersion": "0"
+         "permissions": [
+          {
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>"
+          },
+          {
+           "id": "anyoneWithLink",
+           "type": "anyone"
+          },
+          {
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>"
+          }
+         ]
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 22:57:48 GMT
+  recorded_at: Wed, 02 Jan 2019 22:57:51 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1mSMS2FdBgj9E7hfXLoJKMOJ-WK56Na0V/permissions/anyoneWithLink
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 02 Jan 2019 22:57:51 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 02 Jan 2019 22:57:51 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 22:57:51 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1mSMS2FdBgj9E7hfXLoJKMOJ-WK56Na0V?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 02 Jan 2019 22:57:51 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR COLLABORATOR ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Wed, 02 Jan 2019 22:57:52 GMT
+      Expires:
+      - Wed, 02 Jan 2019 22:57:52 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "notFound",
+            "message": "File not found: 1mSMS2FdBgj9E7hfXLoJKMOJ-WK56Na0V.",
+            "locationType": "parameter",
+            "location": "fileId"
+           }
+          ],
+          "code": 404,
+          "message": "File not found: 1mSMS2FdBgj9E7hfXLoJKMOJ-WK56Na0V."
+         }
+        }
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 22:57:51 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_ApiConnection/_share_file_with_anyone/grants_read_permission_to_the_recipient.yml
+++ b/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_ApiConnection/_share_file_with_anyone/grants_read_permission_to_the_recipient.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Wed, 02 Jan 2019 14:02:33 GMT
+      - Wed, 02 Jan 2019 13:39:19 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,14 +53,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 14:02:33 GMT
+  recorded_at: Wed, 02 Jan 2019 13:39:19 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2019-01-02
-        14:02:33 UTC","parents":["root"]}'
+        13:39:19 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -69,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 14:02:33 GMT
+      - Wed, 02 Jan 2019 13:39:19 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -86,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 14:02:34 GMT
+      - Wed, 02 Jan 2019 13:39:20 GMT
       Vary:
       - Origin
       - X-Origin
@@ -110,8 +110,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1N9MM8PzOb15MnvsSdjBPve2Wl4oxYXed",
-         "name": "Test @ 2019-01-02 14:02:33 UTC",
+         "id": "1qcqdWoYzOxlmj9NSDZaO-eIXqkPRK41S",
+         "name": "Test @ 2019-01-02 13:39:19 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -131,13 +131,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 14:02:34 GMT
+  recorded_at: Wed, 02 Jan 2019 13:39:20 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1N9MM8PzOb15MnvsSdjBPve2Wl4oxYXed/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1qcqdWoYzOxlmj9NSDZaO-eIXqkPRK41S/permissions
     body:
       encoding: UTF-8
-      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+      string: '{"role":"reader","type":"anyone"}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -146,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 14:02:34 GMT
+      - Wed, 02 Jan 2019 13:39:20 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -163,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 14:02:35 GMT
+      - Wed, 02 Jan 2019 13:39:20 GMT
       Vary:
       - Origin
       - X-Origin
@@ -188,15 +188,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#permission",
-         "id": "13193959451567607887",
-         "type": "user",
-         "role": "reader"
+         "id": "anyoneWithLink",
+         "type": "anyone",
+         "role": "reader",
+         "allowFileDiscovery": false
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 14:02:35 GMT
+  recorded_at: Wed, 02 Jan 2019 13:39:21 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1N9MM8PzOb15MnvsSdjBPve2Wl4oxYXed/permissions?fields=permissions/id,%20permissions/emailAddress,%20permissions/type
+    uri: https://www.googleapis.com/drive/v3/files/1qcqdWoYzOxlmj9NSDZaO-eIXqkPRK41S?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -208,7 +209,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 14:02:35 GMT
+      - Wed, 02 Jan 2019 13:39:21 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -219,9 +220,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 02 Jan 2019 14:02:36 GMT
+      - Wed, 02 Jan 2019 13:39:21 GMT
       Date:
-      - Wed, 02 Jan 2019 14:02:36 GMT
+      - Wed, 02 Jan 2019 13:39:21 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -247,120 +248,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "permissions": [
-          {
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>"
-          },
-          {
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>"
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Wed, 02 Jan 2019 14:02:36 GMT
-- request:
-    method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1N9MM8PzOb15MnvsSdjBPve2Wl4oxYXed/permissions/13193959451567607887
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 02 Jan 2019 14:02:36 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 204
-      message: No Content
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Wed, 02 Jan 2019 14:02:36 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Wed, 02 Jan 2019 14:02:37 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1N9MM8PzOb15MnvsSdjBPve2Wl4oxYXed?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Wed, 02 Jan 2019 14:02:37 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Wed, 02 Jan 2019 14:02:37 GMT
-      Date:
-      - Wed, 02 Jan 2019 14:02:37 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1N9MM8PzOb15MnvsSdjBPve2Wl4oxYXed",
-         "name": "Test @ 2019-01-02 14:02:33 UTC",
+         "id": "1qcqdWoYzOxlmj9NSDZaO-eIXqkPRK41S",
+         "name": "Test @ 2019-01-02 13:39:19 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -368,6 +257,13 @@ http_interactions:
          ],
          "thumbnailVersion": "0",
          "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "anyoneWithLink",
+           "type": "anyone",
+           "role": "reader",
+           "allowFileDiscovery": false
+          },
           {
            "kind": "drive#permission",
            "id": "11673017242486491425",
@@ -380,10 +276,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 14:02:37 GMT
+  recorded_at: Wed, 02 Jan 2019 13:39:21 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1N9MM8PzOb15MnvsSdjBPve2Wl4oxYXed
+    uri: https://www.googleapis.com/drive/v3/files/1qcqdWoYzOxlmj9NSDZaO-eIXqkPRK41S
     body:
       encoding: UTF-8
       string: ''
@@ -395,7 +291,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 14:02:37 GMT
+      - Wed, 02 Jan 2019 13:39:21 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -412,7 +308,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 14:02:37 GMT
+      - Wed, 02 Jan 2019 13:39:21 GMT
       Vary:
       - Origin
       - X-Origin
@@ -424,5 +320,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 14:02:37 GMT
+  recorded_at: Wed, 02 Jan 2019 13:39:21 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_ApiConnection/_share_file_with_anyone/when_file_has_already_been_shared_with_anyone/1_2_2_1.yml
+++ b/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_ApiConnection/_share_file_with_anyone/when_file_has_already_been_shared_with_anyone/1_2_2_1.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Fri, 16 Nov 2018 23:40:20 GMT
+      - Wed, 02 Jan 2019 13:39:21 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,14 +53,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Fri, 16 Nov 2018 23:40:20 GMT
+  recorded_at: Wed, 02 Jan 2019 13:39:22 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-11-16
-        23:40:20 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2019-01-02
+        13:39:22 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -69,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 16 Nov 2018 23:40:20 GMT
+      - Wed, 02 Jan 2019 13:39:22 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -86,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 16 Nov 2018 23:40:20 GMT
+      - Wed, 02 Jan 2019 13:39:22 GMT
       Vary:
       - Origin
       - X-Origin
@@ -110,8 +110,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "17F0GKNSPhfbH0CzMWAE0V04_u33qngXq",
-         "name": "Test @ 2018-11-16 23:40:20 UTC",
+         "id": "16ZxDV5yu0Nx7U5GhfvJg8kHP2ZBjulLE",
+         "name": "Test @ 2019-01-02 13:39:22 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -131,13 +131,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 16 Nov 2018 23:40:21 GMT
+  recorded_at: Wed, 02 Jan 2019 13:39:22 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/17F0GKNSPhfbH0CzMWAE0V04_u33qngXq/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/16ZxDV5yu0Nx7U5GhfvJg8kHP2ZBjulLE/permissions
     body:
       encoding: UTF-8
-      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+      string: '{"role":"reader","type":"anyone"}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -146,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 16 Nov 2018 23:40:21 GMT
+      - Wed, 02 Jan 2019 13:39:22 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -163,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 16 Nov 2018 23:40:21 GMT
+      - Wed, 02 Jan 2019 13:39:23 GMT
       Vary:
       - Origin
       - X-Origin
@@ -188,18 +188,19 @@ http_interactions:
       string: |
         {
          "kind": "drive#permission",
-         "id": "13193959451567607887",
-         "type": "user",
-         "role": "reader"
+         "id": "anyoneWithLink",
+         "type": "anyone",
+         "role": "reader",
+         "allowFileDiscovery": false
         }
     http_version: 
-  recorded_at: Fri, 16 Nov 2018 23:40:22 GMT
+  recorded_at: Wed, 02 Jan 2019 13:39:23 GMT
 - request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/17F0GKNSPhfbH0CzMWAE0V04_u33qngXq/permissions?fields=permissions/id,%20permissions/emailAddress
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/16ZxDV5yu0Nx7U5GhfvJg8kHP2ZBjulLE/permissions
     body:
       encoding: UTF-8
-      string: ''
+      string: '{"role":"reader","type":"anyone"}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -208,22 +209,24 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 16 Nov 2018 23:40:22 GMT
+      - Wed, 02 Jan 2019 13:39:23 GMT
+      Content-Type:
+      - application/json
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
   response:
     status:
       code: 200
       message: OK
     headers:
-      Expires:
-      - Fri, 16 Nov 2018 23:40:22 GMT
-      Date:
-      - Fri, 16 Nov 2018 23:40:22 GMT
       Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 02 Jan 2019 13:39:23 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,22 +250,17 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "permissions": [
-          {
-           "id": "13193959451567607887",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>"
-          },
-          {
-           "id": "11673017242486491425",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>"
-          }
-         ]
+         "kind": "drive#permission",
+         "id": "anyoneWithLink",
+         "type": "anyone",
+         "role": "reader",
+         "allowFileDiscovery": false
         }
     http_version: 
-  recorded_at: Fri, 16 Nov 2018 23:40:22 GMT
+  recorded_at: Wed, 02 Jan 2019 13:39:24 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/17F0GKNSPhfbH0CzMWAE0V04_u33qngXq/permissions/13193959451567607887
+    uri: https://www.googleapis.com/drive/v3/files/16ZxDV5yu0Nx7U5GhfvJg8kHP2ZBjulLE
     body:
       encoding: UTF-8
       string: ''
@@ -274,7 +272,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 16 Nov 2018 23:40:22 GMT
+      - Wed, 02 Jan 2019 13:39:24 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -291,7 +289,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 16 Nov 2018 23:40:22 GMT
+      - Wed, 02 Jan 2019 13:39:24 GMT
       Vary:
       - Origin
       - X-Origin
@@ -303,111 +301,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 16 Nov 2018 23:40:22 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/17F0GKNSPhfbH0CzMWAE0V04_u33qngXq/permissions?fields=permissions/id,%20permissions/emailAddress
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Fri, 16 Nov 2018 23:40:22 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Fri, 16 Nov 2018 23:40:22 GMT
-      Date:
-      - Fri, 16 Nov 2018 23:40:22 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "permissions": [
-          {
-           "id": "11673017242486491425",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>"
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Fri, 16 Nov 2018 23:40:22 GMT
-- request:
-    method: delete
-    uri: https://www.googleapis.com/drive/v3/files/17F0GKNSPhfbH0CzMWAE0V04_u33qngXq
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Fri, 16 Nov 2018 23:40:22 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 204
-      message: No Content
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Fri, 16 Nov 2018 23:40:23 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 16 Nov 2018 23:40:23 GMT
+  recorded_at: Wed, 02 Jan 2019 13:39:24 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_ApiConnection/_unshare_file/when_file_has_already_been_unshared_with_the_recipient/1_3_2_1.yml
+++ b/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_ApiConnection/_unshare_file/when_file_has_already_been_unshared_with_the_recipient/1_3_2_1.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Wed, 02 Jan 2019 14:02:33 GMT
+      - Wed, 02 Jan 2019 14:02:38 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,14 +53,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 14:02:33 GMT
+  recorded_at: Wed, 02 Jan 2019 14:02:38 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2019-01-02
-        14:02:33 UTC","parents":["root"]}'
+        14:02:38 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -69,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 14:02:33 GMT
+      - Wed, 02 Jan 2019 14:02:38 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -86,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 14:02:34 GMT
+      - Wed, 02 Jan 2019 14:02:38 GMT
       Vary:
       - Origin
       - X-Origin
@@ -110,8 +110,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1N9MM8PzOb15MnvsSdjBPve2Wl4oxYXed",
-         "name": "Test @ 2019-01-02 14:02:33 UTC",
+         "id": "18Iw9yGwsx1iNFTTew3qJr_GWzSfjL0jC",
+         "name": "Test @ 2019-01-02 14:02:38 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -131,10 +131,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 14:02:34 GMT
+  recorded_at: Wed, 02 Jan 2019 14:02:38 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1N9MM8PzOb15MnvsSdjBPve2Wl4oxYXed/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/18Iw9yGwsx1iNFTTew3qJr_GWzSfjL0jC/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -146,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 14:02:34 GMT
+      - Wed, 02 Jan 2019 14:02:38 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -163,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 14:02:35 GMT
+      - Wed, 02 Jan 2019 14:02:39 GMT
       Vary:
       - Origin
       - X-Origin
@@ -193,10 +193,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 14:02:35 GMT
+  recorded_at: Wed, 02 Jan 2019 14:02:39 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1N9MM8PzOb15MnvsSdjBPve2Wl4oxYXed/permissions?fields=permissions/id,%20permissions/emailAddress,%20permissions/type
+    uri: https://www.googleapis.com/drive/v3/files/18Iw9yGwsx1iNFTTew3qJr_GWzSfjL0jC/permissions?fields=permissions/id,%20permissions/emailAddress,%20permissions/type
     body:
       encoding: UTF-8
       string: ''
@@ -208,7 +208,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 14:02:35 GMT
+      - Wed, 02 Jan 2019 14:02:39 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -219,9 +219,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 02 Jan 2019 14:02:36 GMT
+      - Wed, 02 Jan 2019 14:02:40 GMT
       Date:
-      - Wed, 02 Jan 2019 14:02:36 GMT
+      - Wed, 02 Jan 2019 14:02:40 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -261,10 +261,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 14:02:36 GMT
+  recorded_at: Wed, 02 Jan 2019 14:02:40 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1N9MM8PzOb15MnvsSdjBPve2Wl4oxYXed/permissions/13193959451567607887
+    uri: https://www.googleapis.com/drive/v3/files/18Iw9yGwsx1iNFTTew3qJr_GWzSfjL0jC/permissions/13193959451567607887
     body:
       encoding: UTF-8
       string: ''
@@ -276,7 +276,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 14:02:36 GMT
+      - Wed, 02 Jan 2019 14:02:40 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -293,7 +293,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 14:02:36 GMT
+      - Wed, 02 Jan 2019 14:02:42 GMT
       Vary:
       - Origin
       - X-Origin
@@ -305,10 +305,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 14:02:37 GMT
+  recorded_at: Wed, 02 Jan 2019 14:02:42 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1N9MM8PzOb15MnvsSdjBPve2Wl4oxYXed?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/18Iw9yGwsx1iNFTTew3qJr_GWzSfjL0jC/permissions?fields=permissions/id,%20permissions/emailAddress,%20permissions/type
     body:
       encoding: UTF-8
       string: ''
@@ -320,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 14:02:37 GMT
+      - Wed, 02 Jan 2019 14:02:42 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -331,9 +331,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 02 Jan 2019 14:02:37 GMT
+      - Wed, 02 Jan 2019 14:02:56 GMT
       Date:
-      - Wed, 02 Jan 2019 14:02:37 GMT
+      - Wed, 02 Jan 2019 14:02:56 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -359,31 +359,19 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1N9MM8PzOb15MnvsSdjBPve2Wl4oxYXed",
-         "name": "Test @ 2019-01-02 14:02:33 UTC",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
-         "thumbnailVersion": "0",
          "permissions": [
           {
-           "kind": "drive#permission",
            "id": "11673017242486491425",
            "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>"
           }
          ]
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 14:02:37 GMT
+  recorded_at: Wed, 02 Jan 2019 14:02:56 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1N9MM8PzOb15MnvsSdjBPve2Wl4oxYXed
+    uri: https://www.googleapis.com/drive/v3/files/18Iw9yGwsx1iNFTTew3qJr_GWzSfjL0jC
     body:
       encoding: UTF-8
       string: ''
@@ -395,7 +383,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 14:02:37 GMT
+      - Wed, 02 Jan 2019 14:02:56 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -412,7 +400,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 14:02:37 GMT
+      - Wed, 02 Jan 2019 14:02:57 GMT
       Vary:
       - Origin
       - X-Origin
@@ -424,5 +412,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 14:02:37 GMT
+  recorded_at: Wed, 02 Jan 2019 14:02:57 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_ApiConnection/_unshare_file_with_anyone/removes_read_permission_from_the_recipient.yml
+++ b/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_ApiConnection/_unshare_file_with_anyone/removes_read_permission_from_the_recipient.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Fri, 16 Nov 2018 23:40:17 GMT
+      - Wed, 02 Jan 2019 13:51:18 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,14 +53,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Fri, 16 Nov 2018 23:40:17 GMT
+  recorded_at: Wed, 02 Jan 2019 13:51:18 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-11-16
-        23:40:17 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2019-01-02
+        13:51:18 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -69,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 16 Nov 2018 23:40:17 GMT
+      - Wed, 02 Jan 2019 13:51:18 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -86,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 16 Nov 2018 23:40:17 GMT
+      - Wed, 02 Jan 2019 13:51:19 GMT
       Vary:
       - Origin
       - X-Origin
@@ -110,8 +110,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "178qUK3sjuU_FwcbY-uQS5IbCw41xQ5_e",
-         "name": "Test @ 2018-11-16 23:40:17 UTC",
+         "id": "1SSFCqmH0Utg4xXFCm0MHVW0Vcj0iQaQ4",
+         "name": "Test @ 2019-01-02 13:51:18 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -131,13 +131,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 16 Nov 2018 23:40:18 GMT
+  recorded_at: Wed, 02 Jan 2019 13:51:19 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/178qUK3sjuU_FwcbY-uQS5IbCw41xQ5_e/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1SSFCqmH0Utg4xXFCm0MHVW0Vcj0iQaQ4/permissions
     body:
       encoding: UTF-8
-      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+      string: '{"role":"reader","type":"anyone"}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -146,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 16 Nov 2018 23:40:18 GMT
+      - Wed, 02 Jan 2019 13:51:19 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -163,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 16 Nov 2018 23:40:18 GMT
+      - Wed, 02 Jan 2019 13:51:20 GMT
       Vary:
       - Origin
       - X-Origin
@@ -188,15 +188,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#permission",
-         "id": "13193959451567607887",
-         "type": "user",
-         "role": "reader"
+         "id": "anyoneWithLink",
+         "type": "anyone",
+         "role": "reader",
+         "allowFileDiscovery": false
         }
     http_version: 
-  recorded_at: Fri, 16 Nov 2018 23:40:19 GMT
+  recorded_at: Wed, 02 Jan 2019 13:51:20 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/178qUK3sjuU_FwcbY-uQS5IbCw41xQ5_e/permissions?fields=permissions/id,%20permissions/emailAddress
+    uri: https://www.googleapis.com/drive/v3/files/1SSFCqmH0Utg4xXFCm0MHVW0Vcj0iQaQ4/permissions?fields=permissions/id,%20permissions/emailAddress,%20permissions/type
     body:
       encoding: UTF-8
       string: ''
@@ -208,7 +209,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 16 Nov 2018 23:40:19 GMT
+      - Wed, 02 Jan 2019 13:51:20 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -219,9 +220,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Fri, 16 Nov 2018 23:40:19 GMT
+      - Wed, 02 Jan 2019 13:51:20 GMT
       Date:
-      - Fri, 16 Nov 2018 23:40:19 GMT
+      - Wed, 02 Jan 2019 13:51:20 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -249,20 +250,21 @@ http_interactions:
         {
          "permissions": [
           {
-           "id": "13193959451567607887",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>"
+           "id": "anyoneWithLink",
+           "type": "anyone"
           },
           {
            "id": "11673017242486491425",
+           "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>"
           }
          ]
         }
     http_version: 
-  recorded_at: Fri, 16 Nov 2018 23:40:19 GMT
+  recorded_at: Wed, 02 Jan 2019 13:51:20 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/178qUK3sjuU_FwcbY-uQS5IbCw41xQ5_e/permissions/13193959451567607887
+    uri: https://www.googleapis.com/drive/v3/files/1SSFCqmH0Utg4xXFCm0MHVW0Vcj0iQaQ4/permissions/anyoneWithLink
     body:
       encoding: UTF-8
       string: ''
@@ -274,7 +276,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 16 Nov 2018 23:40:19 GMT
+      - Wed, 02 Jan 2019 13:51:20 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -291,7 +293,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 16 Nov 2018 23:40:19 GMT
+      - Wed, 02 Jan 2019 13:51:21 GMT
       Vary:
       - Origin
       - X-Origin
@@ -303,10 +305,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 16 Nov 2018 23:40:19 GMT
+  recorded_at: Wed, 02 Jan 2019 13:51:21 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/178qUK3sjuU_FwcbY-uQS5IbCw41xQ5_e?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1SSFCqmH0Utg4xXFCm0MHVW0Vcj0iQaQ4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -318,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 16 Nov 2018 23:40:19 GMT
+      - Wed, 02 Jan 2019 13:51:21 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -329,9 +331,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Fri, 16 Nov 2018 23:40:19 GMT
+      - Wed, 02 Jan 2019 13:51:21 GMT
       Date:
-      - Fri, 16 Nov 2018 23:40:19 GMT
+      - Wed, 02 Jan 2019 13:51:21 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -357,8 +359,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "178qUK3sjuU_FwcbY-uQS5IbCw41xQ5_e",
-         "name": "Test @ 2018-11-16 23:40:17 UTC",
+         "id": "1SSFCqmH0Utg4xXFCm0MHVW0Vcj0iQaQ4",
+         "name": "Test @ 2019-01-02 13:51:18 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -378,10 +380,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 16 Nov 2018 23:40:19 GMT
+  recorded_at: Wed, 02 Jan 2019 13:51:21 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/178qUK3sjuU_FwcbY-uQS5IbCw41xQ5_e
+    uri: https://www.googleapis.com/drive/v3/files/1SSFCqmH0Utg4xXFCm0MHVW0Vcj0iQaQ4
     body:
       encoding: UTF-8
       string: ''
@@ -393,7 +395,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 16 Nov 2018 23:40:19 GMT
+      - Wed, 02 Jan 2019 13:51:21 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -410,7 +412,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 16 Nov 2018 23:40:20 GMT
+      - Wed, 02 Jan 2019 13:51:22 GMT
       Vary:
       - Origin
       - X-Origin
@@ -422,5 +424,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 16 Nov 2018 23:40:20 GMT
+  recorded_at: Wed, 02 Jan 2019 13:51:22 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_ApiConnection/_unshare_file_with_anyone/when_file_has_already_been_unshared_with_anyone/1_4_2_1.yml
+++ b/spec/support/fixtures/vcr_cassettes/Providers_GoogleDrive_ApiConnection/_unshare_file_with_anyone/when_file_has_already_been_unshared_with_anyone/1_4_2_1.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Wed, 02 Jan 2019 14:02:33 GMT
+      - Wed, 02 Jan 2019 13:51:22 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,14 +53,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 14:02:33 GMT
+  recorded_at: Wed, 02 Jan 2019 13:51:22 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2019-01-02
-        14:02:33 UTC","parents":["root"]}'
+        13:51:22 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -69,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 14:02:33 GMT
+      - Wed, 02 Jan 2019 13:51:22 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -86,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 14:02:34 GMT
+      - Wed, 02 Jan 2019 13:51:23 GMT
       Vary:
       - Origin
       - X-Origin
@@ -110,8 +110,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1N9MM8PzOb15MnvsSdjBPve2Wl4oxYXed",
-         "name": "Test @ 2019-01-02 14:02:33 UTC",
+         "id": "1z6IY_9YsUbAYYKuBsugNPrYHS75-DpJl",
+         "name": "Test @ 2019-01-02 13:51:22 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -131,13 +131,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 14:02:34 GMT
+  recorded_at: Wed, 02 Jan 2019 13:51:23 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1N9MM8PzOb15MnvsSdjBPve2Wl4oxYXed/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1z6IY_9YsUbAYYKuBsugNPrYHS75-DpJl/permissions
     body:
       encoding: UTF-8
-      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+      string: '{"role":"reader","type":"anyone"}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -146,7 +146,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 14:02:34 GMT
+      - Wed, 02 Jan 2019 13:51:23 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -163,7 +163,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 14:02:35 GMT
+      - Wed, 02 Jan 2019 13:51:24 GMT
       Vary:
       - Origin
       - X-Origin
@@ -188,15 +188,16 @@ http_interactions:
       string: |
         {
          "kind": "drive#permission",
-         "id": "13193959451567607887",
-         "type": "user",
-         "role": "reader"
+         "id": "anyoneWithLink",
+         "type": "anyone",
+         "role": "reader",
+         "allowFileDiscovery": false
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 14:02:35 GMT
+  recorded_at: Wed, 02 Jan 2019 13:51:24 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1N9MM8PzOb15MnvsSdjBPve2Wl4oxYXed/permissions?fields=permissions/id,%20permissions/emailAddress,%20permissions/type
+    uri: https://www.googleapis.com/drive/v3/files/1z6IY_9YsUbAYYKuBsugNPrYHS75-DpJl/permissions?fields=permissions/id,%20permissions/emailAddress,%20permissions/type
     body:
       encoding: UTF-8
       string: ''
@@ -208,7 +209,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 14:02:35 GMT
+      - Wed, 02 Jan 2019 13:51:24 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -219,9 +220,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 02 Jan 2019 14:02:36 GMT
+      - Wed, 02 Jan 2019 13:51:24 GMT
       Date:
-      - Wed, 02 Jan 2019 14:02:36 GMT
+      - Wed, 02 Jan 2019 13:51:24 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -249,9 +250,8 @@ http_interactions:
         {
          "permissions": [
           {
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>"
+           "id": "anyoneWithLink",
+           "type": "anyone"
           },
           {
            "id": "11673017242486491425",
@@ -261,10 +261,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 14:02:36 GMT
+  recorded_at: Wed, 02 Jan 2019 13:51:24 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1N9MM8PzOb15MnvsSdjBPve2Wl4oxYXed/permissions/13193959451567607887
+    uri: https://www.googleapis.com/drive/v3/files/1z6IY_9YsUbAYYKuBsugNPrYHS75-DpJl/permissions/anyoneWithLink
     body:
       encoding: UTF-8
       string: ''
@@ -276,7 +276,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 14:02:36 GMT
+      - Wed, 02 Jan 2019 13:51:24 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -293,7 +293,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 14:02:36 GMT
+      - Wed, 02 Jan 2019 13:51:25 GMT
       Vary:
       - Origin
       - X-Origin
@@ -305,10 +305,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 14:02:37 GMT
+  recorded_at: Wed, 02 Jan 2019 13:51:25 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1N9MM8PzOb15MnvsSdjBPve2Wl4oxYXed?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1z6IY_9YsUbAYYKuBsugNPrYHS75-DpJl/permissions?fields=permissions/id,%20permissions/emailAddress,%20permissions/type
     body:
       encoding: UTF-8
       string: ''
@@ -320,7 +320,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 14:02:37 GMT
+      - Wed, 02 Jan 2019 13:51:25 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -331,9 +331,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 02 Jan 2019 14:02:37 GMT
+      - Wed, 02 Jan 2019 13:51:26 GMT
       Date:
-      - Wed, 02 Jan 2019 14:02:37 GMT
+      - Wed, 02 Jan 2019 13:51:26 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -359,31 +359,19 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1N9MM8PzOb15MnvsSdjBPve2Wl4oxYXed",
-         "name": "Test @ 2019-01-02 14:02:33 UTC",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
-         ],
-         "thumbnailVersion": "0",
          "permissions": [
           {
-           "kind": "drive#permission",
            "id": "11673017242486491425",
            "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>"
           }
          ]
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 14:02:37 GMT
+  recorded_at: Wed, 02 Jan 2019 13:51:26 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1N9MM8PzOb15MnvsSdjBPve2Wl4oxYXed
+    uri: https://www.googleapis.com/drive/v3/files/1z6IY_9YsUbAYYKuBsugNPrYHS75-DpJl
     body:
       encoding: UTF-8
       string: ''
@@ -395,7 +383,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 14:02:37 GMT
+      - Wed, 02 Jan 2019 13:51:26 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -412,7 +400,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 14:02:37 GMT
+      - Wed, 02 Jan 2019 13:51:26 GMT
       Vary:
       - Origin
       - X-Origin
@@ -424,5 +412,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 14:02:37 GMT
+  recorded_at: Wed, 02 Jan 2019 13:51:26 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Visitors_As_a_guest/non-collaborator/when_project_has_an_archive/I_have_view_access_to_the_archive.yml
+++ b/spec/support/fixtures/vcr_cassettes/Visitors_As_a_guest/non-collaborator/when_project_has_an_archive/I_have_view_access_to_the_archive.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Fri, 28 Dec 2018 14:02:39 GMT
+      - Wed, 02 Jan 2019 16:18:59 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:02:39 GMT
+  recorded_at: Wed, 02 Jan 2019 16:19:00 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Fri, 28 Dec 2018 14:02:40 GMT
+      - Wed, 02 Jan 2019 16:19:00 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:02:40 GMT
+  recorded_at: Wed, 02 Jan 2019 16:19:00 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-12-28
-        14:02:40 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2019-01-02
+        16:19:00 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:02:40 GMT
+      - Wed, 02 Jan 2019 16:19:00 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 28 Dec 2018 14:02:42 GMT
+      - Wed, 02 Jan 2019 16:19:01 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "12We18d0jNE1BBYnOMdJCnDMa0Mv83auw",
-         "name": "Test @ 2018-12-28 14:02:40 UTC",
+         "id": "1g0t7cu5x3H-mpJ8jBdF_QU2fyKwFhrr2",
+         "name": "Test @ 2019-01-02 16:19:00 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,7 +185,7 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:02:42 GMT
+  recorded_at: Wed, 02 Jan 2019 16:19:01 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -214,7 +214,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Fri, 28 Dec 2018 14:02:42 GMT
+      - Wed, 02 Jan 2019 16:19:03 GMT
       Server:
       - ESF
       Cache-Control:
@@ -239,14 +239,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:02:42 GMT
+  recorded_at: Wed, 02 Jan 2019 16:19:03 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.document","name":"My Google
-        Drive File","parents":["12We18d0jNE1BBYnOMdJCnDMa0Mv83auw"]}'
+        Drive File","parents":["1g0t7cu5x3H-mpJ8jBdF_QU2fyKwFhrr2"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -255,7 +255,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:02:42 GMT
+      - Wed, 02 Jan 2019 16:19:03 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -272,7 +272,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 28 Dec 2018 14:02:44 GMT
+      - Wed, 02 Jan 2019 16:19:05 GMT
       Vary:
       - Origin
       - X-Origin
@@ -296,12 +296,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1rXVQr8cTckS_g1inwFCU0bMEUI-kmElEA5Nt7D-zyOY",
+         "id": "1TC-Bsw414cB49XmH2fzDSc1wKr1uhkI_HlZiUKzyTIg",
          "name": "My Google Drive File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "12We18d0jNE1BBYnOMdJCnDMa0Mv83auw"
+          "1g0t7cu5x3H-mpJ8jBdF_QU2fyKwFhrr2"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -317,10 +317,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:02:44 GMT
+  recorded_at: Wed, 02 Jan 2019 16:19:05 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/12We18d0jNE1BBYnOMdJCnDMa0Mv83auw/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1g0t7cu5x3H-mpJ8jBdF_QU2fyKwFhrr2/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -332,7 +332,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:02:44 GMT
+      - Wed, 02 Jan 2019 16:19:05 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -349,7 +349,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 28 Dec 2018 14:02:45 GMT
+      - Wed, 02 Jan 2019 16:19:06 GMT
       Vary:
       - Origin
       - X-Origin
@@ -379,14 +379,14 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:02:45 GMT
+  recorded_at: Wed, 02 Jan 2019 16:19:06 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"4 Heart of
-        Gold (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"3 Bistromath
+        (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -395,7 +395,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:02:50 GMT
+      - Wed, 02 Jan 2019 16:19:11 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -412,7 +412,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 28 Dec 2018 14:02:51 GMT
+      - Wed, 02 Jan 2019 16:19:12 GMT
       Vary:
       - Origin
       - X-Origin
@@ -436,8 +436,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1bLx2l-wTKMzTvN5anVl3kEoPjsS86YGl",
-         "name": "4 Heart of Gold (Archive)",
+         "id": "1-GI4EeOpIaJRvT2dVPtGFaOapmwIPi_H",
+         "name": "3 Bistromath (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -457,10 +457,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:02:51 GMT
+  recorded_at: Wed, 02 Jan 2019 16:19:12 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1bLx2l-wTKMzTvN5anVl3kEoPjsS86YGl/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1-GI4EeOpIaJRvT2dVPtGFaOapmwIPi_H/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -472,7 +472,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:02:51 GMT
+      - Wed, 02 Jan 2019 16:19:12 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -489,7 +489,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 28 Dec 2018 14:02:52 GMT
+      - Wed, 02 Jan 2019 16:19:13 GMT
       Vary:
       - Origin
       - X-Origin
@@ -519,10 +519,73 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:02:52 GMT
+  recorded_at: Wed, 02 Jan 2019 16:19:13 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1-GI4EeOpIaJRvT2dVPtGFaOapmwIPi_H/permissions
+    body:
+      encoding: UTF-8
+      string: '{"role":"reader","type":"anyone"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 02 Jan 2019 16:19:13 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 02 Jan 2019 16:19:14 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "anyoneWithLink",
+         "type": "anyone",
+         "role": "reader",
+         "allowFileDiscovery": false
+        }
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 16:19:14 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/12We18d0jNE1BBYnOMdJCnDMa0Mv83auw?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1g0t7cu5x3H-mpJ8jBdF_QU2fyKwFhrr2?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -534,7 +597,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:02:52 GMT
+      - Wed, 02 Jan 2019 16:19:14 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -545,9 +608,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Fri, 28 Dec 2018 14:02:53 GMT
+      - Wed, 02 Jan 2019 16:19:15 GMT
       Date:
-      - Fri, 28 Dec 2018 14:02:53 GMT
+      - Wed, 02 Jan 2019 16:19:15 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -573,8 +636,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "12We18d0jNE1BBYnOMdJCnDMa0Mv83auw",
-         "name": "Test @ 2018-12-28 14:02:40 UTC",
+         "id": "1g0t7cu5x3H-mpJ8jBdF_QU2fyKwFhrr2",
+         "name": "Test @ 2019-01-02 16:19:00 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -600,10 +663,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:02:53 GMT
+  recorded_at: Wed, 02 Jan 2019 16:19:15 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/12We18d0jNE1BBYnOMdJCnDMa0Mv83auw/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1g0t7cu5x3H-mpJ8jBdF_QU2fyKwFhrr2/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -615,7 +678,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:02:53 GMT
+      - Wed, 02 Jan 2019 16:19:15 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -633,9 +696,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Fri, 28 Dec 2018 14:02:53 GMT
+      - Wed, 02 Jan 2019 16:19:15 GMT
       Expires:
-      - Fri, 28 Dec 2018 14:02:53 GMT
+      - Wed, 02 Jan 2019 16:19:15 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -667,10 +730,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:02:53 GMT
+  recorded_at: Wed, 02 Jan 2019 16:19:15 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%2712We18d0jNE1BBYnOMdJCnDMa0Mv83auw%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271g0t7cu5x3H-mpJ8jBdF_QU2fyKwFhrr2%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -682,7 +745,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:02:54 GMT
+      - Wed, 02 Jan 2019 16:19:15 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -693,9 +756,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Fri, 28 Dec 2018 14:02:54 GMT
+      - Wed, 02 Jan 2019 16:19:16 GMT
       Date:
-      - Fri, 28 Dec 2018 14:02:54 GMT
+      - Wed, 02 Jan 2019 16:19:16 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -723,14 +786,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1rXVQr8cTckS_g1inwFCU0bMEUI-kmElEA5Nt7D-zyOY",
+           "id": "1TC-Bsw414cB49XmH2fzDSc1wKr1uhkI_HlZiUKzyTIg",
            "name": "My Google Drive File",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "12We18d0jNE1BBYnOMdJCnDMa0Mv83auw"
+            "1g0t7cu5x3H-mpJ8jBdF_QU2fyKwFhrr2"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1rXVQr8cTckS_g1inwFCU0bMEUI-kmElEA5Nt7D-zyOY&v=1&s=AMedNnoAAAAAXCZJLsOAPGPg3JhKbMbshsnUUKANjdyO&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1TC-Bsw414cB49XmH2fzDSc1wKr1uhkI_HlZiUKzyTIg&v=1&s=AMedNnoAAAAAXC0ApL4UUhZxHDyTBUZmFLguFRMDQY4L&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -756,10 +819,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:02:54 GMT
+  recorded_at: Wed, 02 Jan 2019 16:19:16 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1rXVQr8cTckS_g1inwFCU0bMEUI-kmElEA5Nt7D-zyOY/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1TC-Bsw414cB49XmH2fzDSc1wKr1uhkI_HlZiUKzyTIg/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -771,7 +834,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:02:54 GMT
+      - Wed, 02 Jan 2019 16:19:16 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -782,9 +845,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Fri, 28 Dec 2018 14:02:54 GMT
+      - Wed, 02 Jan 2019 16:19:16 GMT
       Date:
-      - Fri, 28 Dec 2018 14:02:54 GMT
+      - Wed, 02 Jan 2019 16:19:16 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -813,13 +876,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-12-28T14:02:43.751Z"
+         "modifiedTime": "2019-01-02T16:19:04.393Z"
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:02:55 GMT
+  recorded_at: Wed, 02 Jan 2019 16:19:16 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1rXVQr8cTckS_g1inwFCU0bMEUI-kmElEA5Nt7D-zyOY&s=AMedNnoAAAAAXCZJLsOAPGPg3JhKbMbshsnUUKANjdyO&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1TC-Bsw414cB49XmH2fzDSc1wKr1uhkI_HlZiUKzyTIg&s=AMedNnoAAAAAXC0ApL4UUhZxHDyTBUZmFLguFRMDQY4L&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -831,7 +894,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:02:55 GMT
+      - Wed, 02 Jan 2019 16:19:16 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -862,7 +925,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Fri, 28 Dec 2018 14:02:55 GMT
+      - Wed, 02 Jan 2019 16:19:27 GMT
       Server:
       - fife
       Content-Length:
@@ -876,13 +939,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:02:55 GMT
+  recorded_at: Wed, 02 Jan 2019 16:19:30 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1rXVQr8cTckS_g1inwFCU0bMEUI-kmElEA5Nt7D-zyOY/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1TC-Bsw414cB49XmH2fzDSc1wKr1uhkI_HlZiUKzyTIg/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"My Google Drive File","parents":["1bLx2l-wTKMzTvN5anVl3kEoPjsS86YGl"]}'
+      string: '{"name":"My Google Drive File","parents":["1-GI4EeOpIaJRvT2dVPtGFaOapmwIPi_H"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -891,7 +954,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:02:56 GMT
+      - Wed, 02 Jan 2019 16:19:30 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -908,7 +971,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 28 Dec 2018 14:02:58 GMT
+      - Wed, 02 Jan 2019 16:19:32 GMT
       Vary:
       - Origin
       - X-Origin
@@ -932,12 +995,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1oxPziiBVGcbP8_Bb77F-ZCDagpkKayXgTGYsB-Pn7_g",
+         "id": "15jsJ6aZVwwEgEHjqChzqTEjxBSA3v0xx2Ke8QupPkZk",
          "name": "My Google Drive File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1bLx2l-wTKMzTvN5anVl3kEoPjsS86YGl"
+          "1-GI4EeOpIaJRvT2dVPtGFaOapmwIPi_H"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -952,6 +1015,13 @@ http_interactions:
           },
           {
            "kind": "drive#permission",
+           "id": "anyoneWithLink",
+           "type": "anyone",
+           "role": "reader",
+           "allowFileDiscovery": false
+          },
+          {
+           "kind": "drive#permission",
            "id": "11673017242486491425",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
@@ -962,10 +1032,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:02:58 GMT
+  recorded_at: Wed, 02 Jan 2019 16:19:32 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1oxPziiBVGcbP8_Bb77F-ZCDagpkKayXgTGYsB-Pn7_g?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/15jsJ6aZVwwEgEHjqChzqTEjxBSA3v0xx2Ke8QupPkZk?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -977,7 +1047,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:02:58 GMT
+      - Wed, 02 Jan 2019 16:19:32 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -988,9 +1058,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Fri, 28 Dec 2018 14:02:58 GMT
+      - Wed, 02 Jan 2019 16:19:32 GMT
       Date:
-      - Fri, 28 Dec 2018 14:02:58 GMT
+      - Wed, 02 Jan 2019 16:19:32 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1016,12 +1086,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1oxPziiBVGcbP8_Bb77F-ZCDagpkKayXgTGYsB-Pn7_g",
+         "id": "15jsJ6aZVwwEgEHjqChzqTEjxBSA3v0xx2Ke8QupPkZk",
          "name": "My Google Drive File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1bLx2l-wTKMzTvN5anVl3kEoPjsS86YGl"
+          "1-GI4EeOpIaJRvT2dVPtGFaOapmwIPi_H"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1036,6 +1106,13 @@ http_interactions:
           },
           {
            "kind": "drive#permission",
+           "id": "anyoneWithLink",
+           "type": "anyone",
+           "role": "reader",
+           "allowFileDiscovery": false
+          },
+          {
+           "kind": "drive#permission",
            "id": "11673017242486491425",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
@@ -1046,10 +1123,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:02:58 GMT
+  recorded_at: Wed, 02 Jan 2019 16:19:33 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1oxPziiBVGcbP8_Bb77F-ZCDagpkKayXgTGYsB-Pn7_g/export?alt=media&mimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document
+    uri: https://www.googleapis.com/drive/v3/files/15jsJ6aZVwwEgEHjqChzqTEjxBSA3v0xx2Ke8QupPkZk/export?alt=media&mimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document
     body:
       encoding: UTF-8
       string: ''
@@ -1061,7 +1138,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:02:58 GMT
+      - Wed, 02 Jan 2019 16:19:33 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
   response:
@@ -1070,9 +1147,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Fri, 28 Dec 2018 14:02:58 GMT
+      - Wed, 02 Jan 2019 16:19:33 GMT
       Date:
-      - Fri, 28 Dec 2018 14:02:58 GMT
+      - Wed, 02 Jan 2019 16:19:33 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Disposition:
@@ -1097,16 +1174,16 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        UEsDBBQACAgIAF0wnE0AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICABdMJxNAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIAF0wnE1JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICABdMJxNj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICABdMJxNrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAXTCcTYjORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAF0wnE0B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIAF0wnE2QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgAXTCcTS1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgAXTCcTSFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIAF0wnE0zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
+        UEsDBBQACAgIAHBCIk4AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICABwQiJOAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAcEIiTgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAcEIiTgAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgAcEIiTgAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgAcEIiTgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgAcEIiTgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgAcEIiTgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgAcEIiTgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIAHBCIk5JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICABwQiJOj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICABwQiJOrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAcEIiTojORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAHBCIk4B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIAHBCIk6QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgAcEIiTi1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgAcEIiTiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIAHBCIk4zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:02:58 GMT
+  recorded_at: Wed, 02 Jan 2019 16:19:34 GMT
 - request:
     method: put
     uri: http://localhost:9998/tika
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        UEsDBBQACAgIAF0wnE0AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICABdMJxNAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIAF0wnE1JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICABdMJxNj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICABdMJxNrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAXTCcTYjORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAF0wnE0B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIAF0wnE2QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgAXTCcTS1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgAXTCcTSFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIAF0wnE0zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
+        UEsDBBQACAgIAHBCIk4AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICABwQiJOAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAcEIiTgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAcEIiTgAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgAcEIiTgAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgAcEIiTgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgAcEIiTgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgAcEIiTgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgAcEIiTgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIAHBCIk5JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICABwQiJOj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICABwQiJOrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAcEIiTojORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAHBCIk4B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIAHBCIk6QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgAcEIiTi1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgAcEIiTiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIAHBCIk4zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -1124,7 +1201,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Dec 2018 14:02:58 GMT
+      - Wed, 02 Jan 2019 16:19:34 GMT
       Content-Type:
       - text/html
       Transfer-Encoding:
@@ -1147,10 +1224,10 @@ http_interactions:
         </body>
         </html>
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:02:59 GMT
+  recorded_at: Wed, 02 Jan 2019 16:19:34 GMT
 - request:
-    method: delete
-    uri: https://www.googleapis.com/drive/v3/files/12We18d0jNE1BBYnOMdJCnDMa0Mv83auw
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/15jsJ6aZVwwEgEHjqChzqTEjxBSA3v0xx2Ke8QupPkZk?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1162,7 +1239,69 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:03:00 GMT
+      - Wed, 02 Jan 2019 16:19:35 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR COLLABORATOR ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Wed, 02 Jan 2019 16:19:36 GMT
+      Date:
+      - Wed, 02 Jan 2019 16:19:36 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "15jsJ6aZVwwEgEHjqChzqTEjxBSA3v0xx2Ke8QupPkZk",
+         "name": "My Google Drive File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=15jsJ6aZVwwEgEHjqChzqTEjxBSA3v0xx2Ke8QupPkZk&v=1&s=AMedNnoAAAAAXC0AuHAfRTX6SkaqjkuXcQEgqbGb-YGp&sz=s220",
+         "thumbnailVersion": "1"
+        }
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 16:19:36 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1g0t7cu5x3H-mpJ8jBdF_QU2fyKwFhrr2
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 02 Jan 2019 16:19:36 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1179,7 +1318,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 28 Dec 2018 14:03:00 GMT
+      - Wed, 02 Jan 2019 16:19:37 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1191,5 +1330,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:03:01 GMT
+  recorded_at: Wed, 02 Jan 2019 16:19:37 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Visitors_As_a_guest/non-collaborator/when_project_has_an_archive/I_have_view_access_to_the_archive.yml
+++ b/spec/support/fixtures/vcr_cassettes/Visitors_As_a_guest/non-collaborator/when_project_has_an_archive/I_have_view_access_to_the_archive.yml
@@ -1,0 +1,1195 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://oauth2.googleapis.com/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR TRACKING ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Fri, 28 Dec 2018 14:02:39 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:02:39 GMT
+- request:
+    method: post
+    uri: https://oauth2.googleapis.com/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR USER ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Fri, 28 Dec 2018 14:02:40 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:02:40 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-12-28
+        14:02:40 UTC","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:02:40 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 28 Dec 2018 14:02:42 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "12We18d0jNE1BBYnOMdJCnDMa0Mv83auw",
+         "name": "Test @ 2018-12-28 14:02:40 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AEIi2L68pCuiUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:02:42 GMT
+- request:
+    method: post
+    uri: https://oauth2.googleapis.com/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR COLLABORATOR
+        ACCOUNT>&client_id=<CLIENT ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Fri, 28 Dec 2018 14:02:42 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR COLLABORATOR ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:02:42 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"My Google
+        Drive File","parents":["12We18d0jNE1BBYnOMdJCnDMa0Mv83auw"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:02:42 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 28 Dec 2018 14:02:44 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1rXVQr8cTckS_g1inwFCU0bMEUI-kmElEA5Nt7D-zyOY",
+         "name": "My Google Drive File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "12We18d0jNE1BBYnOMdJCnDMa0Mv83auw"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:02:44 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/12We18d0jNE1BBYnOMdJCnDMa0Mv83auw/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:02:44 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 28 Dec 2018 14:02:45 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "11673017242486491425",
+         "type": "user",
+         "role": "writer"
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:02:45 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"4 Heart of
+        Gold (Archive)","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:02:50 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 28 Dec 2018 14:02:51 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1bLx2l-wTKMzTvN5anVl3kEoPjsS86YGl",
+         "name": "4 Heart of Gold (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:02:51 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1bLx2l-wTKMzTvN5anVl3kEoPjsS86YGl/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:02:51 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 28 Dec 2018 14:02:52 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "13193959451567607887",
+         "type": "user",
+         "role": "reader"
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:02:52 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/12We18d0jNE1BBYnOMdJCnDMa0Mv83auw?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:02:52 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 28 Dec 2018 14:02:53 GMT
+      Date:
+      - Fri, 28 Dec 2018 14:02:53 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "12We18d0jNE1BBYnOMdJCnDMa0Mv83auw",
+         "name": "Test @ 2018-12-28 14:02:40 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:02:53 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/12We18d0jNE1BBYnOMdJCnDMa0Mv83auw/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:02:53 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Fri, 28 Dec 2018 14:02:53 GMT
+      Expires:
+      - Fri, 28 Dec 2018 14:02:53 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:02:53 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%2712We18d0jNE1BBYnOMdJCnDMa0Mv83auw%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:02:54 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 28 Dec 2018 14:02:54 GMT
+      Date:
+      - Fri, 28 Dec 2018 14:02:54 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "files": [
+          {
+           "id": "1rXVQr8cTckS_g1inwFCU0bMEUI-kmElEA5Nt7D-zyOY",
+           "name": "My Google Drive File",
+           "mimeType": "application/vnd.google-apps.document",
+           "trashed": false,
+           "parents": [
+            "12We18d0jNE1BBYnOMdJCnDMa0Mv83auw"
+           ],
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1rXVQr8cTckS_g1inwFCU0bMEUI-kmElEA5Nt7D-zyOY&v=1&s=AMedNnoAAAAAXCZJLsOAPGPg3JhKbMbshsnUUKANjdyO&sz=s220",
+           "thumbnailVersion": "1",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "writer",
+             "displayName": "Upshift One",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "13193959451567607887",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+             "role": "owner",
+             "displayName": "Testuser Upshift One",
+             "deleted": false
+            }
+           ]
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:02:54 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1rXVQr8cTckS_g1inwFCU0bMEUI-kmElEA5Nt7D-zyOY/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:02:54 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 28 Dec 2018 14:02:54 GMT
+      Date:
+      - Fri, 28 Dec 2018 14:02:54 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-12-28T14:02:43.751Z"
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:02:55 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1rXVQr8cTckS_g1inwFCU0bMEUI-kmElEA5Nt7D-zyOY&s=AMedNnoAAAAAXCZJLsOAPGPg3JhKbMbshsnUUKANjdyO&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:02:55 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Fri, 28 Dec 2018 14:02:55 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:02:55 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1rXVQr8cTckS_g1inwFCU0bMEUI-kmElEA5Nt7D-zyOY/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"My Google Drive File","parents":["1bLx2l-wTKMzTvN5anVl3kEoPjsS86YGl"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:02:56 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 28 Dec 2018 14:02:58 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1oxPziiBVGcbP8_Bb77F-ZCDagpkKayXgTGYsB-Pn7_g",
+         "name": "My Google Drive File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1bLx2l-wTKMzTvN5anVl3kEoPjsS86YGl"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:02:58 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1oxPziiBVGcbP8_Bb77F-ZCDagpkKayXgTGYsB-Pn7_g?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:02:58 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 28 Dec 2018 14:02:58 GMT
+      Date:
+      - Fri, 28 Dec 2018 14:02:58 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1oxPziiBVGcbP8_Bb77F-ZCDagpkKayXgTGYsB-Pn7_g",
+         "name": "My Google Drive File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1bLx2l-wTKMzTvN5anVl3kEoPjsS86YGl"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:02:58 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1oxPziiBVGcbP8_Bb77F-ZCDagpkKayXgTGYsB-Pn7_g/export?alt=media&mimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:02:58 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 28 Dec 2018 14:02:58 GMT
+      Date:
+      - Fri, 28 Dec 2018 14:02:58 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Disposition:
+      - attachment
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/vnd.openxmlformats-officedocument.wordprocessingml.document
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '6061'
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        UEsDBBQACAgIAF0wnE0AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICABdMJxNAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIAF0wnE1JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICABdMJxNj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICABdMJxNrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAXTCcTYjORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAF0wnE0B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIAF0wnE2QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgAXTCcTS1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgAXTCcTSFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIAF0wnE0zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:02:58 GMT
+- request:
+    method: put
+    uri: http://localhost:9998/tika
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        UEsDBBQACAgIAF0wnE0AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICABdMJxNAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgAXTCcTQAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIAF0wnE1JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICABdMJxNj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICABdMJxNrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAXTCcTYjORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAF0wnE0B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIAF0wnE2QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgAXTCcTS1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgAXTCcTSFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIAF0wnE0zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - text/html
+      User-Agent:
+      - Ruby
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/octet-stream
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 28 Dec 2018 14:02:58 GMT
+      Content-Type:
+      - text/html
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(9.4.z-SNAPSHOT)
+    body:
+      encoding: UTF-8
+      string: |
+        <html xmlns="http://www.w3.org/1999/xhtml">
+        <head>
+        <meta name="X-Parsed-By" content="org.apache.tika.parser.DefaultParser"/>
+        <meta name="X-Parsed-By" content="org.apache.tika.parser.microsoft.ooxml.OOXMLParser"/>
+        <meta name="Content-Type" content="application/vnd.openxmlformats-officedocument.wordprocessingml.document"/>
+        <title>
+        </title>
+        </head>
+        <body>
+        <p/>
+        </body>
+        </html>
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:02:59 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/12We18d0jNE1BBYnOMdJCnDMa0Mv83auw
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:03:00 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 28 Dec 2018 14:03:00 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:03:01 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Visitors_As_a_guest/non-collaborator/when_project_has_an_archive/when_project_is_made_private/I_no_longer_have_read_access_to_the_archive.yml
+++ b/spec/support/fixtures/vcr_cassettes/Visitors_As_a_guest/non-collaborator/when_project_has_an_archive/when_project_is_made_private/I_no_longer_have_read_access_to_the_archive.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Wed, 02 Jan 2019 16:19:42 GMT
+      - Wed, 02 Jan 2019 16:46:57 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 16:19:44 GMT
+  recorded_at: Wed, 02 Jan 2019 16:46:57 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Wed, 02 Jan 2019 16:19:52 GMT
+      - Wed, 02 Jan 2019 16:46:57 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 16:19:56 GMT
+  recorded_at: Wed, 02 Jan 2019 16:46:57 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2019-01-02
-        16:19:56 UTC","parents":["root"]}'
+        16:46:57 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 16:19:56 GMT
+      - Wed, 02 Jan 2019 16:46:57 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 16:20:02 GMT
+      - Wed, 02 Jan 2019 16:46:58 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "16QaFynf-Rh2td7nJJXCxbW6_S9Taj3N-",
-         "name": "Test @ 2019-01-02 16:19:56 UTC",
+         "id": "1yHWESUMQeZUlEL7dSQtOowqwH9RglkCg",
+         "name": "Test @ 2019-01-02 16:46:57 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,7 +185,7 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 16:20:03 GMT
+  recorded_at: Wed, 02 Jan 2019 16:46:58 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -214,7 +214,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Wed, 02 Jan 2019 16:20:06 GMT
+      - Wed, 02 Jan 2019 16:47:03 GMT
       Server:
       - ESF
       Cache-Control:
@@ -239,14 +239,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 16:20:07 GMT
+  recorded_at: Wed, 02 Jan 2019 16:47:06 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.document","name":"My Google
-        Drive File","parents":["16QaFynf-Rh2td7nJJXCxbW6_S9Taj3N-"]}'
+        Drive File","parents":["1yHWESUMQeZUlEL7dSQtOowqwH9RglkCg"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -255,7 +255,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 16:20:07 GMT
+      - Wed, 02 Jan 2019 16:47:06 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -272,7 +272,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 16:20:09 GMT
+      - Wed, 02 Jan 2019 16:47:07 GMT
       Vary:
       - Origin
       - X-Origin
@@ -296,12 +296,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1Or5sMboIcgKeJeQd9mNBKzIQOjjDqLUV-B4K2OMy7Qo",
+         "id": "1d979wSmJF5WL7Ims0C1WeTfLZnd01_z9Z1nUQunucFI",
          "name": "My Google Drive File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "16QaFynf-Rh2td7nJJXCxbW6_S9Taj3N-"
+          "1yHWESUMQeZUlEL7dSQtOowqwH9RglkCg"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -317,10 +317,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 16:20:10 GMT
+  recorded_at: Wed, 02 Jan 2019 16:47:07 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/16QaFynf-Rh2td7nJJXCxbW6_S9Taj3N-/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1yHWESUMQeZUlEL7dSQtOowqwH9RglkCg/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -332,7 +332,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 16:20:10 GMT
+      - Wed, 02 Jan 2019 16:47:07 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -349,7 +349,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 16:20:10 GMT
+      - Wed, 02 Jan 2019 16:47:08 GMT
       Vary:
       - Origin
       - X-Origin
@@ -379,14 +379,14 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 16:20:11 GMT
+  recorded_at: Wed, 02 Jan 2019 16:47:08 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"4 Tanngrisnir
-        (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"4 Heart of
+        Gold (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -395,7 +395,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 16:20:16 GMT
+      - Wed, 02 Jan 2019 16:47:13 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -412,7 +412,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 16:20:17 GMT
+      - Wed, 02 Jan 2019 16:47:15 GMT
       Vary:
       - Origin
       - X-Origin
@@ -436,8 +436,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1Uzo-9pSgKbngwLi7tSTMVWpnor4G6Knm",
-         "name": "4 Tanngrisnir (Archive)",
+         "id": "1v6nplNJDS7Ahcz-IF_ruaRSKc5ppd9cE",
+         "name": "4 Heart of Gold (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -457,10 +457,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 16:20:17 GMT
+  recorded_at: Wed, 02 Jan 2019 16:47:15 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1Uzo-9pSgKbngwLi7tSTMVWpnor4G6Knm/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1v6nplNJDS7Ahcz-IF_ruaRSKc5ppd9cE/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -472,7 +472,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 16:20:17 GMT
+      - Wed, 02 Jan 2019 16:47:15 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -489,7 +489,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 16:20:18 GMT
+      - Wed, 02 Jan 2019 16:47:16 GMT
       Vary:
       - Origin
       - X-Origin
@@ -519,10 +519,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 16:20:19 GMT
+  recorded_at: Wed, 02 Jan 2019 16:47:16 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1Uzo-9pSgKbngwLi7tSTMVWpnor4G6Knm/permissions
+    uri: https://www.googleapis.com/drive/v3/files/1v6nplNJDS7Ahcz-IF_ruaRSKc5ppd9cE/permissions
     body:
       encoding: UTF-8
       string: '{"role":"reader","type":"anyone"}'
@@ -534,7 +534,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 16:20:19 GMT
+      - Wed, 02 Jan 2019 16:47:16 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -551,7 +551,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 16:20:19 GMT
+      - Wed, 02 Jan 2019 16:47:17 GMT
       Vary:
       - Origin
       - X-Origin
@@ -582,10 +582,10 @@ http_interactions:
          "allowFileDiscovery": false
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 16:20:21 GMT
+  recorded_at: Wed, 02 Jan 2019 16:47:17 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/16QaFynf-Rh2td7nJJXCxbW6_S9Taj3N-?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1yHWESUMQeZUlEL7dSQtOowqwH9RglkCg?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -597,7 +597,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 16:20:21 GMT
+      - Wed, 02 Jan 2019 16:47:17 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -608,9 +608,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 02 Jan 2019 16:20:21 GMT
+      - Wed, 02 Jan 2019 16:47:17 GMT
       Date:
-      - Wed, 02 Jan 2019 16:20:21 GMT
+      - Wed, 02 Jan 2019 16:47:17 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -636,8 +636,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "16QaFynf-Rh2td7nJJXCxbW6_S9Taj3N-",
-         "name": "Test @ 2019-01-02 16:19:56 UTC",
+         "id": "1yHWESUMQeZUlEL7dSQtOowqwH9RglkCg",
+         "name": "Test @ 2019-01-02 16:46:57 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -663,10 +663,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 16:20:22 GMT
+  recorded_at: Wed, 02 Jan 2019 16:47:18 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/16QaFynf-Rh2td7nJJXCxbW6_S9Taj3N-/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1yHWESUMQeZUlEL7dSQtOowqwH9RglkCg/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -678,7 +678,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 16:20:22 GMT
+      - Wed, 02 Jan 2019 16:47:18 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -696,9 +696,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Wed, 02 Jan 2019 16:20:22 GMT
+      - Wed, 02 Jan 2019 16:47:18 GMT
       Expires:
-      - Wed, 02 Jan 2019 16:20:22 GMT
+      - Wed, 02 Jan 2019 16:47:18 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -730,10 +730,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 16:20:22 GMT
+  recorded_at: Wed, 02 Jan 2019 16:47:18 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%2716QaFynf-Rh2td7nJJXCxbW6_S9Taj3N-%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271yHWESUMQeZUlEL7dSQtOowqwH9RglkCg%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -745,7 +745,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 16:20:22 GMT
+      - Wed, 02 Jan 2019 16:47:18 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -756,9 +756,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 02 Jan 2019 16:20:22 GMT
+      - Wed, 02 Jan 2019 16:47:19 GMT
       Date:
-      - Wed, 02 Jan 2019 16:20:22 GMT
+      - Wed, 02 Jan 2019 16:47:19 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -786,14 +786,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1Or5sMboIcgKeJeQd9mNBKzIQOjjDqLUV-B4K2OMy7Qo",
+           "id": "1d979wSmJF5WL7Ims0C1WeTfLZnd01_z9Z1nUQunucFI",
            "name": "My Google Drive File",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "16QaFynf-Rh2td7nJJXCxbW6_S9Taj3N-"
+            "1yHWESUMQeZUlEL7dSQtOowqwH9RglkCg"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Or5sMboIcgKeJeQd9mNBKzIQOjjDqLUV-B4K2OMy7Qo&v=1&s=AMedNnoAAAAAXC0A5iKugCfyKapOv6JE9CwwR5mRXfdw&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1d979wSmJF5WL7Ims0C1WeTfLZnd01_z9Z1nUQunucFI&v=1&s=AMedNnoAAAAAXC0HNs-ret4L6mt--0L3usjyq1xt9XDZ&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -819,10 +819,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 16:20:23 GMT
+  recorded_at: Wed, 02 Jan 2019 16:47:19 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Or5sMboIcgKeJeQd9mNBKzIQOjjDqLUV-B4K2OMy7Qo/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1d979wSmJF5WL7Ims0C1WeTfLZnd01_z9Z1nUQunucFI/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -834,7 +834,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 16:20:23 GMT
+      - Wed, 02 Jan 2019 16:47:19 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -845,9 +845,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 02 Jan 2019 16:20:23 GMT
+      - Wed, 02 Jan 2019 16:47:19 GMT
       Date:
-      - Wed, 02 Jan 2019 16:20:23 GMT
+      - Wed, 02 Jan 2019 16:47:19 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -876,13 +876,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2019-01-02T16:20:08.363Z"
+         "modifiedTime": "2019-01-02T16:47:06.765Z"
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 16:20:23 GMT
+  recorded_at: Wed, 02 Jan 2019 16:47:20 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1Or5sMboIcgKeJeQd9mNBKzIQOjjDqLUV-B4K2OMy7Qo&s=AMedNnoAAAAAXC0A5iKugCfyKapOv6JE9CwwR5mRXfdw&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1d979wSmJF5WL7Ims0C1WeTfLZnd01_z9Z1nUQunucFI&s=AMedNnoAAAAAXC0HNs-ret4L6mt--0L3usjyq1xt9XDZ&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -894,7 +894,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 16:20:23 GMT
+      - Wed, 02 Jan 2019 16:47:20 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -925,7 +925,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Wed, 02 Jan 2019 16:20:25 GMT
+      - Wed, 02 Jan 2019 16:47:20 GMT
       Server:
       - fife
       Content-Length:
@@ -939,13 +939,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 16:20:26 GMT
+  recorded_at: Wed, 02 Jan 2019 16:47:21 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1Or5sMboIcgKeJeQd9mNBKzIQOjjDqLUV-B4K2OMy7Qo/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1d979wSmJF5WL7Ims0C1WeTfLZnd01_z9Z1nUQunucFI/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"My Google Drive File","parents":["1Uzo-9pSgKbngwLi7tSTMVWpnor4G6Knm"]}'
+      string: '{"name":"My Google Drive File","parents":["1v6nplNJDS7Ahcz-IF_ruaRSKc5ppd9cE"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -954,7 +954,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 16:20:26 GMT
+      - Wed, 02 Jan 2019 16:47:21 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -971,7 +971,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 16:20:28 GMT
+      - Wed, 02 Jan 2019 16:47:23 GMT
       Vary:
       - Origin
       - X-Origin
@@ -995,12 +995,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1xQnjpyS97aVmwg8WwUpVKMDNuK8Ch60_Ii1pbqDruTo",
+         "id": "1o9YNNPpfX1AXEacWGV7jh80-TQRfx3oemLWAAlbrI_I",
          "name": "My Google Drive File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1Uzo-9pSgKbngwLi7tSTMVWpnor4G6Knm"
+          "1v6nplNJDS7Ahcz-IF_ruaRSKc5ppd9cE"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1032,10 +1032,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 16:20:28 GMT
+  recorded_at: Wed, 02 Jan 2019 16:47:23 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1xQnjpyS97aVmwg8WwUpVKMDNuK8Ch60_Ii1pbqDruTo?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1o9YNNPpfX1AXEacWGV7jh80-TQRfx3oemLWAAlbrI_I?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1047,7 +1047,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 16:20:28 GMT
+      - Wed, 02 Jan 2019 16:47:23 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1058,9 +1058,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 02 Jan 2019 16:20:28 GMT
+      - Wed, 02 Jan 2019 16:47:23 GMT
       Date:
-      - Wed, 02 Jan 2019 16:20:28 GMT
+      - Wed, 02 Jan 2019 16:47:23 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1086,12 +1086,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1xQnjpyS97aVmwg8WwUpVKMDNuK8Ch60_Ii1pbqDruTo",
+         "id": "1o9YNNPpfX1AXEacWGV7jh80-TQRfx3oemLWAAlbrI_I",
          "name": "My Google Drive File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1Uzo-9pSgKbngwLi7tSTMVWpnor4G6Knm"
+          "1v6nplNJDS7Ahcz-IF_ruaRSKc5ppd9cE"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1123,10 +1123,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 16:20:28 GMT
+  recorded_at: Wed, 02 Jan 2019 16:47:24 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1xQnjpyS97aVmwg8WwUpVKMDNuK8Ch60_Ii1pbqDruTo/export?alt=media&mimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document
+    uri: https://www.googleapis.com/drive/v3/files/1o9YNNPpfX1AXEacWGV7jh80-TQRfx3oemLWAAlbrI_I/export?alt=media&mimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document
     body:
       encoding: UTF-8
       string: ''
@@ -1138,7 +1138,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 16:20:28 GMT
+      - Wed, 02 Jan 2019 16:47:24 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
   response:
@@ -1147,9 +1147,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 02 Jan 2019 16:20:29 GMT
+      - Wed, 02 Jan 2019 16:47:24 GMT
       Date:
-      - Wed, 02 Jan 2019 16:20:29 GMT
+      - Wed, 02 Jan 2019 16:47:24 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Disposition:
@@ -1174,16 +1174,16 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        UEsDBBQACAgIAI5CIk4AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICACOQiJOAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIAI5CIk5JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICACOQiJOj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICACOQiJOrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAjkIiTojORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAI5CIk4B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIAI5CIk6QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgAjkIiTi1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgAjkIiTiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIAI5CIk4zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
+        UEsDBBQACAgIAOxFIk4AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICADsRSJOAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgA7EUiTgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgA7EUiTgAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgA7EUiTgAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgA7EUiTgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgA7EUiTgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgA7EUiTgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgA7EUiTgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIAOxFIk5JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICADsRSJOj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICADsRSJOrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgA7EUiTojORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAOxFIk4B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIAOxFIk6QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgA7EUiTi1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgA7EUiTiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIAOxFIk4zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 16:20:29 GMT
+  recorded_at: Wed, 02 Jan 2019 16:47:24 GMT
 - request:
     method: put
     uri: http://localhost:9998/tika
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        UEsDBBQACAgIAI5CIk4AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICACOQiJOAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIAI5CIk5JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICACOQiJOj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICACOQiJOrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAjkIiTojORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAI5CIk4B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIAI5CIk6QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgAjkIiTi1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgAjkIiTiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIAI5CIk4zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
+        UEsDBBQACAgIAOxFIk4AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICADsRSJOAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgA7EUiTgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgA7EUiTgAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgA7EUiTgAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgA7EUiTgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgA7EUiTgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgA7EUiTgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgA7EUiTgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIAOxFIk5JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICADsRSJOj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICADsRSJOrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgA7EUiTojORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAOxFIk4B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIAOxFIk6QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgA7EUiTi1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgA7EUiTiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIAOxFIk4zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -1201,7 +1201,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 02 Jan 2019 16:20:29 GMT
+      - Wed, 02 Jan 2019 16:47:24 GMT
       Content-Type:
       - text/html
       Transfer-Encoding:
@@ -1224,10 +1224,10 @@ http_interactions:
         </body>
         </html>
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 16:20:29 GMT
+  recorded_at: Wed, 02 Jan 2019 16:47:24 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1xQnjpyS97aVmwg8WwUpVKMDNuK8Ch60_Ii1pbqDruTo?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1v6nplNJDS7Ahcz-IF_ruaRSKc5ppd9cE/permissions?fields=permissions/id,%20permissions/emailAddress,%20permissions/type
     body:
       encoding: UTF-8
       string: ''
@@ -1239,9 +1239,9 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 16:20:34 GMT
+      - Wed, 02 Jan 2019 16:47:24 GMT
       Authorization:
-      - Bearer <ACCESS TOKEN FOR COLLABORATOR ACCOUNT>
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
       - application/x-www-form-urlencoded
   response:
@@ -1250,9 +1250,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Wed, 02 Jan 2019 16:20:34 GMT
+      - Wed, 02 Jan 2019 16:47:25 GMT
       Date:
-      - Wed, 02 Jan 2019 16:20:34 GMT
+      - Wed, 02 Jan 2019 16:47:25 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1278,18 +1278,28 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1xQnjpyS97aVmwg8WwUpVKMDNuK8Ch60_Ii1pbqDruTo",
-         "name": "My Google Drive File",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1xQnjpyS97aVmwg8WwUpVKMDNuK8Ch60_Ii1pbqDruTo&v=1&s=AMedNnoAAAAAXC0A8goq3CpvtbzR9VzFQ-r6wD_JRZsH&sz=s220",
-         "thumbnailVersion": "1"
+         "permissions": [
+          {
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>"
+          },
+          {
+           "id": "anyoneWithLink",
+           "type": "anyone"
+          },
+          {
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>"
+          }
+         ]
         }
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 16:20:35 GMT
+  recorded_at: Wed, 02 Jan 2019 16:47:25 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/16QaFynf-Rh2td7nJJXCxbW6_S9Taj3N-
+    uri: https://www.googleapis.com/drive/v3/files/1v6nplNJDS7Ahcz-IF_ruaRSKc5ppd9cE/permissions/anyoneWithLink
     body:
       encoding: UTF-8
       string: ''
@@ -1301,7 +1311,120 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Wed, 02 Jan 2019 16:20:35 GMT
+      - Wed, 02 Jan 2019 16:47:25 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 02 Jan 2019 16:47:26 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 16:47:26 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1o9YNNPpfX1AXEacWGV7jh80-TQRfx3oemLWAAlbrI_I?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 02 Jan 2019 16:47:38 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR COLLABORATOR ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Wed, 02 Jan 2019 16:47:38 GMT
+      Expires:
+      - Wed, 02 Jan 2019 16:47:38 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "notFound",
+            "message": "File not found: 1o9YNNPpfX1AXEacWGV7jh80-TQRfx3oemLWAAlbrI_I.",
+            "locationType": "parameter",
+            "location": "fileId"
+           }
+          ],
+          "code": 404,
+          "message": "File not found: 1o9YNNPpfX1AXEacWGV7jh80-TQRfx3oemLWAAlbrI_I."
+         }
+        }
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 16:47:38 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1yHWESUMQeZUlEL7dSQtOowqwH9RglkCg
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 02 Jan 2019 16:47:38 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1318,7 +1441,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Wed, 02 Jan 2019 16:20:35 GMT
+      - Wed, 02 Jan 2019 16:47:39 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1330,5 +1453,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 02 Jan 2019 16:20:35 GMT
+  recorded_at: Wed, 02 Jan 2019 16:47:39 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Visitors_As_a_guest/non-collaborator/when_project_has_an_archive/when_project_is_made_private/I_no_longer_have_read_access_to_the_archive.yml
+++ b/spec/support/fixtures/vcr_cassettes/Visitors_As_a_guest/non-collaborator/when_project_has_an_archive/when_project_is_made_private/I_no_longer_have_read_access_to_the_archive.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Fri, 28 Dec 2018 14:03:01 GMT
+      - Wed, 02 Jan 2019 16:19:42 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:03:01 GMT
+  recorded_at: Wed, 02 Jan 2019 16:19:44 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Fri, 28 Dec 2018 14:03:01 GMT
+      - Wed, 02 Jan 2019 16:19:52 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:03:01 GMT
+  recorded_at: Wed, 02 Jan 2019 16:19:56 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-12-28
-        14:03:01 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2019-01-02
+        16:19:56 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:03:01 GMT
+      - Wed, 02 Jan 2019 16:19:56 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 28 Dec 2018 14:03:02 GMT
+      - Wed, 02 Jan 2019 16:20:02 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1PJJ2wUIcv9cE59L1uSSXAadYdkQmR11e",
-         "name": "Test @ 2018-12-28 14:03:01 UTC",
+         "id": "16QaFynf-Rh2td7nJJXCxbW6_S9Taj3N-",
+         "name": "Test @ 2019-01-02 16:19:56 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,7 +185,7 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:03:02 GMT
+  recorded_at: Wed, 02 Jan 2019 16:20:03 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -214,7 +214,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Fri, 28 Dec 2018 14:03:02 GMT
+      - Wed, 02 Jan 2019 16:20:06 GMT
       Server:
       - ESF
       Cache-Control:
@@ -239,14 +239,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:03:02 GMT
+  recorded_at: Wed, 02 Jan 2019 16:20:07 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: '{"mimeType":"application/vnd.google-apps.document","name":"My Google
-        Drive File","parents":["1PJJ2wUIcv9cE59L1uSSXAadYdkQmR11e"]}'
+        Drive File","parents":["16QaFynf-Rh2td7nJJXCxbW6_S9Taj3N-"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -255,7 +255,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:03:02 GMT
+      - Wed, 02 Jan 2019 16:20:07 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -272,7 +272,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 28 Dec 2018 14:03:04 GMT
+      - Wed, 02 Jan 2019 16:20:09 GMT
       Vary:
       - Origin
       - X-Origin
@@ -296,12 +296,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1bd_lLEk5TF89ugF1VpHDDGlrXZTa7NYmUm4pNtEFwp4",
+         "id": "1Or5sMboIcgKeJeQd9mNBKzIQOjjDqLUV-B4K2OMy7Qo",
          "name": "My Google Drive File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1PJJ2wUIcv9cE59L1uSSXAadYdkQmR11e"
+          "16QaFynf-Rh2td7nJJXCxbW6_S9Taj3N-"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -317,10 +317,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:03:04 GMT
+  recorded_at: Wed, 02 Jan 2019 16:20:10 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1PJJ2wUIcv9cE59L1uSSXAadYdkQmR11e/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/16QaFynf-Rh2td7nJJXCxbW6_S9Taj3N-/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -332,7 +332,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:03:04 GMT
+      - Wed, 02 Jan 2019 16:20:10 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -349,7 +349,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 28 Dec 2018 14:03:04 GMT
+      - Wed, 02 Jan 2019 16:20:10 GMT
       Vary:
       - Origin
       - X-Origin
@@ -379,14 +379,14 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:03:04 GMT
+  recorded_at: Wed, 02 Jan 2019 16:20:11 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"5 Starship
-        Titanic (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"4 Tanngrisnir
+        (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -395,7 +395,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:03:10 GMT
+      - Wed, 02 Jan 2019 16:20:16 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -412,7 +412,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 28 Dec 2018 14:03:10 GMT
+      - Wed, 02 Jan 2019 16:20:17 GMT
       Vary:
       - Origin
       - X-Origin
@@ -436,8 +436,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1E9PmCY9ne0QoqC_Y0BrA9wOsauCARS7P",
-         "name": "5 Starship Titanic (Archive)",
+         "id": "1Uzo-9pSgKbngwLi7tSTMVWpnor4G6Knm",
+         "name": "4 Tanngrisnir (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -457,10 +457,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:03:10 GMT
+  recorded_at: Wed, 02 Jan 2019 16:20:17 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1E9PmCY9ne0QoqC_Y0BrA9wOsauCARS7P/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1Uzo-9pSgKbngwLi7tSTMVWpnor4G6Knm/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -472,7 +472,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:03:10 GMT
+      - Wed, 02 Jan 2019 16:20:17 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -489,7 +489,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 28 Dec 2018 14:03:11 GMT
+      - Wed, 02 Jan 2019 16:20:18 GMT
       Vary:
       - Origin
       - X-Origin
@@ -519,10 +519,73 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:03:11 GMT
+  recorded_at: Wed, 02 Jan 2019 16:20:19 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1Uzo-9pSgKbngwLi7tSTMVWpnor4G6Knm/permissions
+    body:
+      encoding: UTF-8
+      string: '{"role":"reader","type":"anyone"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Wed, 02 Jan 2019 16:20:19 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Wed, 02 Jan 2019 16:20:19 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "anyoneWithLink",
+         "type": "anyone",
+         "role": "reader",
+         "allowFileDiscovery": false
+        }
+    http_version: 
+  recorded_at: Wed, 02 Jan 2019 16:20:21 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1PJJ2wUIcv9cE59L1uSSXAadYdkQmR11e?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/16QaFynf-Rh2td7nJJXCxbW6_S9Taj3N-?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -534,7 +597,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:03:11 GMT
+      - Wed, 02 Jan 2019 16:20:21 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -545,9 +608,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Fri, 28 Dec 2018 14:03:11 GMT
+      - Wed, 02 Jan 2019 16:20:21 GMT
       Date:
-      - Fri, 28 Dec 2018 14:03:11 GMT
+      - Wed, 02 Jan 2019 16:20:21 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -573,8 +636,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1PJJ2wUIcv9cE59L1uSSXAadYdkQmR11e",
-         "name": "Test @ 2018-12-28 14:03:01 UTC",
+         "id": "16QaFynf-Rh2td7nJJXCxbW6_S9Taj3N-",
+         "name": "Test @ 2019-01-02 16:19:56 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -600,10 +663,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:03:11 GMT
+  recorded_at: Wed, 02 Jan 2019 16:20:22 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1PJJ2wUIcv9cE59L1uSSXAadYdkQmR11e/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/16QaFynf-Rh2td7nJJXCxbW6_S9Taj3N-/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -615,7 +678,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:03:11 GMT
+      - Wed, 02 Jan 2019 16:20:22 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -633,9 +696,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Fri, 28 Dec 2018 14:03:12 GMT
+      - Wed, 02 Jan 2019 16:20:22 GMT
       Expires:
-      - Fri, 28 Dec 2018 14:03:12 GMT
+      - Wed, 02 Jan 2019 16:20:22 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -667,10 +730,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:03:12 GMT
+  recorded_at: Wed, 02 Jan 2019 16:20:22 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271PJJ2wUIcv9cE59L1uSSXAadYdkQmR11e%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%2716QaFynf-Rh2td7nJJXCxbW6_S9Taj3N-%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -682,7 +745,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:03:12 GMT
+      - Wed, 02 Jan 2019 16:20:22 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -693,9 +756,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Fri, 28 Dec 2018 14:03:12 GMT
+      - Wed, 02 Jan 2019 16:20:22 GMT
       Date:
-      - Fri, 28 Dec 2018 14:03:12 GMT
+      - Wed, 02 Jan 2019 16:20:22 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -723,14 +786,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1bd_lLEk5TF89ugF1VpHDDGlrXZTa7NYmUm4pNtEFwp4",
+           "id": "1Or5sMboIcgKeJeQd9mNBKzIQOjjDqLUV-B4K2OMy7Qo",
            "name": "My Google Drive File",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1PJJ2wUIcv9cE59L1uSSXAadYdkQmR11e"
+            "16QaFynf-Rh2td7nJJXCxbW6_S9Taj3N-"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1bd_lLEk5TF89ugF1VpHDDGlrXZTa7NYmUm4pNtEFwp4&v=1&s=AMedNnoAAAAAXCZJQMb8otWUQdqlg2nhzEHWDQG4GPWj&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Or5sMboIcgKeJeQd9mNBKzIQOjjDqLUV-B4K2OMy7Qo&v=1&s=AMedNnoAAAAAXC0A5iKugCfyKapOv6JE9CwwR5mRXfdw&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -756,10 +819,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:03:12 GMT
+  recorded_at: Wed, 02 Jan 2019 16:20:23 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1bd_lLEk5TF89ugF1VpHDDGlrXZTa7NYmUm4pNtEFwp4/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1Or5sMboIcgKeJeQd9mNBKzIQOjjDqLUV-B4K2OMy7Qo/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -771,7 +834,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:03:12 GMT
+      - Wed, 02 Jan 2019 16:20:23 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -782,9 +845,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Fri, 28 Dec 2018 14:03:12 GMT
+      - Wed, 02 Jan 2019 16:20:23 GMT
       Date:
-      - Fri, 28 Dec 2018 14:03:12 GMT
+      - Wed, 02 Jan 2019 16:20:23 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -813,13 +876,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-12-28T14:03:02.984Z"
+         "modifiedTime": "2019-01-02T16:20:08.363Z"
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:03:12 GMT
+  recorded_at: Wed, 02 Jan 2019 16:20:23 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1bd_lLEk5TF89ugF1VpHDDGlrXZTa7NYmUm4pNtEFwp4&s=AMedNnoAAAAAXCZJQMb8otWUQdqlg2nhzEHWDQG4GPWj&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1Or5sMboIcgKeJeQd9mNBKzIQOjjDqLUV-B4K2OMy7Qo&s=AMedNnoAAAAAXC0A5iKugCfyKapOv6JE9CwwR5mRXfdw&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -831,7 +894,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:03:12 GMT
+      - Wed, 02 Jan 2019 16:20:23 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -862,7 +925,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Fri, 28 Dec 2018 14:03:13 GMT
+      - Wed, 02 Jan 2019 16:20:25 GMT
       Server:
       - fife
       Content-Length:
@@ -876,13 +939,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:03:13 GMT
+  recorded_at: Wed, 02 Jan 2019 16:20:26 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1bd_lLEk5TF89ugF1VpHDDGlrXZTa7NYmUm4pNtEFwp4/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1Or5sMboIcgKeJeQd9mNBKzIQOjjDqLUV-B4K2OMy7Qo/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"My Google Drive File","parents":["1E9PmCY9ne0QoqC_Y0BrA9wOsauCARS7P"]}'
+      string: '{"name":"My Google Drive File","parents":["1Uzo-9pSgKbngwLi7tSTMVWpnor4G6Knm"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -891,7 +954,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:03:13 GMT
+      - Wed, 02 Jan 2019 16:20:26 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -908,7 +971,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 28 Dec 2018 14:03:15 GMT
+      - Wed, 02 Jan 2019 16:20:28 GMT
       Vary:
       - Origin
       - X-Origin
@@ -932,12 +995,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1ZEzcBRN04QbW2jbR6aMOD3KmqzxRBtv6u3OMJGcbBVY",
+         "id": "1xQnjpyS97aVmwg8WwUpVKMDNuK8Ch60_Ii1pbqDruTo",
          "name": "My Google Drive File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1E9PmCY9ne0QoqC_Y0BrA9wOsauCARS7P"
+          "1Uzo-9pSgKbngwLi7tSTMVWpnor4G6Knm"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -952,6 +1015,13 @@ http_interactions:
           },
           {
            "kind": "drive#permission",
+           "id": "anyoneWithLink",
+           "type": "anyone",
+           "role": "reader",
+           "allowFileDiscovery": false
+          },
+          {
+           "kind": "drive#permission",
            "id": "11673017242486491425",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
@@ -962,10 +1032,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:03:15 GMT
+  recorded_at: Wed, 02 Jan 2019 16:20:28 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1ZEzcBRN04QbW2jbR6aMOD3KmqzxRBtv6u3OMJGcbBVY?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1xQnjpyS97aVmwg8WwUpVKMDNuK8Ch60_Ii1pbqDruTo?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -977,7 +1047,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:03:15 GMT
+      - Wed, 02 Jan 2019 16:20:28 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -988,9 +1058,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Fri, 28 Dec 2018 14:03:15 GMT
+      - Wed, 02 Jan 2019 16:20:28 GMT
       Date:
-      - Fri, 28 Dec 2018 14:03:15 GMT
+      - Wed, 02 Jan 2019 16:20:28 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1016,12 +1086,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1ZEzcBRN04QbW2jbR6aMOD3KmqzxRBtv6u3OMJGcbBVY",
+         "id": "1xQnjpyS97aVmwg8WwUpVKMDNuK8Ch60_Ii1pbqDruTo",
          "name": "My Google Drive File",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1E9PmCY9ne0QoqC_Y0BrA9wOsauCARS7P"
+          "1Uzo-9pSgKbngwLi7tSTMVWpnor4G6Knm"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1036,6 +1106,13 @@ http_interactions:
           },
           {
            "kind": "drive#permission",
+           "id": "anyoneWithLink",
+           "type": "anyone",
+           "role": "reader",
+           "allowFileDiscovery": false
+          },
+          {
+           "kind": "drive#permission",
            "id": "11673017242486491425",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
@@ -1046,10 +1123,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:03:15 GMT
+  recorded_at: Wed, 02 Jan 2019 16:20:28 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1ZEzcBRN04QbW2jbR6aMOD3KmqzxRBtv6u3OMJGcbBVY/export?alt=media&mimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document
+    uri: https://www.googleapis.com/drive/v3/files/1xQnjpyS97aVmwg8WwUpVKMDNuK8Ch60_Ii1pbqDruTo/export?alt=media&mimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document
     body:
       encoding: UTF-8
       string: ''
@@ -1061,7 +1138,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:03:15 GMT
+      - Wed, 02 Jan 2019 16:20:28 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
   response:
@@ -1070,9 +1147,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Fri, 28 Dec 2018 14:03:15 GMT
+      - Wed, 02 Jan 2019 16:20:29 GMT
       Date:
-      - Fri, 28 Dec 2018 14:03:15 GMT
+      - Wed, 02 Jan 2019 16:20:29 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Disposition:
@@ -1097,16 +1174,16 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        UEsDBBQACAgIAGcwnE0AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICABnMJxNAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIAGcwnE1JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICABnMJxNj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICABnMJxNrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAZzCcTYjORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAGcwnE0B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIAGcwnE2QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgAZzCcTS1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgAZzCcTSFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIAGcwnE0zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
+        UEsDBBQACAgIAI5CIk4AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICACOQiJOAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIAI5CIk5JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICACOQiJOj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICACOQiJOrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAjkIiTojORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAI5CIk4B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIAI5CIk6QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgAjkIiTi1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgAjkIiTiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIAI5CIk4zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:03:15 GMT
+  recorded_at: Wed, 02 Jan 2019 16:20:29 GMT
 - request:
     method: put
     uri: http://localhost:9998/tika
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        UEsDBBQACAgIAGcwnE0AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICABnMJxNAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIAGcwnE1JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICABnMJxNj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICABnMJxNrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAZzCcTYjORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAGcwnE0B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIAGcwnE2QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgAZzCcTS1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgAZzCcTSFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIAGcwnE0zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
+        UEsDBBQACAgIAI5CIk4AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICACOQiJOAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgAjkIiTgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIAI5CIk5JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICACOQiJOj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICACOQiJOrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAjkIiTojORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAI5CIk4B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIAI5CIk6QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgAjkIiTi1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgAjkIiTiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIAI5CIk4zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -1124,7 +1201,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Dec 2018 14:03:15 GMT
+      - Wed, 02 Jan 2019 16:20:29 GMT
       Content-Type:
       - text/html
       Transfer-Encoding:
@@ -1147,10 +1224,10 @@ http_interactions:
         </body>
         </html>
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:03:15 GMT
+  recorded_at: Wed, 02 Jan 2019 16:20:29 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1ZEzcBRN04QbW2jbR6aMOD3KmqzxRBtv6u3OMJGcbBVY?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1xQnjpyS97aVmwg8WwUpVKMDNuK8Ch60_Ii1pbqDruTo?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1162,16 +1239,22 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:03:21 GMT
+      - Wed, 02 Jan 2019 16:20:34 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR COLLABORATOR ACCOUNT>
       Content-Type:
       - application/x-www-form-urlencoded
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 200
+      message: OK
     headers:
+      Expires:
+      - Wed, 02 Jan 2019 16:20:34 GMT
+      Date:
+      - Wed, 02 Jan 2019 16:20:34 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
       Vary:
       - Origin
       - X-Origin
@@ -1179,12 +1262,6 @@ http_interactions:
       - application/json; charset=UTF-8
       Content-Encoding:
       - gzip
-      Date:
-      - Fri, 28 Dec 2018 14:03:21 GMT
-      Expires:
-      - Fri, 28 Dec 2018 14:03:21 GMT
-      Cache-Control:
-      - private, max-age=0
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -1201,25 +1278,18 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "notFound",
-            "message": "File not found: 1ZEzcBRN04QbW2jbR6aMOD3KmqzxRBtv6u3OMJGcbBVY.",
-            "locationType": "parameter",
-            "location": "fileId"
-           }
-          ],
-          "code": 404,
-          "message": "File not found: 1ZEzcBRN04QbW2jbR6aMOD3KmqzxRBtv6u3OMJGcbBVY."
-         }
+         "id": "1xQnjpyS97aVmwg8WwUpVKMDNuK8Ch60_Ii1pbqDruTo",
+         "name": "My Google Drive File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1xQnjpyS97aVmwg8WwUpVKMDNuK8Ch60_Ii1pbqDruTo&v=1&s=AMedNnoAAAAAXC0A8goq3CpvtbzR9VzFQ-r6wD_JRZsH&sz=s220",
+         "thumbnailVersion": "1"
         }
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:03:21 GMT
+  recorded_at: Wed, 02 Jan 2019 16:20:35 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1PJJ2wUIcv9cE59L1uSSXAadYdkQmR11e
+    uri: https://www.googleapis.com/drive/v3/files/16QaFynf-Rh2td7nJJXCxbW6_S9Taj3N-
     body:
       encoding: UTF-8
       string: ''
@@ -1231,7 +1301,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 28 Dec 2018 14:03:21 GMT
+      - Wed, 02 Jan 2019 16:20:35 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -1248,7 +1318,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 28 Dec 2018 14:03:22 GMT
+      - Wed, 02 Jan 2019 16:20:35 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1260,5 +1330,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 28 Dec 2018 14:03:22 GMT
+  recorded_at: Wed, 02 Jan 2019 16:20:35 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Visitors_As_a_guest/non-collaborator/when_project_has_an_archive/when_project_is_made_private/I_no_longer_have_read_access_to_the_archive.yml
+++ b/spec/support/fixtures/vcr_cassettes/Visitors_As_a_guest/non-collaborator/when_project_has_an_archive/when_project_is_made_private/I_no_longer_have_read_access_to_the_archive.yml
@@ -1,0 +1,1264 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://oauth2.googleapis.com/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR TRACKING ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Fri, 28 Dec 2018 14:03:01 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:03:01 GMT
+- request:
+    method: post
+    uri: https://oauth2.googleapis.com/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR USER ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Fri, 28 Dec 2018 14:03:01 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR USER ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:03:01 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-12-28
+        14:03:01 UTC","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:03:01 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 28 Dec 2018 14:03:02 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1PJJ2wUIcv9cE59L1uSSXAadYdkQmR11e",
+         "name": "Test @ 2018-12-28 14:03:01 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AEIi2L68pCuiUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:03:02 GMT
+- request:
+    method: post
+    uri: https://oauth2.googleapis.com/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR COLLABORATOR
+        ACCOUNT>&client_id=<CLIENT ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Fri, 28 Dec 2018 14:03:02 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR COLLABORATOR ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:03:02 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"My Google
+        Drive File","parents":["1PJJ2wUIcv9cE59L1uSSXAadYdkQmR11e"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:03:02 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 28 Dec 2018 14:03:04 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1bd_lLEk5TF89ugF1VpHDDGlrXZTa7NYmUm4pNtEFwp4",
+         "name": "My Google Drive File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1PJJ2wUIcv9cE59L1uSSXAadYdkQmR11e"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:03:04 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1PJJ2wUIcv9cE59L1uSSXAadYdkQmR11e/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:03:04 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 28 Dec 2018 14:03:04 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "11673017242486491425",
+         "type": "user",
+         "role": "writer"
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:03:04 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"5 Starship
+        Titanic (Archive)","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:03:10 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 28 Dec 2018 14:03:10 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1E9PmCY9ne0QoqC_Y0BrA9wOsauCARS7P",
+         "name": "5 Starship Titanic (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:03:10 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1E9PmCY9ne0QoqC_Y0BrA9wOsauCARS7P/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:03:10 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 28 Dec 2018 14:03:11 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "13193959451567607887",
+         "type": "user",
+         "role": "reader"
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:03:11 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1PJJ2wUIcv9cE59L1uSSXAadYdkQmR11e?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:03:11 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 28 Dec 2018 14:03:11 GMT
+      Date:
+      - Fri, 28 Dec 2018 14:03:11 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1PJJ2wUIcv9cE59L1uSSXAadYdkQmR11e",
+         "name": "Test @ 2018-12-28 14:03:01 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:03:11 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1PJJ2wUIcv9cE59L1uSSXAadYdkQmR11e/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:03:11 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Fri, 28 Dec 2018 14:03:12 GMT
+      Expires:
+      - Fri, 28 Dec 2018 14:03:12 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:03:12 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271PJJ2wUIcv9cE59L1uSSXAadYdkQmR11e%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:03:12 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 28 Dec 2018 14:03:12 GMT
+      Date:
+      - Fri, 28 Dec 2018 14:03:12 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "files": [
+          {
+           "id": "1bd_lLEk5TF89ugF1VpHDDGlrXZTa7NYmUm4pNtEFwp4",
+           "name": "My Google Drive File",
+           "mimeType": "application/vnd.google-apps.document",
+           "trashed": false,
+           "parents": [
+            "1PJJ2wUIcv9cE59L1uSSXAadYdkQmR11e"
+           ],
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1bd_lLEk5TF89ugF1VpHDDGlrXZTa7NYmUm4pNtEFwp4&v=1&s=AMedNnoAAAAAXCZJQMb8otWUQdqlg2nhzEHWDQG4GPWj&sz=s220",
+           "thumbnailVersion": "1",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "writer",
+             "displayName": "Upshift One",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "13193959451567607887",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+             "role": "owner",
+             "displayName": "Testuser Upshift One",
+             "deleted": false
+            }
+           ]
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:03:12 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1bd_lLEk5TF89ugF1VpHDDGlrXZTa7NYmUm4pNtEFwp4/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:03:12 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 28 Dec 2018 14:03:12 GMT
+      Date:
+      - Fri, 28 Dec 2018 14:03:12 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2018-12-28T14:03:02.984Z"
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:03:12 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1bd_lLEk5TF89ugF1VpHDDGlrXZTa7NYmUm4pNtEFwp4&s=AMedNnoAAAAAXCZJQMb8otWUQdqlg2nhzEHWDQG4GPWj&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:03:12 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Fri, 28 Dec 2018 14:03:13 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:03:13 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1bd_lLEk5TF89ugF1VpHDDGlrXZTa7NYmUm4pNtEFwp4/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"My Google Drive File","parents":["1E9PmCY9ne0QoqC_Y0BrA9wOsauCARS7P"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:03:13 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 28 Dec 2018 14:03:15 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1ZEzcBRN04QbW2jbR6aMOD3KmqzxRBtv6u3OMJGcbBVY",
+         "name": "My Google Drive File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1E9PmCY9ne0QoqC_Y0BrA9wOsauCARS7P"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:03:15 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1ZEzcBRN04QbW2jbR6aMOD3KmqzxRBtv6u3OMJGcbBVY?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:03:15 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 28 Dec 2018 14:03:15 GMT
+      Date:
+      - Fri, 28 Dec 2018 14:03:15 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1ZEzcBRN04QbW2jbR6aMOD3KmqzxRBtv6u3OMJGcbBVY",
+         "name": "My Google Drive File",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1E9PmCY9ne0QoqC_Y0BrA9wOsauCARS7P"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:03:15 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1ZEzcBRN04QbW2jbR6aMOD3KmqzxRBtv6u3OMJGcbBVY/export?alt=media&mimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:03:15 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Fri, 28 Dec 2018 14:03:15 GMT
+      Date:
+      - Fri, 28 Dec 2018 14:03:15 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Disposition:
+      - attachment
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/vnd.openxmlformats-officedocument.wordprocessingml.document
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '6061'
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        UEsDBBQACAgIAGcwnE0AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICABnMJxNAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIAGcwnE1JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICABnMJxNj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICABnMJxNrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAZzCcTYjORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAGcwnE0B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIAGcwnE2QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgAZzCcTS1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgAZzCcTSFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIAGcwnE0zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:03:15 GMT
+- request:
+    method: put
+    uri: http://localhost:9998/tika
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        UEsDBBQACAgIAGcwnE0AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICABnMJxNAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgAZzCcTQAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIAGcwnE1JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICABnMJxNj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICABnMJxNrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAZzCcTYjORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAGcwnE0B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIAGcwnE2QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgAZzCcTS1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgAZzCcTSFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIAGcwnE0zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - text/html
+      User-Agent:
+      - Ruby
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/octet-stream
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 28 Dec 2018 14:03:15 GMT
+      Content-Type:
+      - text/html
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(9.4.z-SNAPSHOT)
+    body:
+      encoding: UTF-8
+      string: |
+        <html xmlns="http://www.w3.org/1999/xhtml">
+        <head>
+        <meta name="X-Parsed-By" content="org.apache.tika.parser.DefaultParser"/>
+        <meta name="X-Parsed-By" content="org.apache.tika.parser.microsoft.ooxml.OOXMLParser"/>
+        <meta name="Content-Type" content="application/vnd.openxmlformats-officedocument.wordprocessingml.document"/>
+        <title>
+        </title>
+        </head>
+        <body>
+        <p/>
+        </body>
+        </html>
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:03:15 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1ZEzcBRN04QbW2jbR6aMOD3KmqzxRBtv6u3OMJGcbBVY?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:03:21 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR COLLABORATOR ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Fri, 28 Dec 2018 14:03:21 GMT
+      Expires:
+      - Fri, 28 Dec 2018 14:03:21 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "notFound",
+            "message": "File not found: 1ZEzcBRN04QbW2jbR6aMOD3KmqzxRBtv6u3OMJGcbBVY.",
+            "locationType": "parameter",
+            "location": "fileId"
+           }
+          ],
+          "code": 404,
+          "message": "File not found: 1ZEzcBRN04QbW2jbR6aMOD3KmqzxRBtv6u3OMJGcbBVY."
+         }
+        }
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:03:21 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1PJJ2wUIcv9cE59L1uSSXAadYdkQmR11e
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Fri, 28 Dec 2018 14:03:21 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Fri, 28 Dec 2018 14:03:22 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39,35"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 28 Dec 2018 14:03:22 GMT
+recorded_with: VCR 4.0.0

--- a/spec/support/helpers/features_helper.rb
+++ b/spec/support/helpers/features_helper.rb
@@ -9,4 +9,9 @@ module FeaturesHelper
     fill_in 'Password', with: account.password
     click_on 'Log in'
   end
+
+  # signs out the account
+  def sign_out
+    visit '/logout'
+  end
 end

--- a/spec/views/file_infos/index_spec.rb
+++ b/spec/views/file_infos/index_spec.rb
@@ -292,19 +292,28 @@ RSpec.describe 'file_infos/index', type: :view do
           .and_return true
       end
 
-      it 'has restore action for diff 1' do
+      it 'does not have restore action' do
         render
-        restore_action = profile_project_file_restores_path(
-          project.owner, project, committed_file_diffs.first.new_version
-        )
+        expect(rendered).not_to have_text('Restore')
+      end
 
-        expect(rendered).to have_css(
-          'form'\
-          "[action='#{restore_action}']"\
-          "[method='post']",
-          text: 'Restore',
-          count: 1
-        )
+      context 'when current user can restore files' do
+        before { assign(:user_can_restore_files, true) }
+
+        it 'has restore action for diff 1' do
+          render
+          restore_action = profile_project_file_restores_path(
+            project.owner, project, committed_file_diffs.first.new_version
+          )
+
+          expect(rendered).to have_css(
+            'form'\
+            "[action='#{restore_action}']"\
+            "[method='post']",
+            text: 'Restore',
+            count: 1
+          )
+        end
       end
     end
   end

--- a/spec/views/file_infos/index_spec.rb
+++ b/spec/views/file_infos/index_spec.rb
@@ -18,12 +18,6 @@ RSpec.describe 'file_infos/index', type: :view do
     assign(:committed_file_diffs, committed_file_diffs)
   end
 
-  it 'renders that the file has been deleted from the project' do
-    render
-    expect(rendered)
-      .to have_text "This file has been deleted from #{project.title}."
-  end
-
   it 'does not have a link to the file on Google Drive' do
     render
     expect(rendered).not_to have_link 'Open in Drive'
@@ -39,6 +33,16 @@ RSpec.describe 'file_infos/index', type: :view do
     expect(rendered).to have_text 'No previous versions of this file exist.'
   end
 
+  context 'when current user can view files in branches' do
+    before { assign(:user_can_view_file_in_branch, true) }
+
+    it 'renders that the file has been deleted from the project' do
+      render
+      expect(rendered)
+        .to have_text "This file has been deleted from #{project.title}."
+    end
+  end
+
   context 'when uncaptured file diff is present' do
     let(:uncaptured_file_diff) do
       build_stubbed :vcs_file_diff,
@@ -47,25 +51,14 @@ RSpec.describe 'file_infos/index', type: :view do
     let(:version) { build_stubbed :vcs_version, name: 'My Document' }
     let(:parent_in_branch) { build_stubbed :vcs_file_in_branch, :folder }
 
-    it 'has a link to the file on Google Drive' do
+    it 'does not have a link to the file on Google Drive' do
       render
-      expect(rendered).to have_link 'Open in Drive',
-                                    href: uncaptured_file_diff.link_to_remote
+      expect(rendered).not_to have_link 'Open in Drive'
     end
 
-    it 'renders that the file has been unchanged since the last revision' do
+    it 'does not have a link to the parent folder' do
       render
-      expect(rendered).to have_text 'New Changes (since last revision)'
-      expect(rendered).to have_text(
-        'No changes have been made to this file since the last revision'
-      )
-    end
-
-    it 'has a link to the parent folder' do
-      render
-      link = profile_project_folder_path(project.owner, project,
-                                         parent_in_branch.hashed_file_id)
-      expect(rendered).to have_link 'Open Parent Folder', href: link
+      expect(rendered).not_to have_link 'Open Parent Folder'
     end
 
     it 'does not have a button to force sync the file' do
@@ -83,82 +76,109 @@ RSpec.describe 'file_infos/index', type: :view do
       )
     end
 
-    context 'when parent is root folder' do
-      let(:parent_in_branch) { build_stubbed :vcs_file_in_branch, :root }
+    context 'when current user can view files in branches' do
+      before { assign(:user_can_view_file_in_branch, true) }
 
-      it 'has a link to the root folder' do
+      it 'has a link to the file on Google Drive' do
         render
-        link = profile_project_root_folder_path(project.owner, project)
-        expect(rendered).to have_link 'Open Home Folder', href: link
-      end
-    end
-
-    context 'when uncaptured file diff has changes' do
-      before do
-        allow(uncaptured_file_diff).to receive(:change_types)
-          .and_return %i[addition modification movement rename deletion]
-        allow(uncaptured_file_diff).to receive(:ancestor_path).and_return 'Home'
+        expect(rendered).to have_link 'Open in Drive',
+                                      href: uncaptured_file_diff.link_to_remote
       end
 
-      it 'renders uncaptured changes' do
+      it 'renders that the file has been unchanged since the last revision' do
         render
-        expect(rendered).to have_text 'My Document added to Home'
+        expect(rendered).to have_text 'New Changes (since last revision)'
         expect(rendered).to have_text(
-          'My Document renamed from ' \
-          "'#{uncaptured_file_diff.previous_name}' in Home"
+          'No changes have been made to this file since the last revision'
         )
-        expect(rendered).to have_text 'My Document modified in Home'
-        expect(rendered).to have_text 'My Document moved to Home'
-        expect(rendered).to have_text 'My Document deleted from Home'
       end
 
-      context 'when diff is modification and has content change' do
-        let(:content_change) do
-          VCS::Operations::ContentDiffer.new(
-            new_content: 'hi',
-            old_content: 'bye'
-          )
-        end
-
-        before do
-          allow(uncaptured_file_diff).to receive(:modification?).and_return true
-          allow(uncaptured_file_diff)
-            .to receive(:content_change).and_return content_change
-        end
-
-        it 'shows the diff' do
-          render
-          expect(rendered).to have_css('.fragment.addition', text: 'hi')
-          expect(rendered).to have_css('.fragment.deletion', text: 'bye')
-        end
-
-        it 'has a link to side-by-side diff' do
-          render
-          link = profile_project_file_change_path(
-            project.owner, project, uncaptured_file_diff.hashed_file_id
-          )
-          expect(rendered).to have_link('View side-by-side', href: link)
-        end
-      end
-    end
-
-    context 'when current user can force sync files in project' do
-      before { assign(:user_can_force_sync_files, true) }
-
-      it 'has a button to force sync the file' do
+      it 'has a link to the parent folder' do
         render
-        sync_path =
-          profile_project_force_syncs_path(
-            project.owner,
-            project,
-            VCS::File.id_to_hashid(uncaptured_file_diff.file_id)
+        link = profile_project_folder_path(project.owner, project,
+                                           parent_in_branch.hashed_file_id)
+        expect(rendered).to have_link 'Open Parent Folder', href: link
+      end
+
+      context 'when parent is root folder' do
+        let(:parent_in_branch) { build_stubbed :vcs_file_in_branch, :root }
+
+        it 'has a link to the root folder' do
+          render
+          link = profile_project_root_folder_path(project.owner, project)
+          expect(rendered).to have_link 'Open Home Folder', href: link
+        end
+      end
+
+      context 'when uncaptured file diff has changes' do
+        before do
+          allow(uncaptured_file_diff).to receive(:change_types)
+            .and_return %i[addition modification movement rename deletion]
+          allow(uncaptured_file_diff)
+            .to receive(:ancestor_path).and_return 'Home'
+        end
+
+        it 'renders uncaptured changes' do
+          render
+          expect(rendered).to have_text 'My Document added to Home'
+          expect(rendered).to have_text(
+            'My Document renamed from ' \
+            "'#{uncaptured_file_diff.previous_name}' in Home"
           )
-        expect(rendered).to have_css(
-          'form'\
-          "[action='#{sync_path}']"\
-          "[method='post']",
-          text: 'Force Sync'
-        )
+          expect(rendered).to have_text 'My Document modified in Home'
+          expect(rendered).to have_text 'My Document moved to Home'
+          expect(rendered).to have_text 'My Document deleted from Home'
+        end
+
+        context 'when diff is modification and has content change' do
+          let(:content_change) do
+            VCS::Operations::ContentDiffer.new(
+              new_content: 'hi',
+              old_content: 'bye'
+            )
+          end
+
+          before do
+            allow(uncaptured_file_diff)
+              .to receive(:modification?).and_return true
+            allow(uncaptured_file_diff)
+              .to receive(:content_change).and_return content_change
+          end
+
+          it 'shows the diff' do
+            render
+            expect(rendered).to have_css('.fragment.addition', text: 'hi')
+            expect(rendered).to have_css('.fragment.deletion', text: 'bye')
+          end
+
+          it 'has a link to side-by-side diff' do
+            render
+            link = profile_project_file_change_path(
+              project.owner, project, uncaptured_file_diff.hashed_file_id
+            )
+            expect(rendered).to have_link('View side-by-side', href: link)
+          end
+        end
+
+        context 'when current user can force sync files in project' do
+          before { assign(:user_can_force_sync_files, true) }
+
+          it 'has a button to force sync the file' do
+            render
+            sync_path =
+              profile_project_force_syncs_path(
+                project.owner,
+                project,
+                VCS::File.id_to_hashid(uncaptured_file_diff.file_id)
+              )
+            expect(rendered).to have_css(
+              'form'\
+              "[action='#{sync_path}']"\
+              "[method='post']",
+              text: 'Force Sync'
+            )
+          end
+        end
       end
     end
   end

--- a/spec/views/projects/_head_spec.rb
+++ b/spec/views/projects/_head_spec.rb
@@ -95,11 +95,20 @@ RSpec.describe 'projects/_head', type: :view do
       )
     end
 
-    it 'renders a link to open that folder in Google Drive' do
+    it 'does not render a link to open that folder in Google Drive' do
       render
-      expect(rendered).to have_link(
-        'Open in Drive', href: root.link_to_remote
-      )
+      expect(rendered).not_to have_link('Open in Drive')
+    end
+
+    context 'when user can collaborate on project' do
+      let(:can_collaborate) { true }
+
+      it 'renders a link to open that folder in Google Drive' do
+        render
+        expect(rendered).to have_link(
+          'Open in Drive', href: root.link_to_remote
+        )
+      end
     end
   end
 end

--- a/spec/views/projects/_head_spec.rb
+++ b/spec/views/projects/_head_spec.rb
@@ -77,14 +77,29 @@ RSpec.describe 'projects/_head', type: :view do
       allow(project).to receive(:setup_not_started?).and_return false
       allow(project).to receive(:setup_in_progress?).and_return false
       allow(project).to receive(:setup_completed?).and_return true
+      allow(project).to receive(:revisions).and_return %w[r1]
     end
 
-    it 'renders a link to the project files' do
+    it 'renders a link to the project files at last revision' do
       render
       expect(rendered).to have_link(
         'Files',
-        href: profile_project_root_folder_path(project.owner, project.slug)
+        href: profile_project_revision_root_folder_path(
+          project.owner, project.slug, project.revisions.last
+        )
       )
+    end
+
+    context 'when user can collaborate on project' do
+      let(:can_collaborate) { true }
+
+      it 'renders a link to the project files' do
+        render
+        expect(rendered).to have_link(
+          'Files',
+          href: profile_project_root_folder_path(project.owner, project.slug)
+        )
+      end
     end
 
     it 'renders a link to the project revisions' do

--- a/spec/views/revisions/folders/show_spec.rb
+++ b/spec/views/revisions/folders/show_spec.rb
@@ -56,18 +56,9 @@ RSpec.describe 'revisions/folders/show', type: :view do
     )
   end
 
-  it 'has a button to restore the revision' do
+  it 'does not have a button to restore the revision' do
     render
-    restore_action = profile_project_revision_restores_path(
-      project.owner, project, revision.id
-    )
-
-    expect(rendered).to have_css(
-      'form'\
-      "[action='#{restore_action}']"\
-      "[method='post']",
-      text: 'Restore Revision'
-    )
+    expect(rendered).not_to have_text('Restore')
   end
 
   it 'renders the names of files and folders' do
@@ -103,6 +94,24 @@ RSpec.describe 'revisions/folders/show', type: :view do
     render
     children.each do |child|
       expect(rendered).not_to have_link(child.name)
+    end
+  end
+
+  context 'when user can restore revisions' do
+    before { assign(:user_can_restore_revision, true) }
+
+    it 'has a button to restore the revision' do
+      render
+      restore_action = profile_project_revision_restores_path(
+        project.owner, project, revision.id
+      )
+
+      expect(rendered).to have_css(
+        'form'\
+        "[action='#{restore_action}']"\
+        "[method='post']",
+        text: 'Restore Revision'
+      )
     end
   end
 


### PR DESCRIPTION
Admins can make projects public via the admin panel by toggling the `is_public`
setting.

Making a project public means that...
- visitors (non-logged in users and non-collaborating users) can see the project
  overview, revisions page, file info page, and time travel to revisions.
  Visitors cannot see work-in-progress/uncaptured changes.
- the project archive is readable by the public, so that visitors can see and
  read files while time traveling.

This resolves:
- [#253](https://github.com/OpenlyOne/openly/issues/253)
- [#257](https://github.com/OpenlyOne/openly/issues/257)
- [#258](https://github.com/OpenlyOne/openly/issues/258)
- [#259](https://github.com/OpenlyOne/openly/issues/259)
- [#251](https://github.com/OpenlyOne/openly/issues/251)