### PR TITLE
Project preview cards: Add lock icon for private projects

### DIFF
--- a/app/assets/stylesheets/controllers/profiles.scss
+++ b/app/assets/stylesheets/controllers/profiles.scss
@@ -98,5 +98,13 @@ $picture-size-small: 100px;
       margin: 0;
       margin-left: 50px;
     }
+
+    .lock-icon-wrapper {
+      line-height: 36px;
+    }
+
+    .lock-icon {
+      vertical-align: middle;
+    }
   }
 }

--- a/app/assets/stylesheets/shared/cards.scss
+++ b/app/assets/stylesheets/shared/cards.scss
@@ -23,6 +23,11 @@
   }
 
   .card-action {
-    padding: 12px 4px;
+    padding-bottom: 4px;
+    padding-top: 4px;
+
+    .btn-flat {
+      padding: 0;
+    }
   }
 }

--- a/app/views/projects/_project.slim
+++ b/app/views/projects/_project.slim
@@ -26,3 +26,7 @@
 
     .card-action
       span.btn-flat Open
+      - if project.private?
+        span.lock-icon-wrapper.right.gray-text.text-darken-2 title='Project is private'
+          svg.lock-icon style="width:24px;height:24px" viewBox="0 0 24 24"
+            path fill="currentColor" d="M12,17A2,2 0 0,0 14,15C14,13.89 13.1,13 12,13A2,2 0 0,0 10,15A2,2 0 0,0 12,17M18,8A2,2 0 0,1 20,10V20A2,2 0 0,1 18,22H6A2,2 0 0,1 4,20V10C4,8.89 4.9,8 6,8H7V6A5,5 0 0,1 12,1A5,5 0 0,1 17,6V8H18M12,3A3,3 0 0,0 9,6V8H15V6A3,3 0 0,0 12,3Z"

--- a/spec/views/profiles/show_spec.rb
+++ b/spec/views/profiles/show_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe 'profiles/show', type: :view do
   let(:profile) { build(:user, :with_social_links) }
   let(:projects) do
-    build_stubbed_list(:project, 3, :with_repository, owner: profile)
+    build_stubbed_list(:project, 3, :public, :with_repository, owner: profile)
   end
 
   before do
@@ -64,6 +64,20 @@ RSpec.describe 'profiles/show', type: :view do
         project.title,
         href: profile_project_path(project.owner, project)
       )
+    end
+  end
+
+  it 'does not a private indicator' do
+    render
+    expect(rendered).not_to have_css '.project .lock-icon'
+  end
+
+  context 'when project is private' do
+    before { allow(projects.first).to receive(:private?).and_return true }
+
+    it 'has a private indicator' do
+      render
+      expect(rendered).to have_css '.project .lock-icon'
     end
   end
 


### PR DESCRIPTION
Add a lock icon to preview cards of private projects to help users
distinguish between private and public projects.

Addresses [#251](https://github.com/OpenlyOne/openly/issues/291)