### PR TITLE
Improve notification icon

### DIFF
--- a/app/views/application/_navbar_signed_in.slim
+++ b/app/views/application/_navbar_signed_in.slim
@@ -10,9 +10,17 @@ li
     - if notification_count.nonzero?
       span.badge.unread.black.white-text.z-depth-1.right
         = notification_count
-    i.material-icons
-      svg style="width:24px;height:24px" viewBox="0 0 24 24"
-        path fill="currentColor" d="M17.9,17.39C17.64,16.59 16.89,16 16,16H15V13A1,1 0 0,0 14,12H8V10H10A1,1 0 0,0 11,9V7H13A2,2 0 0,0 15,5V4.59C17.93,5.77 20,8.64 20,12C20,14.08 19.2,15.97 17.9,17.39M11,19.93C7.05,19.44 4,16.08 4,12C4,11.38 4.08,10.78 4.21,10.21L9,15V16A2,2 0 0,0 11,18M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2Z"
+
+      / ringing bell
+      i.material-icons
+        svg style="width:24px;height:24px" viewBox="0 0 24 24"
+          path fill="currentColor" d="M21,19V20H3V19L5,17V11C5,7.9 7.03,5.17 10,4.29C10,4.19 10,4.1 10,4A2,2 0 0,1 12,2A2,2 0 0,1 14,4C14,4.1 14,4.19 14,4.29C16.97,5.17 19,7.9 19,11V17L21,19M14,21A2,2 0 0,1 12,23A2,2 0 0,1 10,21M19.75,3.19L18.33,4.61C20.04,6.3 21,8.6 21,11H23C23,8.07 21.84,5.25 19.75,3.19M1,11H3C3,8.6 3.96,6.3 5.67,4.61L4.25,3.19C2.16,5.25 1,8.07 1,11Z"
+
+    - else
+      / non-ringing bell
+      i.material-icons
+        svg style="width:24px;height:24px" viewBox="0 0 24 24"
+          path fill="currentColor" d="M21,19V20H3V19L5,17V11C5,7.9 7.03,5.17 10,4.29C10,4.19 10,4.1 10,4A2,2 0 0,1 12,2A2,2 0 0,1 14,4C14,4.1 14,4.19 14,4.29C16.97,5.17 19,7.9 19,11V17L21,19M14,21A2,2 0 0,1 12,23A2,2 0 0,1 10,21"
 
 
 li


### PR DESCRIPTION
Use Google's `bell` and `bell-ring` icon as the notifications icon.
`bell` is used when no unread notifications are present.
`bell-ring` is used when unread notifications are present.

Resolves [#318](https://github.com/OpenlyOne/openly/issues/318)