### PR TITLE
Manage project collaborators via admin panel

### DIFF
--- a/app/controllers/admin/profiles/users_controller.rb
+++ b/app/controllers/admin/profiles/users_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Admin
+  module Profiles
+    # Administration controller for managing users
+    class UsersController < Admin::ApplicationController
+      private
+
+      # Do not allow creation of new users. Create a new account instead.
+      def show_action?(action, _resource)
+        action.to_sym != :new
+      end
+
+      # Manually set resource class, otherwise Administrate defaults to
+      # Profile::User
+      def resource_class
+        ActiveSupport::Inflector.constantize('Profiles::User')
+      end
+
+      # Manually set dashboard class, otherwise Administrate defaults to
+      # Profile::UserDashboard
+      def dashboard_class
+        ActiveSupport::Inflector.constantize("#{resource_class}Dashboard")
+      end
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,10 +12,10 @@ class ApplicationController < ActionController::Base
 
   # override sign in redirect (Devise)
   def after_sign_in_path_for(resource)
-    location = stored_location_for(resource) || url_for(resource.user)
+    location = stored_location_for(resource) || profile_path(resource.user)
 
     # Redirect to profile page if stored location is root path
-    return url_for(resource.user) if location.eql?('/')
+    return profile_path(resource.user) if location.eql?('/')
 
     location
   end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -20,7 +20,7 @@ class ProfilesController < ApplicationController
 
   def update
     if @profile.update(profile_params)
-      redirect_with_success_to @profile
+      redirect_with_success_to profile_path(@profile)
     else
       render :edit
     end
@@ -29,7 +29,7 @@ class ProfilesController < ApplicationController
   private
 
   rescue_from CanCan::AccessDenied do |exception|
-    redirect_to @profile, alert: exception.message
+    redirect_to profile_path(@profile), alert: exception.message
   end
 
   def authorize_action

--- a/app/controllers/project_setups_controller.rb
+++ b/app/controllers/project_setups_controller.rb
@@ -42,7 +42,8 @@ class ProjectSetupsController < ApplicationController
   end
 
   def can_can_access_denied(exception)
-    super || redirect_to([@project.owner, @project], alert: exception.message)
+    super || redirect_to(profile_project_path(@project.owner, @project),
+                         alert: exception.message)
   end
 
   def project_setup_params
@@ -65,7 +66,7 @@ class ProjectSetupsController < ApplicationController
   def redirect_to_project_if_setup_complete
     return unless @project.setup_completed?
 
-    redirect_to([@project.owner, @project],
+    redirect_to(profile_project_path(@project.owner, @project),
                 notice: 'Setup has been completed.')
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -51,7 +51,7 @@ class ProjectsController < ApplicationController
 
   def destroy
     if @project.destroy
-      redirect_with_success_to [@project.owner]
+      redirect_with_success_to profile_path(@project.owner)
     else
       redirect_to project_overview_path,
                   alert: 'An unexpected error occured while deleting the ' \

--- a/app/controllers/revisions_controller.rb
+++ b/app/controllers/revisions_controller.rb
@@ -56,7 +56,8 @@ class RevisionsController < ApplicationController
   end
 
   def can_can_access_denied(exception)
-    super || redirect_to([@project.owner, @project], alert: exception.message)
+    super || redirect_to(profile_project_path(@project.owner, @project),
+                         alert: exception.message)
   end
 
   def find_revision

--- a/app/dashboards/account_dashboard.rb
+++ b/app/dashboards/account_dashboard.rb
@@ -54,7 +54,7 @@ class AccountDashboard < Administrate::BaseDashboard
   # Overwrite this method to customize how accounts are displayed
   # across all pages of the admin dashboard.
   #
-  # def display_resource(account)
-  #   "Account ##{account.id}"
-  # end
+  def display_resource(account)
+    account.email
+  end
 end

--- a/app/dashboards/profiles/user_dashboard.rb
+++ b/app/dashboards/profiles/user_dashboard.rb
@@ -15,6 +15,7 @@ module Profiles
       id: Field::Number,
       name: Field::String,
       handle: Field::String,
+      account: Field::BelongsTo,
       color_scheme: Field::Select.with_options(collection: Color.options),
       picture: PaperclipField,
       banner: PaperclipField,
@@ -32,17 +33,28 @@ module Profiles
     #
     # By default, it's limited to four items to reduce clutter on index pages.
     # Feel free to add, remove, or rearrange items.
-    # COLLECTION_ATTRIBUTES = [
-    #   :id,
-    #   :name
-    # ].freeze
+    COLLECTION_ATTRIBUTES = %i[
+      id
+      name
+      handle
+      account
+    ].freeze
 
     # SHOW_PAGE_ATTRIBUTES
     # an array of attributes that will be displayed on the model's show page.
-    # SHOW_PAGE_ATTRIBUTES = [
-    #   :id,
-    #   :name
-    # ].freeze
+    SHOW_PAGE_ATTRIBUTES = %i[
+      name
+      handle
+      account
+      color_scheme
+      picture
+      banner
+      about
+      location
+      link_to_website
+      link_to_facebook
+      link_to_twitter
+    ].freeze
 
     # FORM_ATTRIBUTES
     # an array of attributes that will be displayed

--- a/app/dashboards/project_dashboard.rb
+++ b/app/dashboards/project_dashboard.rb
@@ -12,6 +12,7 @@ class ProjectDashboard < Administrate::BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     owner: Field::BelongsTo.with_options(class_name: 'Profiles::User'),
+    collaborators: Field::HasMany.with_options(class_name: 'Profiles::User'),
     id: Field::Number,
     title: Field::String,
     slug: Field::String,
@@ -31,6 +32,7 @@ class ProjectDashboard < Administrate::BaseDashboard
     id
     title
     owner
+    collaborators
     is_public
   ].freeze
 
@@ -40,6 +42,7 @@ class ProjectDashboard < Administrate::BaseDashboard
     id
     title
     owner
+    collaborators
     slug
     description
     tag_list
@@ -54,6 +57,7 @@ class ProjectDashboard < Administrate::BaseDashboard
   FORM_ATTRIBUTES = %i[
     title
     owner
+    collaborators
     slug
     description
     tag_list

--- a/app/models/profiles/user.rb
+++ b/app/models/profiles/user.rb
@@ -7,12 +7,6 @@ module Profiles
   class User < Base
     acts_as_notifier
 
-    # Adopt route key of Profiles::Base class
-    # See: https://stackoverflow.com/a/9463495/6451879
-    def self.model_name
-      Base.model_name
-    end
-
     # Associations
     belongs_to :account
     has_many :visits, class_name: 'Ahoy::Visit'

--- a/app/views/fields/belongs_to/_index.html.erb
+++ b/app/views/fields/belongs_to/_index.html.erb
@@ -1,0 +1,28 @@
+<%#
+# BelongsTo Index Partial
+
+This partial renders a belongs_to relationship,
+to be displayed on a resource's index page.
+
+By default, the relationship is rendered as a link to the associated object.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::BelongsTo][1].
+  A wrapper around the belongs_to relationship pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/BelongsTo
+%>
+
+<% if field.data %>
+  <% if valid_action?(:show, field.associated_class) %>
+    <%# Force using object ID as primary key %>
+    <%= link_to(
+      field.display_associated_resource,
+      [namespace, field.data, id: field.data.id, format: nil],
+    ) %>
+  <% else %>
+    <%= field.display_associated_resource %>
+  <% end %>
+<% end %>

--- a/app/views/fields/belongs_to/_show.html.erb
+++ b/app/views/fields/belongs_to/_show.html.erb
@@ -1,0 +1,28 @@
+<%#
+# BelongsTo Show Partial
+
+This partial renders a belongs_to relationship,
+to be displayed on a resource's show page.
+
+By default, the relationship is rendered as a link to the associated object.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::BelongsTo][1].
+  A wrapper around the belongs_to relationship pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/BelongsTo
+%>
+
+<% if field.data %>
+  <% if valid_action?(:show, field.associated_class) %>
+    <%# Force using object ID as primary key %>
+    <%= link_to(
+      field.display_associated_resource,
+      [namespace, field.data, id: field.data.id, format: nil],
+    ) %>
+  <% else %>
+    <%= field.display_associated_resource %>
+  <% end %>
+<% end %>

--- a/app/views/fields/has_one/_index.html.erb
+++ b/app/views/fields/has_one/_index.html.erb
@@ -16,6 +16,8 @@ By default, the relationship is rendered as a link to the associated object.
 %>
 
 <% if field.data %>
-  <%# Do not render link to associated resource %>
-  <%= field.display_associated_resource %>
+  <%= link_to(
+    field.display_associated_resource,
+    [namespace, field.data, id: field.data.id, format: nil],
+  ) %>
 <% end %>

--- a/app/views/fields/has_one/_show.html.erb
+++ b/app/views/fields/has_one/_show.html.erb
@@ -16,9 +16,13 @@ All fields of has_one relationship would be rendered
 %>
 
 <% if field.data %>
-  <%# Do not render link to associated resource %>
   <fieldset class="attribute--nested">
-    <legend><%= field.nested_form.resource_name.titleize %></legend>
+    <legend>
+      <%= link_to(
+        field.display_associated_resource,
+        [namespace, field.data, id: field.data.id, format: nil],
+      ) %>
+    </legend>
     <% field.nested_form.attributes.each do |attribute| -%>
       <div>
       <dt class="attribute-label">

--- a/app/views/profiles/edit.slim
+++ b/app/views/profiles/edit.slim
@@ -1,4 +1,4 @@
-= form_for @profile do |f|
+= form_for @profile.becomes(Profiles::Base) do |f|
 
   .page-heading.primary-color.primary-color-text.no-margin-bottom.z-depth-1
     .container

--- a/app/views/project_overviews/show.slim
+++ b/app/views/project_overviews/show.slim
@@ -4,7 +4,7 @@
   .action-bar.right
     - if @user_can_edit_project
       = link_to( \
-          url_for([:edit, @project.owner, @project]), \
+          url_for([:edit, @project.owner.becomes(Profiles::Base), @project]), \
           id: 'edit_project', \
           class: 'btn-floating btn-large primary-color primary-color-text')
         svg viewBox="0 0 24 24"

--- a/app/views/projects/_form.slim
+++ b/app/views/projects/_form.slim
@@ -1,4 +1,4 @@
-= form_for [@project.owner, @project], url: url do |f|
+= form_for [@project.owner.becomes(Profiles::Base), @project], url: url do |f|
 
   / show input field instead of title
   - content_for :project_title do

--- a/app/views/projects/_project.slim
+++ b/app/views/projects/_project.slim
@@ -1,5 +1,5 @@
 .col.s12.m6.l4
-  = link_to url_for([project.owner, project]), class: 'card hoverable'
+  = link_to url_for([project.owner.becomes(Profiles::Base), project]), class: 'card hoverable'
     .card-image style="background-image: url(#{image_path('projects/banner.jpg')});"
     .card-title.truncate.primary-color.primary-color-text = project.title
     - if project.tags.any? || project.description.present?

--- a/app/views/projects/edit.slim
+++ b/app/views/projects/edit.slim
@@ -11,7 +11,7 @@
   .row
     .col.s12.l6
       = button_to('Delete Project',
-                url_for([@project.owner, @project]),
+                url_for([@project.owner.becomes(Profiles::Base), @project]),
                 data: { confirm: 'Are you sure?' },
                 method: :delete,
                 class: 'btn primary-color primary-color-text')

--- a/app/views/projects/new.slim
+++ b/app/views/projects/new.slim
@@ -1,4 +1,4 @@
-= form_for [@project.owner, @project], url: url_for(@project) do |f|
+= form_for [@project.owner.becomes(Profiles::Base), @project], url: url_for(@project) do |f|
 
   .page-heading.primary-color.primary-color-text.z-depth-1
     .container

--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -66,4 +66,14 @@ if defined? Bullet
   Bullet.add_whitelist type: :unused_eager_loading,
                        class_name: 'VCS::Version',
                        association: :content
+
+  # Bullet complains in admin panel when showing # of project collaborators
+  Bullet.add_whitelist type: :unused_eager_loading,
+                       class_name: 'Project',
+                       association: :collaborators
+
+  # Bullet complains in admin panel when showing # of project collaborators
+  Bullet.add_whitelist type: :unused_eager_loading,
+                       class_name: 'Project',
+                       association: :projects_collaborators
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,9 @@ Rails.application.routes.draw do
   authenticated :account, ->(account) { account.admin? } do
     namespace :admin do
       resources :accounts, :projects
+      namespace :profiles do
+        resources :users
+      end
 
       # Analytics Dashboard
       mount Blazer::Engine, at: 'analytics', as: :analytics

--- a/spec/features/admin_panel_spec.rb
+++ b/spec/features/admin_panel_spec.rb
@@ -22,6 +22,7 @@ feature 'Admin Panel' do
     expect(page).to have_text admin.email
 
     click_on 'Projects'
+    click_on 'Profiles/Users'
   end
 end
 

--- a/spec/models/profiles/base_spec.rb
+++ b/spec/models/profiles/base_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.describe Profiles::Base, type: :model do
+  describe 'route keys' do
+    it 'should have singular route key: profile' do
+      expect(subject.model_name.singular_route_key).to eq 'profile'
+    end
+    it 'should have route key: profiles' do
+      expect(subject.model_name.route_key).to eq 'profiles'
+    end
+  end
+end

--- a/spec/models/shared_examples/being_a_profile.rb
+++ b/spec/models/shared_examples/being_a_profile.rb
@@ -1,15 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'being a profile' do
-  describe 'route keys' do
-    it 'should have singular route key: profile' do
-      expect(subject.model_name.singular_route_key).to eq 'profile'
-    end
-    it 'should have route key: profiles' do
-      expect(subject.model_name.route_key).to eq 'profiles'
-    end
-  end
-
   describe 'associations' do
     it do
       is_expected


### PR DESCRIPTION
Admins can add or remove users as collaborators on projects. This is done
by going to the Projects tab in the admin panel and clicking Edit on one of
the projects.

This resolves [#250](https://github.com/OpenlyOne/openly/issues/250).