### PR TITLE
Profile page: Show only projects that user can view

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -12,6 +12,7 @@ class ProfilesController < ApplicationController
       Project
       .with_permission_level(current_user)
       .where_profile_is_owner_or_collaborator(@profile)
+      .where_permission_level_is_collaboration_or_view(current_user)
       .includes(:owner, :master_branch)
       .order(captured_at: :desc)
     @user_can_edit_profile = can?(:edit, @profile)


### PR DESCRIPTION
On the profile page, show only projects that the user can view (such as
public projects or private projects where the user is a collaborator).
Private projects that the user cannot view are no longer shown. That is
good because they were meant to be private in the first place.

Resolves [#302](https://github.com/OpenlyOne/openly/issues/302).