### PR TITLE
Admin Dashboard: Fix searching for projects

### DIFF
--- a/app/dashboards/project_dashboard.rb
+++ b/app/dashboards/project_dashboard.rb
@@ -17,7 +17,7 @@ class ProjectDashboard < Administrate::BaseDashboard
     title: Field::String,
     slug: Field::String,
     description: Field::Text,
-    tag_list: Field::String,
+    tag_list: Field::String.with_options(searchable: false),
     is_public: Field::Boolean,
     created_at: Field::DateTime,
     updated_at: Field::DateTime

--- a/spec/dashboards/account_dashboard_spec.rb
+++ b/spec/dashboards/account_dashboard_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe AccountDashboard, type: :model do
+  subject(:dashboard) { described_class }
+  let(:attributes)    { dashboard::ATTRIBUTE_TYPES }
+  let(:resource)      { Account }
+
+  describe 'attribute types' do
+    it 'only allows search in attributes that exist in the database' do
+      searchable_attributes = attributes.select do |_key, value|
+        value.searchable?
+      end.keys
+      attributes_in_database = resource.columns.map(&:name).map(&:to_sym)
+
+      expect(attributes_in_database).to include(*searchable_attributes)
+    end
+  end
+end

--- a/spec/dashboards/profiles/user_dashboard_spec.rb
+++ b/spec/dashboards/profiles/user_dashboard_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe Profiles::UserDashboard, type: :model do
+  subject(:dashboard) { described_class }
+  let(:attributes)    { dashboard::ATTRIBUTE_TYPES }
+  let(:resource)      { Profiles::User }
+
+  describe 'attribute types' do
+    it 'only allows search in attributes that exist in the database' do
+      searchable_attributes = attributes.select do |_key, value|
+        value.searchable?
+      end.keys
+      attributes_in_database = resource.columns.map(&:name).map(&:to_sym)
+
+      expect(attributes_in_database).to include(*searchable_attributes)
+    end
+  end
+end

--- a/spec/dashboards/project_dashboard_spec.rb
+++ b/spec/dashboards/project_dashboard_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe ProjectDashboard, type: :model do
+  subject(:dashboard) { described_class }
+  let(:attributes)    { dashboard::ATTRIBUTE_TYPES }
+  let(:resource)      { Project }
+
+  describe 'attribute types' do
+    it 'only allows search in attributes that exist in the database' do
+      searchable_attributes = attributes.select do |_key, value|
+        value.searchable?
+      end.keys
+      attributes_in_database = resource.columns.map(&:name).map(&:to_sym)
+
+      expect(attributes_in_database).to include(*searchable_attributes)
+    end
+  end
+end


### PR DESCRIPTION
When searching the project dashboard, Rails has been throwing an internal
error. This is due to the fact that Administrate is attempting to search
the attribute `tag_list` in the database, but `tag_list` is an entirely
virtual attribute (built from the tags array). To avoid the error,
`tag_list` is explicitly removed from the fields to search.