### PR TITLE
Make private projects a premium feature

### DIFF
--- a/app/assets/stylesheets/shared/chips.scss
+++ b/app/assets/stylesheets/shared/chips.scss
@@ -74,4 +74,10 @@
     border-top-left-radius: inherit;
     border-top-right-radius: 0;
   }
+
+  // align chip with text
+  &.inline {
+    margin: 0 5px;
+    vertical-align: top;
+  }
 }

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -10,6 +10,8 @@ class ProjectsController < ApplicationController
   before_action :set_project, only: %i[show edit update destroy]
   before_action :authorize_action, only: %i[create edit update destroy]
   before_action :authorize_project_access, only: :show
+  before_action :set_user_can_create_private_projects, only: %i[new create]
+
 
   def new; end
 
@@ -105,5 +107,10 @@ class ProjectsController < ApplicationController
 
   def project_overview_path
     profile_project_overview_path(@project.owner, @project)
+  end
+
+  def set_user_can_create_private_projects
+    @user_can_create_private_projects =
+      current_user.can_create_private_projects?
   end
 end

--- a/app/dashboards/account_dashboard.rb
+++ b/app/dashboards/account_dashboard.rb
@@ -16,6 +16,7 @@ class AccountDashboard < Administrate::BaseDashboard
     email: Field::String,
     password: Field::Password,
     password_confirmation: Field::Password,
+    is_premium: Field::Boolean,
     created_at: Field::DateTime,
     updated_at: Field::DateTime
   }.freeze
@@ -28,6 +29,7 @@ class AccountDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = %i[
     id
     email
+    is_premium
     user
   ].freeze
 
@@ -36,6 +38,7 @@ class AccountDashboard < Administrate::BaseDashboard
   SHOW_PAGE_ATTRIBUTES = %i[
     id
     email
+    is_premium
     user
     created_at
     updated_at
@@ -48,6 +51,7 @@ class AccountDashboard < Administrate::BaseDashboard
     email
     password
     password_confirmation
+    is_premium
     user
   ].freeze
 
@@ -55,6 +59,6 @@ class AccountDashboard < Administrate::BaseDashboard
   # across all pages of the admin dashboard.
   #
   def display_resource(account)
-    account.email
+    account.premium? ? "#{account.email} (Premium)" : account.email
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -27,6 +27,11 @@ class Account < ApplicationRecord
   validates :user, presence: true, on: :create
   devise :validatable
 
+  # Return true if the account has a premium membership
+  def premium?
+    is_premium
+  end
+
   # Monkey patch activity_notification's notify_to, so that it returns an
   # instance of Notification (instead of ActivityNotification::Notification)
   def notify_to(notifying_object, options = {})

--- a/app/models/profiles/user.rb
+++ b/app/models/profiles/user.rb
@@ -18,5 +18,9 @@ module Profiles
 
     # Delegations
     delegate :admin?, to: :account
+
+    def premium_account?
+      account.premium?
+    end
   end
 end

--- a/app/models/profiles/user.rb
+++ b/app/models/profiles/user.rb
@@ -22,5 +22,11 @@ module Profiles
     def premium_account?
       account.premium?
     end
+
+    def can_create_private_projects?
+      Ability
+        .new(self)
+        .can?(:create, Project.new(is_public: false, owner: self))
+    end
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -157,11 +157,11 @@ class Project < ApplicationRecord
   end
 
   def private?
-    !public?
+    is_public == false
   end
 
   def public?
-    is_public
+    is_public == true
   end
 
   # Return true if the setup process for this project has not started

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -91,6 +91,11 @@ class Project < ApplicationRecord
   # Title & slug must be present
   validates :title, presence: true, length: { maximum: 50 }
   validates :slug, presence: true
+  validates :is_public,
+            inclusion: {
+              in: [true, false],
+              message: 'must be public or private'
+            }
   # Conduct validations only if slug is present
   with_options if: :slug? do
     validates :slug, length: { maximum: 50 }

--- a/app/views/projects/new.slim
+++ b/app/views/projects/new.slim
@@ -31,9 +31,17 @@
 
           .section.no-padding-top
             label
-              = f.radio_button :is_public, false, checked: @project.private?, class: 'with-gap private'
-              span.black-text
+              = f.radio_button :is_public, false, checked: @project.private?, class: 'with-gap private', disabled: !@user_can_create_private_projects
+              span class=[@user_can_create_private_projects ? 'black-text' : 'gray-text']
                 b Private
+                - unless @user_can_create_private_projects
+                  = mail_to Settings.support_email, \
+                            subject: "Upgrade to premium: #{@current_account.user.handle}", \
+                            body: "Hi there,\n\n\nI would like to update my account #{@current_account.email} to a paid plan.\n\n\nCheers,\n#{@current_account.user.name}"
+                    span.chip.slim.primary-color.primary-color-text.inline
+                      svg.icon style="width:24px;height:24px" viewBox="0 0 24 24"
+                        path fill="currentColor" d="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.45,13.97L5.82,21L12,17.27Z"
+                      | Premium | Upgrade
                 br
                 | You choose who can see this project and make changes.
 

--- a/app/views/projects/new.slim
+++ b/app/views/projects/new.slim
@@ -20,11 +20,22 @@
             = f.text_field :title, placeholder: 'Title', class: 'inherit'
     .row
       .col.s12
-        p
-          | Projects are private by default. Only you (and any collaborators
-            you add to your projects) will be able to see files, changes, and
-            summaries.
-        .spacing.v16px
+        .section.no-padding-top
+          .section.no-padding-top
+            label
+              = f.radio_button :is_public, true, checked: @project.public?, class: 'with-gap public'
+              span.black-text
+                b Public
+                br
+                | Anyone can see this project. Only you can make changes.
+
+          .section.no-padding-top
+            label
+              = f.radio_button :is_public, false, checked: @project.private?, class: 'with-gap private'
+              span.black-text
+                b Private
+                br
+                | You choose who can see this project and make changes.
 
     .row
       .col.s12

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,7 @@ en:
       project:
         slug: 'Project URL'
         link_to_google_drive_folder: 'Link to Google Drive folder'
+        is_public: 'Visibility'
   unauthorized:
     manage:
       profiles/user: "You are not authorized to %{action} this profile."

--- a/db/migrate/20190212053330_add_is_premium_to_accounts.rb
+++ b/db/migrate/20190212053330_add_is_premium_to_accounts.rb
@@ -1,0 +1,5 @@
+class AddIsPremiumToAccounts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :accounts, :is_premium, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20190212095542_remove_column_default_from_projects_is_public.rb
+++ b/db/migrate/20190212095542_remove_column_default_from_projects_is_public.rb
@@ -1,0 +1,9 @@
+class RemoveColumnDefaultFromProjectsIsPublic < ActiveRecord::Migration[5.2]
+  def up
+    change_column_default :projects, :is_public, nil
+  end
+
+  def down
+    change_column_default :projects, :is_public, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_10_093056) do
+ActiveRecord::Schema.define(version: 2019_02_12_053330) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 2019_02_10_093056) do
     t.datetime "updated_at", null: false
     t.datetime "remember_created_at"
     t.boolean "admin", default: false
+    t.boolean "is_premium", default: false, null: false
     t.index ["email"], name: "index_accounts_on_email", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_12_053330) do
+ActiveRecord::Schema.define(version: 2019_02_12_095542) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -220,7 +220,7 @@ ActiveRecord::Schema.define(version: 2019_02_12_053330) do
     t.citext "slug", null: false
     t.text "description"
     t.citext "tags", default: [], array: true
-    t.boolean "is_public", default: false, null: false
+    t.boolean "is_public", null: false
     t.bigint "repository_id"
     t.bigint "master_branch_id"
     t.boolean "are_contributions_enabled", default: false, null: false

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -14,5 +14,13 @@ FactoryBot.define do
     trait :admin do
       admin { true }
     end
+
+    trait :premium do
+      is_premium { true }
+    end
+
+    trait :free do
+      is_premium { false }
+    end
   end
 end

--- a/spec/factories/profiles/base.rb
+++ b/spec/factories/profiles/base.rb
@@ -22,6 +22,13 @@ FactoryBot.define do
       end
     end
 
+    trait :free do
+      account do
+        build(:account, :free, user: Profiles::User.new(name: name),
+                               force_email: account_email)
+      end
+    end
+
     trait :with_social_links do
       link_to_website   { Faker::Internet.url }
       link_to_facebook  { Faker::Internet.url('facebook.com') }

--- a/spec/factories/profiles/base.rb
+++ b/spec/factories/profiles/base.rb
@@ -15,6 +15,13 @@ FactoryBot.define do
     handle    { Faker::Internet.user_name(name.first(26).strip, %w[_]) }
     location  { "#{city}, #{state}, USA" }
 
+    trait :premium do
+      account do
+        build(:account, :premium, user: Profiles::User.new(name: name),
+                                  force_email: account_email)
+      end
+    end
+
     trait :with_social_links do
       link_to_website   { Faker::Internet.url }
       link_to_facebook  { Faker::Internet.url('facebook.com') }

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -33,6 +33,8 @@ feature 'Account' do
       # and there should be an account in the database
       expect(Account.count).to equal 1
       expect(Account).to exist(email: account.email)
+      # and account should not be premium
+      expect(Account.all).to be_none(&:premium?)
       # and there should be a user in the database
       expect(Profiles::User).to exist(account: Account.first)
     end

--- a/spec/features/admin_panel_spec.rb
+++ b/spec/features/admin_panel_spec.rb
@@ -24,6 +24,28 @@ feature 'Admin Panel' do
     click_on 'Projects'
     click_on 'Profiles/Users'
   end
+
+  scenario 'Accounts created default to non-premium' do
+    admin = create :account, :admin
+    sign_in_as admin
+
+    # when I create a new account
+    visit '/admin'
+    click_on 'Accounts'
+    click_on 'New account'
+    fill_in 'Email', with: 'test@user.com'
+    fill_in 'Password', with: 'password'
+    fill_in 'Password confirmation', with: 'password'
+    fill_in 'Name', with: 'Test User'
+    fill_in 'Handle', with: 'testuser'
+    click_on 'Create Account'
+
+    # then the account should be created
+    account = Account.find_by_email('test@user.com')
+    expect(account).to be_present
+    # and it should not be premium
+    expect(account).not_to be_premium
+  end
 end
 
 feature 'Analytics Dashboard' do

--- a/spec/features/premium_feature_spec.rb
+++ b/spec/features/premium_feature_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+feature 'Premium Users' do
+  let(:user_account_email) { ENV['GOOGLE_DRIVE_USER_ACCOUNT'] }
+  let(:project_owner) { create(:user, account: user_account) }
+  let(:user_account)  { build(:account, :premium, email: user_account_email) }
+
+  # create test folder
+  before(:each, :vcr) { prepare_google_drive_test }
+
+  # delete test folder
+  after(:each, :vcr) { tear_down_google_drive_test }
+
+  scenario 'Premium user can create private project', :vcr do
+    # given I am signed in as its owner
+    account = user_account.tap(&:save)
+    sign_in_as account
+
+    # when I click on 'New Project'
+    within 'nav' do
+      click_on 'New Project'
+    end
+    # and fill in title and slug
+    fill_in 'project_title', with: 'My Awesome New Project!'
+    find('.private').click
+    # and save
+    click_on 'Create'
+
+    # then I should be on the project page
+    expect(page).to have_current_path(
+      "/#{account.user.to_param}/my-awesome-new-project/setup/new"
+    )
+    # and see the new project's title
+    expect(page).to have_text 'My Awesome New Project!'
+    # and see a success message
+    expect(page).to have_text 'Project successfully created.'
+    # and have set up an archive folder on Google Drive
+    expect(Project.first.archive).to be_present
+    # and a repository and master branch
+    expect(Project.first.repository).to be_present
+    expect(Project.first.master_branch).to be_present
+    # and be private
+    expect(Project.first).to be_private
+  end
+end

--- a/spec/features/project_spec.rb
+++ b/spec/features/project_spec.rb
@@ -11,7 +11,7 @@ feature 'Project' do
   # delete test folder
   after(:each, :vcr) { tear_down_google_drive_test }
 
-  scenario 'User can create project', :vcr do
+  scenario 'User can create public project', :vcr do
     # given I am signed in as its owner
     account = user_account.tap(&:save)
     sign_in_as account
@@ -22,6 +22,8 @@ feature 'Project' do
     end
     # and fill in title and slug
     fill_in 'project_title', with: 'My Awesome New Project!'
+    find('.public').click
+
     # and save
     click_on 'Create'
 
@@ -38,6 +40,8 @@ feature 'Project' do
     # and a repository and master branch
     expect(Project.first.repository).to be_present
     expect(Project.first.master_branch).to be_present
+    # and be public
+    expect(Project.first).to be_public
   end
 
   scenario 'User can view project' do

--- a/spec/integrations/profiles/user_spec.rb
+++ b/spec/integrations/profiles/user_spec.rb
@@ -110,4 +110,18 @@ RSpec.describe Profiles::User, type: :model do
       expect(exif_data).not_to match(/exif:/)
     end
   end
+
+  describe '#can_create_private_projects?' do
+    context 'when user account is free' do
+      subject(:user) { create(:user, :free) }
+
+      it { is_expected.not_to be_can_create_private_projects }
+    end
+
+    context 'when user account is premium' do
+      subject(:user) { create(:user, :premium) }
+
+      it { is_expected.to be_can_create_private_projects }
+    end
+  end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -67,17 +67,55 @@ RSpec.describe Ability, type: :model do
   end
 
   context 'Projects' do
-    actions = %i[edit update destroy]
-    let(:object) { build_stubbed(:project) }
+    describe 'create' do
+      actions = %i[create]
 
-    context 'when user is owner' do
-      before { object.owner = user }
+      let(:object) { build_stubbed(:project, :public, owner: user) }
+
       it_should_behave_like 'having authorization', actions
+
+      context 'when project is not owned by user' do
+        before { object.owner = build_stubbed(:user) }
+
+        it_should_behave_like 'not having authorization', actions
+      end
+
+      context 'when project visibility has not been chosen' do
+        before { object.is_public = nil }
+
+        it_should_behave_like 'having authorization', actions
+      end
+
+      context 'when project is private' do
+        before { object.is_public = false }
+
+        context 'when user has premium account' do
+          let(:user) { create(:user, :premium) }
+
+          it_should_behave_like 'having authorization', actions
+        end
+
+        context 'when user does not have premium account' do
+          let(:user) { create(:user) }
+
+          it_should_behave_like 'not having authorization', actions
+        end
+      end
     end
 
-    context 'when user is not owner' do
-      before { object.owner = build_stubbed(:user) }
-      it_should_behave_like 'not having authorization', actions
+    describe 'edit, update, destroy' do
+      actions = %i[edit update destroy]
+      let(:object) { build_stubbed(:project) }
+
+      context 'when user is owner' do
+        before { object.owner = user }
+        it_should_behave_like 'having authorization', actions
+      end
+
+      context 'when user is not owner' do
+        before { object.owner = build_stubbed(:user) }
+        it_should_behave_like 'not having authorization', actions
+      end
     end
   end
 

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe Account, type: :model do
   describe 'attributes' do
     it { is_expected.to accept_nested_attributes_for(:user) }
     it { is_expected.to have_readonly_attribute(:email) }
+
+    it 'sets is_premium to false by default' do
+      expect(account).not_to be_premium
+    end
   end
 
   describe 'delegations' do

--- a/spec/models/profiles/user_spec.rb
+++ b/spec/models/profiles/user_spec.rb
@@ -33,4 +33,18 @@ RSpec.describe Profiles::User, type: :model do
       is_expected.to validate_presence_of(:account).with_message 'must exist'
     end
   end
+
+  describe '#premium_account?' do
+    context 'when account is premium' do
+      before { user.account = build_stubbed(:account, :premium) }
+
+      it { is_expected.to be_premium_account }
+    end
+
+    context 'when account is not premium' do
+      before { user.account = build_stubbed(:account, :free) }
+
+      it { is_expected.not_to be_premium_account }
+    end
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -82,6 +82,10 @@ RSpec.describe Project, type: :model do
     it 'disables contributions by default' do
       expect(described_class.new).not_to be_contributions_enabled
     end
+    it 'is neither private nor public by default' do
+      expect(described_class.new).not_to be_private
+      expect(described_class.new).not_to be_public
+    end
   end
 
   describe 'delegations' do
@@ -223,6 +227,13 @@ RSpec.describe Project, type: :model do
     end
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_length_of(:title).is_at_most(50) }
+    it do
+      project.is_public = nil
+      project.valid?
+      expect(project.errors.full_messages).to include(
+        'Visibility must be public or private'
+      )
+    end
 
     context 'when validating slug' do
       it do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -362,6 +362,50 @@ RSpec.describe Project, type: :model do
     end
   end
 
+  describe '#private?' do
+    before { project.is_public = state }
+
+    context 'when is_public = true' do
+      let(:state) { true }
+
+      it { is_expected.not_to be_private }
+    end
+
+    context 'when is_public = false' do
+      let(:state) { false }
+
+      it { is_expected.to be_private }
+    end
+
+    context 'when is_public = nil' do
+      let(:state) { nil }
+
+      it { is_expected.not_to be_private }
+    end
+  end
+
+  describe '#public?' do
+    before { project.is_public = state }
+
+    context 'when is_public = true' do
+      let(:state) { true }
+
+      it { is_expected.to be_public }
+    end
+
+    context 'when is_public = false' do
+      let(:state) { false }
+
+      it { is_expected.not_to be_public }
+    end
+
+    context 'when is_public = nil' do
+      let(:state) { nil }
+
+      it { is_expected.not_to be_public }
+    end
+  end
+
   describe '#setup_not_started?' do
     subject(:setup_started) { project.setup_not_started? }
     let(:not_started)       { false }

--- a/spec/support/fixtures/vcr_cassettes/Premium_Users/Premium_user_can_create_private_project.yml
+++ b/spec/support/fixtures/vcr_cassettes/Premium_Users/Premium_user_can_create_private_project.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Fri, 04 Jan 2019 15:57:45 GMT
+      - Tue, 12 Feb 2019 10:19:49 GMT
       Server:
       - ESF
       Cache-Control:
@@ -40,7 +40,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
@@ -53,14 +53,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Fri, 04 Jan 2019 15:57:45 GMT
+  recorded_at: Tue, 12 Feb 2019 10:19:49 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2019-01-04
-        15:57:45 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2019-02-12
+        10:19:49 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -69,7 +69,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 04 Jan 2019 15:57:45 GMT
+      - Tue, 12 Feb 2019 10:19:49 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -86,7 +86,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 04 Jan 2019 15:57:46 GMT
+      - Tue, 12 Feb 2019 10:19:50 GMT
       Vary:
       - Origin
       - X-Origin
@@ -103,15 +103,15 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1fZwV6GttgPBq-hP8vR7MzUU_VECG4Q5f",
-         "name": "Test @ 2019-01-04 15:57:45 UTC",
+         "id": "1akIHPDQGKvqNS02Da7K5aQk6xZ-Mzdy4",
+         "name": "Test @ 2019-02-12 10:19:49 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -131,7 +131,7 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 04 Jan 2019 15:57:46 GMT
+  recorded_at: Tue, 12 Feb 2019 10:19:50 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
@@ -147,7 +147,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 04 Jan 2019 15:57:46 GMT
+      - Tue, 12 Feb 2019 10:19:51 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -164,7 +164,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 04 Jan 2019 15:57:46 GMT
+      - Tue, 12 Feb 2019 10:19:52 GMT
       Vary:
       - Origin
       - X-Origin
@@ -181,14 +181,14 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1TVpawBNkifDBul9GbWeo3II7COH77zUm",
+         "id": "1jEopirW5r1SzXDVsBi_X_fYQcocsjw6V",
          "name": "My Awesome New Project! (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
@@ -209,10 +209,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Fri, 04 Jan 2019 15:57:46 GMT
+  recorded_at: Tue, 12 Feb 2019 10:19:52 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1TVpawBNkifDBul9GbWeo3II7COH77zUm/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1jEopirW5r1SzXDVsBi_X_fYQcocsjw6V/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -224,7 +224,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 04 Jan 2019 15:57:46 GMT
+      - Tue, 12 Feb 2019 10:19:52 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -241,7 +241,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 04 Jan 2019 15:57:47 GMT
+      - Tue, 12 Feb 2019 10:19:53 GMT
       Vary:
       - Origin
       - X-Origin
@@ -258,7 +258,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
@@ -271,10 +271,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Fri, 04 Jan 2019 15:57:47 GMT
+  recorded_at: Tue, 12 Feb 2019 10:19:53 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1fZwV6GttgPBq-hP8vR7MzUU_VECG4Q5f
+    uri: https://www.googleapis.com/drive/v3/files/1akIHPDQGKvqNS02Da7K5aQk6xZ-Mzdy4
     body:
       encoding: UTF-8
       string: ''
@@ -286,7 +286,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Fri, 04 Jan 2019 15:57:47 GMT
+      - Tue, 12 Feb 2019 10:19:53 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -303,17 +303,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Fri, 04 Jan 2019 15:57:48 GMT
+      - Tue, 12 Feb 2019 10:19:54 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 04 Jan 2019 15:57:48 GMT
+  recorded_at: Tue, 12 Feb 2019 10:19:54 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Project/User_can_create_public_project.yml
+++ b/spec/support/fixtures/vcr_cassettes/Project/User_can_create_public_project.yml
@@ -1,0 +1,382 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://oauth2.googleapis.com/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR TRACKING ACCOUNT>&client_id=<CLIENT
+        ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Tue, 12 Feb 2019 10:21:22 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR TRACKING ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Tue, 12 Feb 2019 10:21:22 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2019-02-12
+        10:21:22 UTC","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Tue, 12 Feb 2019 10:21:22 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Tue, 12 Feb 2019 10:21:23 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1u1KLcwKBeu7pb_FlZoCE9Fsx1QYGDVNf",
+         "name": "Test @ 2019-02-12 10:21:22 UTC",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Tue, 12 Feb 2019 10:21:23 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"My Awesome
+        New Project! (Archive)","parents":["root"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Tue, 12 Feb 2019 10:21:23 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Tue, 12 Feb 2019 10:21:24 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1GYDxZaZo9OX4EmDtBWKymE4ssa7TE95h",
+         "name": "My Awesome New Project! (Archive)",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "0AIeK5UAEPQfeUk9PVA"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Tue, 12 Feb 2019 10:21:24 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1GYDxZaZo9OX4EmDtBWKymE4ssa7TE95h/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Tue, 12 Feb 2019 10:21:24 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Tue, 12 Feb 2019 10:21:25 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "13193959451567607887",
+         "type": "user",
+         "role": "reader"
+        }
+    http_version: 
+  recorded_at: Tue, 12 Feb 2019 10:21:25 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1GYDxZaZo9OX4EmDtBWKymE4ssa7TE95h/permissions
+    body:
+      encoding: UTF-8
+      string: '{"role":"reader","type":"anyone"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Tue, 12 Feb 2019 10:21:25 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Tue, 12 Feb 2019 10:21:25 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#permission",
+         "id": "anyoneWithLink",
+         "type": "anyone",
+         "role": "reader",
+         "allowFileDiscovery": false
+        }
+    http_version: 
+  recorded_at: Tue, 12 Feb 2019 10:21:25 GMT
+- request:
+    method: delete
+    uri: https://www.googleapis.com/drive/v3/files/1u1KLcwKBeu7pb_FlZoCE9Fsx1QYGDVNf
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Tue, 12 Feb 2019 10:21:25 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Tue, 12 Feb 2019 10:21:26 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 12 Feb 2019 10:21:26 GMT
+recorded_with: VCR 4.0.0

--- a/spec/views/projects/new_spec.rb
+++ b/spec/views/projects/new_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe 'projects/new', type: :view do
-  let(:project) { build(:project) }
+  let(:project) { build(:project, is_public: nil) }
 
   before { assign(:project, project) }
 
@@ -25,14 +25,32 @@ RSpec.describe 'projects/new', type: :view do
     expect(rendered).to have_css 'input#project_title'
   end
 
-  it 'informs user that projects are private' do
+  it 'has a select option for visibility' do
     render
-    expect(rendered).to have_text 'Projects are private'
+    expect(rendered).to have_field(
+      class: 'public', type: 'radio', with: true, checked: false
+    )
+    expect(rendered).to have_field(
+      class: 'private', type: 'radio', with: false, checked: false
+    )
+  end
+
+  xit 'has the private option disabled' do
+    expect(rendered).to have_field('Private', type: 'select', disabled: true)
   end
 
   it 'has a button to create the project' do
     render
     expect(rendered)
       .to have_css "button[action='submit']", text: 'Create'
+  end
+
+  xcontext 'when user can create private projects' do
+    before { assign(:user_can_create_private_projects, true) }
+
+    it 'has the private option enabled' do
+      render
+      expect(rendered).to have_field('Private', type: 'select', disabled: false)
+    end
   end
 end

--- a/spec/views/projects/new_spec.rb
+++ b/spec/views/projects/new_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe 'projects/new', type: :view do
   let(:project) { build(:project, is_public: nil) }
 
   before { assign(:project, project) }
+  before { assign(:current_account, create(:account)) }
 
   it 'renders a form with projects_path action' do
     render
@@ -31,12 +32,23 @@ RSpec.describe 'projects/new', type: :view do
       class: 'public', type: 'radio', with: true, checked: false
     )
     expect(rendered).to have_field(
-      class: 'private', type: 'radio', with: false, checked: false
+      class: 'private', type: 'radio',
+      with: false, checked: false, disabled: true
     )
   end
 
-  xit 'has the private option disabled' do
-    expect(rendered).to have_field('Private', type: 'select', disabled: true)
+  it 'has the private option disabled' do
+    render
+    expect(rendered).to have_field(
+      class: 'private', type: 'radio', disabled: true
+    )
+  end
+
+  it 'renders an upgrade button' do
+    render
+    expect(rendered).to have_css(
+      "a[href^='mailto:#{Settings.support_email}']", text: 'Upgrade'
+    )
   end
 
   it 'has a button to create the project' do
@@ -45,12 +57,21 @@ RSpec.describe 'projects/new', type: :view do
       .to have_css "button[action='submit']", text: 'Create'
   end
 
-  xcontext 'when user can create private projects' do
+  context 'when user can create private projects' do
     before { assign(:user_can_create_private_projects, true) }
 
     it 'has the private option enabled' do
       render
-      expect(rendered).to have_field('Private', type: 'select', disabled: false)
+      expect(rendered).to have_field(
+        class: 'private', type: 'radio', with: false, disabled: false
+      )
+    end
+
+    it 'does not render an upgrade button' do
+      render
+      expect(rendered).not_to have_css(
+        "a[href^='mailto:#{Settings.support_email}']", text: 'Upgrade'
+      )
     end
   end
 end


### PR DESCRIPTION
Add support for premium accounts (paid plans). All accounts default to free
accounts. This can be changed via the admin panel.

Free users can only create public projects. Premium users can choose between
creating private and public projects.