### PR TITLE
Sort Projects by Recency

### DIFF
--- a/app/assets/stylesheets/controllers/profiles.scss
+++ b/app/assets/stylesheets/controllers/profiles.scss
@@ -70,6 +70,11 @@ $picture-size-small: 100px;
   // set explicit max-width on this element, so that we can show the optional
   // uncaptured changes indicator
   .project {
+    .title-image {
+      position: relative;
+      top: 10px;
+    }
+
     .title {
       display: inline-block;
       max-width: calc(100% - 48px - 16px);
@@ -86,6 +91,12 @@ $picture-size-small: 100px;
       top: -2px;
       vertical-align: middle;
       width: 8px;
+    }
+
+    .subtitle {
+      font-size: 1rem;
+      margin: 0;
+      margin-left: 50px;
     }
   }
 }

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -13,7 +13,7 @@ class ProfilesController < ApplicationController
       .with_permission_level(current_user)
       .where_profile_is_owner_or_collaborator(@profile)
       .includes(:owner, :master_branch)
-      .order(:title, :id)
+      .order(captured_at: :desc)
     @user_can_edit_profile = can?(:edit, @profile)
   end
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -182,6 +182,12 @@ class Project < ApplicationRecord
     slug_in_database
   end
 
+  # Updates the `captured_at` timestamp
+  # We do not use touch because we do not want to update the updated_at time
+  def touch_captured_at
+    update_attribute(:captured_at, Time.zone.now)
+  end
+
   private
 
   # Build master branch for the repository

--- a/app/models/vcs/commit.rb
+++ b/app/models/vcs/commit.rb
@@ -4,7 +4,7 @@ module VCS
   # A commit is a version of a branch with all its files
   # rubocop:disable Metrics/ClassLength
   class Commit < ApplicationRecord
-    # TODO: Extract Notifying out
+    # TODO: Extract Notifying out into a wrapper class called Revision
     include Notifying
 
     # Associations
@@ -45,10 +45,15 @@ module VCS
                 if: :publishing?, unless: :select_all_file_changes
     after_save :update_files_in_branch, if: :publishing?
     after_save :branch_update_uncaptured_changes_count, if: :publishing?
+    # Update the `captured_at` attribute of project
+    # TODO: Extract into wrapper class because VCS::Commit should have no
+    # =>    knowledge of project
+    after_save :project_touch_captured_at, if: :publishing?
     after_save :trigger_notifications, if: %i[publishing? belongs_to_project?]
 
     # Delegations
     delegate :update_uncaptured_changes_count, to: :branch, prefix: true
+    delegate :touch_captured_at, to: :project, prefix: true, allow_nil: true
 
     # Scopes
     scope :preload_file_diffs_with_versions, lambda {
@@ -215,6 +220,12 @@ module VCS
       return if parent.repository.id == branch.repository_id
 
       errors.add(:parent, 'must belong to same repository')
+    end
+
+    # The project that this commit belongs to
+    # TODO: Extract into wrapper class `Revision`
+    def project
+      Project.find_by_repository_id(repository.id)
     end
 
     def published_origin_revision_exists_for_branch?

--- a/app/views/projects/_project.slim
+++ b/app/views/projects/_project.slim
@@ -3,7 +3,7 @@
     .card-title.truncate
       = image_tag project.owner.picture(:medium),
                   size: '40',
-                  class: 'responsive-img circle left',
+                  class: 'responsive-img circle left title-image',
                   title: project.owner.name
 
       span.title.truncate = project.title
@@ -11,6 +11,11 @@
       / when there are uncaptured changes in project, show small indicator
       - if project.can_collaborate? && project.uncaptured_changes_count.nonzero?
         .uncaptured-changes-indicator.primary-color title='Project has uncaptured changes'
+
+      p.subtitle.truncate.gray-text.text-darken-2
+        ' Updated
+        => time_ago_in_words(project.captured_at)
+        | ago
 
     .card-content
       p

--- a/db/migrate/20190210093056_add_captured_at_to_projects.rb
+++ b/db/migrate/20190210093056_add_captured_at_to_projects.rb
@@ -1,0 +1,15 @@
+class AddCapturedAtToProjects < ActiveRecord::Migration[5.2]
+  def change
+    add_column :projects, :captured_at, :timestamp,
+               default: -> { 'CURRENT_TIMESTAMP' },
+               null: false
+
+    Project.reset_column_information
+    Project.find_each do |project|
+      project.update_attribute(
+        :captured_at,
+        project.revisions.last&.updated_at || project.created_at
+      )
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_10_025157) do
+ActiveRecord::Schema.define(version: 2019_02_10_093056) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -223,6 +223,7 @@ ActiveRecord::Schema.define(version: 2019_02_10_025157) do
     t.bigint "repository_id"
     t.bigint "master_branch_id"
     t.boolean "are_contributions_enabled", default: false, null: false
+    t.datetime "captured_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.index ["master_branch_id"], name: "index_projects_on_master_branch_id"
     t.index ["owner_id", "slug"], name: "index_projects_on_owner_id_and_slug", unique: true
     t.index ["owner_id"], name: "index_projects_on_owner_id"

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -15,6 +15,7 @@ FactoryBot.define do
     owner           { build(:user, account_email: owner_account_email) }
     is_public       { false }
     are_contributions_enabled { true }
+    captured_at { Faker::Time.between(DateTime.now - 7, DateTime.now) }
 
     trait :public do
       is_public { true }

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
     owner           { build(:user, account_email: owner_account_email) }
     is_public       { false }
     are_contributions_enabled { true }
-    captured_at { Faker::Time.between(DateTime.now - 7, DateTime.now) }
+    captured_at { Faker::Time.between(Time.zone.now - 7, Time.zone.now) }
 
     trait :public do
       is_public { true }

--- a/spec/integrations/project_spec.rb
+++ b/spec/integrations/project_spec.rb
@@ -312,4 +312,18 @@ RSpec.describe Project, type: :model do
       end
     end
   end
+
+  describe '#touch_captured_at' do
+    subject(:touch) { project.touch_captured_at }
+
+    it 'sets captured_at to now' do
+      touch
+      project.reload
+      expect(project.captured_at.utc).to be_within(1.second).of Time.zone.now
+    end
+
+    it 'does not change updated_at' do
+      expect { touch }.to change(project, :updated_at)
+    end
+  end
 end

--- a/spec/models/vcs/commit_spec.rb
+++ b/spec/models/vcs/commit_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe VCS::Commit, type: :model do
         allow(commit).to receive(:publishing?).and_return is_publishing
         allow(commit).to receive(:update_files_in_branch)
         allow(commit).to receive(:branch_update_uncaptured_changes_count)
+        allow(commit).to receive(:project_touch_captured_at)
         commit.save
       end
 
@@ -69,6 +70,7 @@ RSpec.describe VCS::Commit, type: :model do
         it do
           is_expected.to have_received(:branch_update_uncaptured_changes_count)
         end
+        it { is_expected.to have_received(:project_touch_captured_at) }
       end
 
       context 'when not publishing' do
@@ -79,6 +81,7 @@ RSpec.describe VCS::Commit, type: :model do
           is_expected
             .not_to have_received(:branch_update_uncaptured_changes_count)
         end
+        it { is_expected.not_to have_received(:project_touch_captured_at) }
       end
     end
   end
@@ -89,6 +92,13 @@ RSpec.describe VCS::Commit, type: :model do
         .to delegate_method(:update_uncaptured_changes_count)
         .to(:branch)
         .with_prefix
+    end
+    it do
+      is_expected
+        .to delegate_method(:touch_captured_at)
+        .to(:project)
+        .with_prefix
+        .allow_nil
     end
   end
 

--- a/spec/views/profiles/show_spec.rb
+++ b/spec/views/profiles/show_spec.rb
@@ -33,11 +33,13 @@ RSpec.describe 'profiles/show', type: :view do
     expect(rendered).to have_text profile.location
   end
 
-  it 'lists projects with title & description' do
+  it 'lists projects with title, description, and captured at' do
     render
     projects.each do |project|
       expect(rendered).to have_text project.title
       expect(rendered).to have_text truncate(project.description, length: 200)
+      expect(rendered)
+        .to have_text "Updated #{time_ago_in_words(project.captured_at)} ago"
     end
   end
 


### PR DESCRIPTION
Add a column to the projects table to add the time of the project's last commit.
This time is displayed on the project preview cards and is used to sort projects
in the order of most to least recent commit.

It should help users more quickly
find the projects they are actively working on and it should help those looking
at other users' repositories quickly decide how up-to-date a project is.

Resolves [#79](https://github.com/OpenlyOne/openly/issues/79).