### PR TITLE
Add uncaptured changes indicator to projects

### DIFF
--- a/app/assets/stylesheets/controllers/profiles.scss
+++ b/app/assets/stylesheets/controllers/profiles.scss
@@ -66,4 +66,26 @@ $picture-size-small: 100px;
       width: 32px;
     }
   }
+
+  // set explicit max-width on this element, so that we can show the optional
+  // uncaptured changes indicator
+  .project {
+    .title {
+      display: inline-block;
+      max-width: calc(100% - 48px - 16px);
+      vertical-align: top;
+      width: auto;
+    }
+
+    .uncaptured-changes-indicator {
+      border-radius: 100%;
+      display: inline-block;
+      height: 8px;
+      margin-left: 8px;
+      position: relative;
+      top: -2px;
+      vertical-align: middle;
+      width: 8px;
+    }
+  }
 }

--- a/app/assets/stylesheets/shared/buttons.scss
+++ b/app/assets/stylesheets/shared/buttons.scss
@@ -32,3 +32,12 @@
   line-height: 28px;
   padding: 0 12px;
 }
+
+// Chip inside button, on the right side
+.btn > .chip.slim {
+  margin: 0;
+  margin-left: 10px;
+  position: relative;
+  top: 15px;
+  vertical-align: top;
+}

--- a/app/assets/stylesheets/shared/colors.scss.erb
+++ b/app/assets/stylesheets/shared/colors.scss.erb
@@ -34,6 +34,11 @@ $colors: map-merge($colors, ('white': ('base': #fff)));
     // scss-lint:disable ImportantRule
     background-color: $color !important;
   }
+  // primary-color-text-inverse: applies main color to an element as text-color
+  .primary-color-text-inverse {
+    // scss-lint:disable ImportantRule
+    color: $color !important;
+  }
 }
 
 @mixin define-classes-based-on-font-color($color) {
@@ -41,6 +46,11 @@ $colors: map-merge($colors, ('white': ('base': #fff)));
   .primary-color-text {
     // scss-lint:disable ImportantRule
     color: $color !important;
+  }
+  // primary-color-inverse: applies font color to an element as background-color
+  .primary-color-inverse {
+    // scss-lint:disable ImportantRule
+    background-color: $color !important;
   }
 }
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -10,6 +10,7 @@ class ProfilesController < ApplicationController
   def show
     @projects =
       Project
+      .with_permission_level(current_user)
       .where_profile_is_owner_or_collaborator(@profile)
       .includes(:owner, :master_branch)
       .order(:title, :id)

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -11,7 +11,7 @@ class ProfilesController < ApplicationController
     @projects =
       Project
       .where_profile_is_owner_or_collaborator(@profile)
-      .includes(:owner)
+      .includes(:owner, :master_branch)
       .order(:title, :id)
     @user_can_edit_profile = can?(:edit, @profile)
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -40,7 +40,7 @@ class Project < ApplicationRecord
   delegate :archive, to: :repository, prefix: true
   delegate :branches, to: :repository
   delegate :in_progress?, :completed?, to: :setup, prefix: true, allow_nil: true
-  delegate :files, to: :master_branch
+  delegate :files, :uncaptured_changes_count, to: :master_branch
 
   # Callbacks
   # Auto-generate slug from title

--- a/app/models/vcs/branch.rb
+++ b/app/models/vcs/branch.rb
@@ -119,6 +119,14 @@ module VCS
       )
     end
 
+    # Update the count of files with uncaptured changes in this branch
+    def update_uncaptured_changes_count
+      update_attribute(
+        :uncaptured_changes_count,
+        files.without_root.where_change_is_uncaptured.count
+      )
+    end
+
     private
 
     def mime_type_class

--- a/app/models/vcs/commit.rb
+++ b/app/models/vcs/commit.rb
@@ -44,7 +44,11 @@ module VCS
     before_save :apply_selected_file_changes,
                 if: :publishing?, unless: :select_all_file_changes
     after_save :update_files_in_branch, if: :publishing?
+    after_save :branch_update_uncaptured_changes_count, if: :publishing?
     after_save :trigger_notifications, if: %i[publishing? belongs_to_project?]
+
+    # Delegations
+    delegate :update_uncaptured_changes_count, to: :branch, prefix: true
 
     # Scopes
     scope :preload_file_diffs_with_versions, lambda {

--- a/app/models/vcs/file_in_branch.rb
+++ b/app/models/vcs/file_in_branch.rb
@@ -46,6 +46,11 @@ module VCS
       )
     }
 
+    # Return only files that have uncaptured changes
+    scope :where_change_is_uncaptured, lambda {
+      where("COALESCE(#{table_name}.current_version_id, '-1') != " \
+            "COALESCE(#{table_name}.committed_version_id, '-1')")
+    }
     # Return only files in branch that have been committed
     scope :committed, -> { where('committed_version_id IS NOT NULL') }
 

--- a/app/models/vcs/file_in_branch.rb
+++ b/app/models/vcs/file_in_branch.rb
@@ -21,6 +21,13 @@ module VCS
     include VCS::Backupable
     include VCS::Downloadable
 
+    # Callbacks
+    after_save :branch_update_uncaptured_changes_count
+    after_destroy :branch_update_uncaptured_changes_count
+
+    # Delegations
+    delegate :update_uncaptured_changes_count, to: :branch, prefix: true
+
     scope :joins_version, lambda {
       joins(
         'INNER JOIN vcs_versions versions ' \

--- a/app/views/folders/show.slim
+++ b/app/views/folders/show.slim
@@ -22,6 +22,8 @@
 / button for committing changes
 - if @user_can_commit_changes
   .fixed-action-btn
-    = link_to 'Capture Changes',
-        new_profile_project_revision_path(@project.owner, @project),
-        class: 'btn btn-large primary-color primary-color-text'
+    = link_to new_profile_project_revision_path(@project.owner, @project),
+              class: 'btn btn-large primary-color primary-color-text'
+      | Capture Changes
+      span.chip.slim.primary-color-inverse.primary-color-text-inverse
+        = @project.uncaptured_changes_count

--- a/app/views/projects/_project.slim
+++ b/app/views/projects/_project.slim
@@ -9,7 +9,7 @@
       span.title.truncate = project.title
 
       / when there are uncaptured changes in project, show small indicator
-      - if project.uncaptured_changes_count.nonzero?
+      - if project.can_collaborate? && project.uncaptured_changes_count.nonzero?
         .uncaptured-changes-indicator.primary-color title='Project has uncaptured changes'
 
     .card-content

--- a/app/views/projects/_project.slim
+++ b/app/views/projects/_project.slim
@@ -1,16 +1,23 @@
 .col.s12.m6.l4
-  = link_to url_for([project.owner.becomes(Profiles::Base), project]), class: 'card hoverable'
+  = link_to url_for([project.owner.becomes(Profiles::Base), project]), class: 'card hoverable project'
     .card-title.truncate
       = image_tag project.owner.picture(:medium),
-                  size: '70',
+                  size: '40',
                   class: 'responsive-img circle left',
                   title: project.owner.name
-      = project.title
+
+      span.title.truncate = project.title
+
+      / when there are uncaptured changes in project, show small indicator
+      - if project.uncaptured_changes_count.nonzero?
+        .uncaptured-changes-indicator.primary-color title='Project has uncaptured changes'
+
     .card-content
       p
         - if project.description.present?
           = truncate(project.description, length: 200)
         - else
           | No description.
+
     .card-action
       span.btn-flat Open

--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -76,4 +76,10 @@ if defined? Bullet
   Bullet.add_whitelist type: :unused_eager_loading,
                        class_name: 'Project',
                        association: :projects_collaborators
+
+  # Bullet complains on the profile page when eager loading master branch but
+  # not actually showing any uncaptured changes indicator
+  Bullet.add_whitelist type: :unused_eager_loading,
+                       class_name: 'Project',
+                       association: :master_branch
 end

--- a/db/migrate/20190210025157_add_uncaptured_changes_count_to_vcs_branches.rb
+++ b/db/migrate/20190210025157_add_uncaptured_changes_count_to_vcs_branches.rb
@@ -1,0 +1,10 @@
+class AddUncapturedChangesCountToVcsBranches < ActiveRecord::Migration[5.2]
+  def change
+    add_column :vcs_branches, :uncaptured_changes_count, :integer,
+               null: false, default: 0
+
+    # set the correct count on existing branches
+    VCS::Branch.reset_column_information
+    VCS::Branch.find_each(&:update_uncaptured_changes_count)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_03_103334) do
+ActiveRecord::Schema.define(version: 2019_02_10_025157) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -247,6 +247,7 @@ ActiveRecord::Schema.define(version: 2019_02_03_103334) do
     t.bigint "repository_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "uncaptured_changes_count", default: 0, null: false
     t.index ["repository_id"], name: "index_vcs_branches_on_repository_id"
   end
 

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -20,6 +20,10 @@ FactoryBot.define do
       is_public { true }
     end
 
+    trait :private do
+      is_public { false }
+    end
+
     trait :setup_complete do
       after(:create) do |project|
         create(:project_setup, :completed, project: project)

--- a/spec/features/file_content_change_spec.rb
+++ b/spec/features/file_content_change_spec.rb
@@ -65,7 +65,7 @@ feature 'File Content Change' do
     visit "#{project.owner.to_param}/#{project.to_param}"
 
     # and click on Capture Changes
-    click_on 'Capture Changes'
+    click_on 'Capture Changes3'
 
     # then I should see one file change
     expect(page).to have_text(

--- a/spec/features/file_restore_spec.rb
+++ b/spec/features/file_restore_spec.rb
@@ -60,7 +60,7 @@ feature 'File Restore', vcr: true do
 
     # and commit the file
     click_on 'Files'
-    click_on 'Capture Changes'
+    click_on 'Capture Changes1'
     fill_in 'Title', with: 'Delete file'
     click_on 'Capture Changes'
 
@@ -97,7 +97,7 @@ feature 'File Restore', vcr: true do
 
       # and commit the file
       click_on 'Files'
-      click_on 'Capture Changes'
+      click_on 'Capture Changes2'
       fill_in 'Title', with: 'Delete subfolder & file'
       click_on 'Capture Changes'
 
@@ -142,7 +142,7 @@ feature 'File Restore', vcr: true do
 
     # and commit the file
     click_on 'Files'
-    click_on 'Capture Changes'
+    click_on 'Capture Changes1'
     fill_in 'Title', with: 'Change file'
     click_on 'Capture Changes'
 
@@ -185,7 +185,7 @@ feature 'File Restore', vcr: true do
 
       # and commit the folder
       click_on 'Files'
-      click_on 'Capture Changes'
+      click_on 'Capture Changes1'
       fill_in 'Title', with: 'Delete folder'
       click_on 'Capture Changes'
 

--- a/spec/features/revision_restore_spec.rb
+++ b/spec/features/revision_restore_spec.rb
@@ -59,7 +59,7 @@ feature 'Revision Restore', :vcr, :delayed_job do
     visit profile_project_path(project.owner, project)
 
     # and capture changes
-    click_on 'Capture Changes'
+    click_on 'Capture Changes8'
 
     # then I should see no changes
     expect(page).not_to have_text 'No files changed'

--- a/spec/features/revision_spec.rb
+++ b/spec/features/revision_spec.rb
@@ -70,7 +70,7 @@ feature 'Revision' do
     expect(master_branch.commits.last).to be_present
     # and see no file modification icons
     expect(page).to have_css '.file.no-change', count: 5
-    expect(page).to have_text 'Capture Changes'
+    expect(page).to have_text 'Capture Changes0'
   end
 
   context 'Selective capture' do

--- a/spec/features/revision_spec.rb
+++ b/spec/features/revision_spec.rb
@@ -54,7 +54,7 @@ feature 'Revision' do
     # and click on Files
     click_on 'Files'
     # and click on Capture Changes
-    click_on 'Capture Changes'
+    click_on 'Capture Changes5'
     # and enter a revision title
     fill_in 'Title', with: 'Initial Capture'
     # and click on 'Capture'
@@ -70,6 +70,7 @@ feature 'Revision' do
     expect(master_branch.commits.last).to be_present
     # and see no file modification icons
     expect(page).to have_css '.file.no-change', count: 5
+    expect(page).to have_text 'Capture Changes'
   end
 
   context 'Selective capture' do
@@ -120,7 +121,7 @@ feature 'Revision' do
       # and click on Files
       click_on 'Files'
       # and click on Capture Changes
-      click_on 'Capture Changes'
+      click_on 'Capture Changes7'
 
       # then I can see the changes I am about to commit
       expect(page).to have_css '.file.addition',      text: added_file.name

--- a/spec/integrations/vcs/file_in_branch_spec.rb
+++ b/spec/integrations/vcs/file_in_branch_spec.rb
@@ -58,6 +58,23 @@ RSpec.describe VCS::FileInBranch, type: :model do
     end
   end
 
+  describe '.where_change_is_uncaptured' do
+    subject(:uncaptured) { described_class.where_change_is_uncaptured }
+
+    let!(:unchanged)  { create_list :vcs_file_in_branch, 2, :unchanged }
+    let!(:deleted)    { create_list :vcs_file_in_branch, 2, :deleted }
+
+    let!(:added) { create_list :vcs_file_in_branch, 2 }
+    let!(:committed_and_deleted) do
+      create_list :vcs_file_in_branch, 2, :deleted, :with_committed_version
+    end
+    let!(:changed) { create_list :vcs_file_in_branch, 2, :with_versions }
+
+    it 'returns added, deleted, and changed files' do
+      is_expected.to match_array(added + committed_and_deleted + changed)
+    end
+  end
+
   describe '.committed' do
     subject { described_class.committed }
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -98,6 +98,10 @@ RSpec.describe Project, type: :model do
         .with_prefix
     end
     it { is_expected.to delegate_method(:branches).to(:repository) }
+    it do
+      is_expected
+        .to delegate_method(:uncaptured_changes_count).to(:master_branch)
+    end
   end
 
   describe 'callbacks' do

--- a/spec/models/vcs/commit_spec.rb
+++ b/spec/models/vcs/commit_spec.rb
@@ -52,6 +52,46 @@ RSpec.describe VCS::Commit, type: :model do
     it { is_expected.to have_readonly_attribute(:parent_id) }
   end
 
+  describe 'callbacks' do
+    let(:commit) { build :vcs_commit }
+    context 'on saving' do
+      before do
+        allow(commit).to receive(:publishing?).and_return is_publishing
+        allow(commit).to receive(:update_files_in_branch)
+        allow(commit).to receive(:branch_update_uncaptured_changes_count)
+        commit.save
+      end
+
+      context 'when publishing' do
+        let(:is_publishing) { true }
+
+        it { is_expected.to have_received(:update_files_in_branch) }
+        it do
+          is_expected.to have_received(:branch_update_uncaptured_changes_count)
+        end
+      end
+
+      context 'when not publishing' do
+        let(:is_publishing) { false }
+
+        it { is_expected.not_to have_received(:update_files_in_branch) }
+        it do
+          is_expected
+            .not_to have_received(:branch_update_uncaptured_changes_count)
+        end
+      end
+    end
+  end
+
+  describe 'delegations' do
+    it do
+      is_expected
+        .to delegate_method(:update_uncaptured_changes_count)
+        .to(:branch)
+        .with_prefix
+    end
+  end
+
   describe 'validations' do
     it { is_expected.not_to validate_presence_of(:title) }
 

--- a/spec/models/vcs/file_in_branch_spec.rb
+++ b/spec/models/vcs/file_in_branch_spec.rb
@@ -77,6 +77,40 @@ RSpec.describe VCS::FileInBranch, type: :model do
     end
   end
 
+  describe 'callbacks' do
+    let!(:file_in_branch)  { create :vcs_file_in_branch }
+    let(:branch)           { file_in_branch.branch }
+
+    before { allow(branch).to receive(:update_uncaptured_changes_count) }
+
+    context 'when creating instance' do
+      before { create :vcs_file_in_branch, branch: branch }
+
+      it { expect(branch).to have_received(:update_uncaptured_changes_count) }
+    end
+
+    context 'when updating instance' do
+      before { file_in_branch.update(name: 'ok') }
+
+      it { expect(branch).to have_received(:update_uncaptured_changes_count) }
+    end
+
+    context 'when destroying instance' do
+      before { file_in_branch.destroy }
+
+      it { expect(branch).to have_received(:update_uncaptured_changes_count) }
+    end
+  end
+
+  describe 'delegations' do
+    it do
+      is_expected
+        .to delegate_method(:update_uncaptured_changes_count)
+        .to(:branch)
+        .with_prefix
+    end
+  end
+
   describe 'validations' do
     it { is_expected.to validate_presence_of(:remote_file_id) }
     it { is_expected.to validate_presence_of(:name) }

--- a/spec/models/vcs/file_in_branch_spec.rb
+++ b/spec/models/vcs/file_in_branch_spec.rb
@@ -8,6 +8,17 @@ require 'models/shared_examples/vcs/being_syncable.rb'
 RSpec.describe VCS::FileInBranch, type: :model do
   subject(:file_in_branch) { build :vcs_file_in_branch }
 
+  describe 'factories' do
+    describe ':unchanged' do
+      subject(:file_in_branch) { create :vcs_file_in_branch, :unchanged }
+
+      it 'creates an unchanged FileInBranch' do
+        expect(file_in_branch.current_version)
+          .to eq file_in_branch.committed_version
+      end
+    end
+  end
+
   it_should_behave_like 'vcs: being backupable' do
     let(:backupable) { file_in_branch }
   end

--- a/spec/views/folders/show_spec.rb
+++ b/spec/views/folders/show_spec.rb
@@ -114,12 +114,15 @@ RSpec.describe 'folders/show', type: :view do
   end
 
   context 'when current user can edit project' do
-    before { assign(:user_can_commit_changes, true) }
+    before do
+      assign(:user_can_commit_changes, true)
+      allow(project).to receive(:uncaptured_changes_count).and_return 55
+    end
 
     it 'has a button to capture changes' do
       render
       expect(rendered).to have_link(
-        'Capture Changes',
+        'Capture Changes55',
         href: new_profile_project_revision_path(project.owner, project)
       )
     end

--- a/spec/views/profiles/show_spec.rb
+++ b/spec/views/profiles/show_spec.rb
@@ -46,6 +46,15 @@ RSpec.describe 'profiles/show', type: :view do
     expect(rendered).not_to have_css '.uncaptured-changes-indicator'
   end
 
+  context 'when user can collaborate' do
+    before do
+      allow(projects.first).to receive(:can_collaborate?).and_return true
+      render
+    end
+
+    it { expect(rendered).not_to have_css '.uncaptured-changes-indicator' }
+  end
+
   it 'links to projects' do
     render
     projects.each do |project|
@@ -58,22 +67,22 @@ RSpec.describe 'profiles/show', type: :view do
 
   context 'when project has uncaptured changes' do
     before do
-      allow(projects.first)
-        .to receive(:uncaptured_changes_count)
-        .and_return 7
-      render
+      allow(projects.first).to receive(:uncaptured_changes_count).and_return 7
     end
 
     context 'when user can collaborate' do
       before do
         allow(projects.first).to receive(:can_collaborate?).and_return true
+        render
       end
 
       it { expect(rendered).to have_css '.uncaptured-changes-indicator' }
     end
 
     context 'when user cannot collaborate' do
-      xit { expect(rendered).not_to have_css '.uncaptured-changes-indicator' }
+      before { render }
+
+      it { expect(rendered).not_to have_css '.uncaptured-changes-indicator' }
     end
   end
 

--- a/spec/views/profiles/show_spec.rb
+++ b/spec/views/profiles/show_spec.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe 'profiles/show', type: :view do
-  let(:profile)   { build(:user, :with_social_links) }
-  let(:projects)  { build_stubbed_list(:project, 3, owner: profile) }
+  let(:profile) { build(:user, :with_social_links) }
+  let(:projects) do
+    build_stubbed_list(:project, 3, :with_repository, owner: profile)
+  end
 
   before do
     assign(:profile, profile)
@@ -39,6 +41,11 @@ RSpec.describe 'profiles/show', type: :view do
     end
   end
 
+  it 'lists projects without an uncaptured changes indicator' do
+    render
+    expect(rendered).not_to have_css '.uncaptured-changes-indicator'
+  end
+
   it 'links to projects' do
     render
     projects.each do |project|
@@ -46,6 +53,27 @@ RSpec.describe 'profiles/show', type: :view do
         project.title,
         href: profile_project_path(project.owner, project)
       )
+    end
+  end
+
+  context 'when project has uncaptured changes' do
+    before do
+      allow(projects.first)
+        .to receive(:uncaptured_changes_count)
+        .and_return 7
+      render
+    end
+
+    context 'when user can collaborate' do
+      before do
+        allow(projects.first).to receive(:can_collaborate?).and_return true
+      end
+
+      it { expect(rendered).to have_css '.uncaptured-changes-indicator' }
+    end
+
+    context 'when user cannot collaborate' do
+      xit { expect(rendered).not_to have_css '.uncaptured-changes-indicator' }
     end
   end
 


### PR DESCRIPTION
Display an indicator for uncaptured file changes on project preview cards as
well as the project's capture changes button. The purpose is to help people be
more aware of projects that have uncaptured work.

Resolves [#305](https://github.com/OpenlyOne/openly/issues/305).