### PR TITLE
Hotfix v0.35.1: Relabel CTA on landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v0.35.1 (Feb 16, 2019)
+
+**Fixes:**
+- Relabel CTA on landing page to 'Get Started' because it may invite more
+  responses than 'Join Waitlist'
+
 ## v0.35 (Feb 13, 2019)
 
 **Enhancements:**

--- a/app/views/static/_call_to_action.slim
+++ b/app/views/static/_call_to_action.slim
@@ -1,4 +1,4 @@
 a.btn-large.primary-color.primary-color-text[
   target='_blank'
-  href='http://bit.ly/OpenlyWaitlist']
-  | Join Waitlist
+  href='https://bit.ly/GetStartedOpenly']
+  | Get Started

--- a/spec/features/static_spec.rb
+++ b/spec/features/static_spec.rb
@@ -4,6 +4,6 @@ feature 'Static Pages' do
   scenario 'Visiting the home page' do
     visit '/'
     expect(page).to have_content 'Work on documents just like you do on code.'
-    expect(page).to have_link 'Join Waitlist'
+    expect(page).to have_link 'Get Started'
   end
 end


### PR DESCRIPTION
**Fixes:**
- Relabel CTA on landing page to 'Get Started' because it may invite
  more responses than 'Join Waitlist'