### PR TITLE
File Diffs: Show 'no diff' message when all fragments are retained

### DIFF
--- a/app/assets/stylesheets/controllers/revisions.scss
+++ b/app/assets/stylesheets/controllers/revisions.scss
@@ -88,5 +88,16 @@
     .links {
       margin-top: 5px;
     }
+
+    .help-icon-wrapper {
+      cursor: help;
+      margin-left: 5px;
+      position: relative;
+      top: -2px;
+    }
+
+    .help-icon {
+      vertical-align: middle;
+    }
   }
 }

--- a/app/views/contributions/reviews/_content_change.slim
+++ b/app/views/contributions/reviews/_content_change.slim
@@ -1,0 +1,17 @@
+.content-change
+
+  / If all fragments are retained, do not show a (useless) diff. Show message
+  / instead.
+  - if content_change.fragments.all?(&:retain?)
+    span.fragment
+      | Text will not change
+      span.help-icon-wrapper.gray-text.text-lighten-1 title='The text content of this file will not change. The file shows up as modified because other elements - such as styles or images - will be modified.'
+        svg.help-icon style="width:24px;height:24px;" viewBox="0 0 24 24"
+          path fill="currentColor" d="M13,9H11V7H13M13,17H11V11H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z"
+
+
+  / Okay, we have an actual diff. Let's display it.
+  - else
+    = render partial: 'revisions/content_change_fragment',
+             collection: content_change.fragments,
+             locals: { truncate_content: true }

--- a/app/views/contributions/reviews/_file_change.slim
+++ b/app/views/contributions/reviews/_file_change.slim
@@ -41,7 +41,5 @@ div.file[class=file_change.symbolic_mime_type
                          link_options: link_options }
 
   - if file_change.modification? && file_change.content_change.present?
-    .content-change
-      = render partial: 'revisions/content_change_fragment',
-               collection: file_change.content_change.fragments,
-               locals: { truncate_content: true }
+    = render partial: 'contributions/reviews/content_change',
+             object: file_change.content_change

--- a/app/views/revisions/_content_change.slim
+++ b/app/views/revisions/_content_change.slim
@@ -1,0 +1,22 @@
+.content-change
+
+  / If all fragments are retained, do not show a (useless) diff. Show message
+  / instead.
+  - if content_change.fragments.all?(&:retain?)
+    span.fragment
+      | Text did not change
+      span.help-icon-wrapper.gray-text.text-lighten-1 title='The text content of this file has not changed. The file shows up as modified because other elements - such as styles or images - were modified.'
+        svg.help-icon style="width:24px;height:24px;" viewBox="0 0 24 24"
+          path fill="currentColor" d="M13,9H11V7H13M13,17H11V11H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z"
+
+
+  / Okay, we have an actual diff. Let's display it.
+  - else
+    = render partial: 'revisions/content_change_fragment',
+             collection: content_change.fragments,
+             locals: { truncate_content: true }
+
+    .links
+      = link_to 'View side-by-side',
+                send(file_change_path, *path_parameters, hashed_file_id),
+                link_options.merge(class: 'btn-flat btn-slim grey lighten-2')

--- a/app/views/revisions/_file_change.slim
+++ b/app/views/revisions/_file_change.slim
@@ -38,14 +38,9 @@ div.file[class=file_change.symbolic_mime_type
                          link_options: link_options }
 
   - if file_change.modification? && file_change.content_change.present?
-    .content-change
-      = render partial: 'revisions/content_change_fragment',
-               collection: file_change.content_change.fragments,
-               locals: { truncate_content: true }
-
-      .links
-        - file_change_path ||= :profile_project_file_change_path
-        - path_parameters ||= [project.owner, project]
-        = link_to 'View side-by-side',
-                  send(file_change_path, *path_parameters, file_change.hashed_file_id),
-                  link_options.merge(class: 'btn-flat btn-slim grey lighten-2')
+    = render partial: 'revisions/content_change',
+             object: file_change.content_change,
+             locals: { hashed_file_id: file_change.hashed_file_id,
+                       file_change_path: file_change_path || :profile_project_file_change_path,
+                       path_parameters: path_parameters || [project.owner, project],
+                       link_options: link_options }

--- a/spec/views/contributions/reviews/show_spec.rb
+++ b/spec/views/contributions/reviews/show_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'views/shared_examples/showing_content_changes.rb'
+
 RSpec.describe 'contributions/reviews/show', type: :view do
   let(:project)       { build_stubbed :project, :with_repository }
   let(:repository)    { project.repository }
@@ -200,34 +202,13 @@ RSpec.describe 'contributions/reviews/show', type: :view do
       end
     end
 
-    context 'when diff is modification and has content change' do
-      let(:change) { revision.file_changes.first }
-      let(:content_change) do
-        VCS::Operations::ContentDiffer.new(
-          new_content: 'hi',
-          old_content: 'bye'
-        )
-      end
+    it_should_behave_like 'showing content changes',
+                          with_link_to_side_by_side: false do
+      let(:diff) { revision.file_changes.first }
       let(:link_to_side_by_side) do
         profile_project_contribution_file_change_path(
-          project.owner, project, contribution, change.hashed_file_id
+          project.owner, project, contribution, diff.hashed_file_id
         )
-      end
-
-      before do
-        allow(change).to receive(:modification?).and_return true
-        allow(change).to receive(:content_change).and_return content_change
-      end
-
-      it 'shows the diff' do
-        render
-        expect(rendered).to have_css('.fragment.addition', text: 'hi')
-        expect(rendered).to have_css('.fragment.deletion', text: 'bye')
-      end
-
-      it 'does not have link to side-by-side diff' do
-        render
-        expect(rendered).not_to have_link(href: link_to_side_by_side)
       end
     end
   end

--- a/spec/views/contributions/reviews/show_spec.rb
+++ b/spec/views/contributions/reviews/show_spec.rb
@@ -210,6 +210,7 @@ RSpec.describe 'contributions/reviews/show', type: :view do
           project.owner, project, contribution, diff.hashed_file_id
         )
       end
+      let(:text_unchanged_message) { 'Text will not change' }
     end
   end
 end

--- a/spec/views/file_infos/index_spec.rb
+++ b/spec/views/file_infos/index_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'views/shared_examples/showing_content_changes.rb'
+
 RSpec.describe 'file_infos/index', type: :view do
   let(:project)               { build_stubbed :project }
   let(:master_branch)         { build_stubbed :vcs_branch }
@@ -156,33 +158,12 @@ RSpec.describe 'file_infos/index', type: :view do
           expect(rendered).to have_text 'My Document deleted from Home'
         end
 
-        context 'when diff is modification and has content change' do
-          let(:content_change) do
-            VCS::Operations::ContentDiffer.new(
-              new_content: 'hi',
-              old_content: 'bye'
+        it_should_behave_like 'showing content changes' do
+          let(:diff) { uncaptured_file_diff }
+          let(:link_to_side_by_side) do
+            profile_project_file_change_path(
+              project.owner, project, diff.hashed_file_id
             )
-          end
-
-          before do
-            allow(uncaptured_file_diff)
-              .to receive(:modification?).and_return true
-            allow(uncaptured_file_diff)
-              .to receive(:content_change).and_return content_change
-          end
-
-          it 'shows the diff' do
-            render
-            expect(rendered).to have_css('.fragment.addition', text: 'hi')
-            expect(rendered).to have_css('.fragment.deletion', text: 'bye')
-          end
-
-          it 'has a link to side-by-side diff' do
-            render
-            link = profile_project_file_change_path(
-              project.owner, project, uncaptured_file_diff.hashed_file_id
-            )
-            expect(rendered).to have_link('View side-by-side', href: link)
           end
         end
 
@@ -299,33 +280,12 @@ RSpec.describe 'file_infos/index', type: :view do
       )
     end
 
-    context 'when diff is modification and has content change' do
-      let(:content_change) do
-        VCS::Operations::ContentDiffer.new(
-          new_content: 'hi',
-          old_content: 'bye'
+    it_should_behave_like 'showing content changes' do
+      let(:diff) { committed_file_diffs.first }
+      let(:link_to_side_by_side) do
+        profile_project_revision_file_change_path(
+          project.owner, project, r1, diff.hashed_file_id
         )
-      end
-
-      before do
-        allow(committed_file_diffs.first)
-          .to receive(:modification?).and_return true
-        allow(committed_file_diffs.first)
-          .to receive(:content_change).and_return content_change
-      end
-
-      it 'shows the diff' do
-        render
-        expect(rendered).to have_css('.fragment.addition', text: 'hi')
-        expect(rendered).to have_css('.fragment.deletion', text: 'bye')
-      end
-
-      it 'has a link to side-by-side diff' do
-        render
-        link = profile_project_revision_file_change_path(
-          project.owner, project, r1, committed_file_diffs.first.hashed_file_id
-        )
-        expect(rendered).to have_link(href: link)
       end
     end
 

--- a/spec/views/revisions/new_spec.rb
+++ b/spec/views/revisions/new_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'views/shared_examples/showing_content_changes.rb'
+
 RSpec.describe 'revisions/new', type: :view do
   let(:project)       { build_stubbed :project, :with_repository }
   let(:repository)    { project.repository }
@@ -108,41 +110,11 @@ RSpec.describe 'revisions/new', type: :view do
       expect(rendered).not_to have_css("a:not([target='_blank'])")
     end
 
-    context 'when diff is modification and has content change' do
-      let(:change) { revision.file_changes.first }
-      let(:content_change) do
-        VCS::Operations::ContentDiffer.new(
-          new_content: 'hi',
-          old_content: 'bye'
-        )
-      end
+    it_should_behave_like 'showing content changes', link_in_new_tab: true do
+      let(:diff) { revision.file_changes.first }
       let(:link_to_side_by_side) do
         profile_project_file_change_path(
-          project.owner, project, change.hashed_file_id
-        )
-      end
-
-      before do
-        allow(change).to receive(:modification?).and_return true
-        allow(change).to receive(:content_change).and_return content_change
-      end
-
-      it 'shows the diff' do
-        render
-        expect(rendered).to have_css('.fragment.addition', text: 'hi')
-        expect(rendered).to have_css('.fragment.deletion', text: 'bye')
-      end
-
-      it 'has a link to side-by-side diff' do
-        render
-        expect(rendered)
-          .to have_link('View side-by-side', href: link_to_side_by_side)
-      end
-
-      it 'opens side-by-side diff in a new tab' do
-        render
-        expect(rendered).to have_selector(
-          "a[href='#{link_to_side_by_side}'][target='_blank']"
+          project.owner, project, diff.hashed_file_id
         )
       end
     end

--- a/spec/views/shared_examples/showing_content_changes.rb
+++ b/spec/views/shared_examples/showing_content_changes.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'showing content changes' \
+  do |with_link_to_side_by_side: true, link_in_new_tab: false|
+
+  it 'does not show the content change' do
+    render
+    expect(rendered).not_to have_css('.fragment.addition')
+    expect(rendered).not_to have_css('.fragment.deletion')
+  end
+
+  context 'when diff is modification and has content change' do
+    let(:content_change) do
+      VCS::Operations::ContentDiffer.new(
+        new_content: 'hi',
+        old_content: 'bye'
+      )
+    end
+
+    before do
+      allow(diff).to receive(:modification?).and_return true
+      allow(diff).to receive(:content_change).and_return content_change
+    end
+
+    it 'shows the diff' do
+      render
+      expect(rendered).to have_css('.fragment.addition', text: 'hi')
+      expect(rendered).to have_css('.fragment.deletion', text: 'bye')
+    end
+
+    if with_link_to_side_by_side
+      it 'has a link to side-by-side diff' do
+        render
+        expect(rendered)
+          .to have_link('View side-by-side', href: link_to_side_by_side)
+      end
+    else
+      it 'does not have a link to side-by-side diff' do
+        render
+        expect(rendered).not_to have_link(href: link_to_side_by_side)
+      end
+    end
+
+    if link_in_new_tab
+      it 'opens side-by-side diff in a new tab' do
+        render
+        expect(rendered).to have_selector(
+          "a[href='#{link_to_side_by_side}'][target='_blank']"
+        )
+      end
+    end
+
+    xcontext 'when all fragments are retained' do
+      before do
+        content_change.fragments.each do |fragment|
+          allow(fragment).to receive(:retain?).and_return true
+        end
+      end
+
+      it 'displays information that the text did not change' do
+        render
+        expect(rendered).to have_text 'Text did not change'
+      end
+    end
+  end
+end

--- a/spec/views/shared_examples/showing_content_changes.rb
+++ b/spec/views/shared_examples/showing_content_changes.rb
@@ -3,6 +3,8 @@
 RSpec.shared_examples 'showing content changes' \
   do |with_link_to_side_by_side: true, link_in_new_tab: false|
 
+  let(:text_unchanged_message) { 'Text did not change' }
+
   it 'does not show the content change' do
     render
     expect(rendered).not_to have_css('.fragment.addition')
@@ -50,7 +52,7 @@ RSpec.shared_examples 'showing content changes' \
       end
     end
 
-    xcontext 'when all fragments are retained' do
+    context 'when all fragments are retained' do
       before do
         content_change.fragments.each do |fragment|
           allow(fragment).to receive(:retain?).and_return true
@@ -59,7 +61,7 @@ RSpec.shared_examples 'showing content changes' \
 
       it 'displays information that the text did not change' do
         render
-        expect(rendered).to have_text 'Text did not change'
+        expect(rendered).to have_text text_unchanged_message
       end
     end
   end


### PR DESCRIPTION
Inform the user that there has been no change in document text when all
fragments are retained between two versions. The file still shows up as
modified because other, non-text elements of the file were modified.

Resolves [#240](https://github.com/OpenlyOne/openly/issues/240)