### PR TITLE
Contribution: Apply suggested changes relative to origin revision

### DIFF
--- a/app/controllers/contributions_controller.rb
+++ b/app/controllers/contributions_controller.rb
@@ -43,7 +43,10 @@ class ContributionsController < ApplicationController
   end
 
   def build_contribution
-    @contribution = @project.contributions.build(creator: current_user)
+    @contribution = @project.contributions.build(
+      creator: current_user,
+      origin_revision: @project.revisions.last
+    )
   end
 
   def find_contribution

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -12,7 +12,6 @@ class ProjectsController < ApplicationController
   before_action :authorize_project_access, only: :show
   before_action :set_user_can_create_private_projects, only: %i[new create]
 
-
   def new; end
 
   def create

--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # A contribution to a project (equivalent of pull request/merge request)
+# rubocop:disable Metrics/ClassLength
 class Contribution < ApplicationRecord
   # Associations
   belongs_to :project
@@ -50,6 +51,17 @@ class Contribution < ApplicationRecord
 
     # Return true
     true
+  end
+
+  # Calculate the file changes suggested by this contribution
+  # TODO: Factor author out of this
+  def suggested_file_diffs
+    @suggested_file_diffs ||=
+      branch
+      .all_commits.create!(parent: origin_revision, author: creator)
+      .tap(&:commit_all_files_in_branch)
+      .tap(&:generate_diffs)
+      .file_diffs.includes(:new_version, :old_version)
   end
 
   # Build the revision to be accepted
@@ -130,3 +142,4 @@ class Contribution < ApplicationRecord
                                           author_id: creator_id)
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -109,12 +109,11 @@ class Contribution < ApplicationRecord
       (will_save_change_to_is_accepted? || saved_change_to_is_accepted?)
   end
 
-  # TODO: Copy files from the origin revision rather than just forking master
-  # =>    at the latest revision
   def fork_master_branch
     self.branch = project_master_branch.create_fork(
       creator: creator,
-      remote_parent_id: project.archive.remote_file_id
+      remote_parent_id: project.archive.remote_file_id,
+      commit: origin_revision
     )
   end
 

--- a/app/models/contribution.rb
+++ b/app/models/contribution.rb
@@ -45,8 +45,11 @@ class Contribution < ApplicationRecord
                                               revision: revision },
                                             :accept)
 
-    # TODO: Factor author/creator out of this
-    project.master_branch.restore_commit(revision, author: creator)
+    # Apply suggested changes onto files in master branch
+    VCS::Operations::RestoreFilesFromDiffs.restore(
+      file_diffs: revision.file_diffs.includes(:new_version),
+      target_branch: project.master_branch
+    )
 
     # Return true
     true

--- a/app/models/vcs/branch.rb
+++ b/app/models/vcs/branch.rb
@@ -2,6 +2,7 @@
 
 module VCS
   # A branch of the repository
+  # rubocop:disable Metrics/ClassLength
   class Branch < ApplicationRecord
     # Associations
     belongs_to :repository
@@ -93,6 +94,11 @@ module VCS
       end
     end
 
+    def mark_files_as_committed(commit)
+      copy_untracked_files_from_commit(commit)
+      copy_committed_version_id_from_commit(commit)
+    end
+
     # Fork this branch
     # TODO: Author should be extracted out of this operation. It is
     # =>    not needed. But we need to remove the not null constraint from the
@@ -129,6 +135,41 @@ module VCS
 
     private
 
+    # Copy over any files from commit that are not yet tracked in this branch
+    # All new files are marked as deleted
+    def copy_untracked_files_from_commit(commit)
+      # Select all versions that belong to a file not present in this branch
+      file_ids_in_this_branch = files.pluck(:file_id)
+      versions_to_copy = commit.committed_versions
+                               .where.not(file_id: file_ids_in_this_branch)
+
+      # Create a new VCS::FileInBranch record for every file not present in
+      # this branch
+      VCS::FileInBranch.import(
+        %i[branch_id file_id is_deleted],
+        versions_to_copy.map { |version| [id, version.file_id, true] },
+        validate: false
+      )
+    end
+
+    # Update each file in stage by joining it onto the commit's committed
+    # versions via file id and setting the committed_version_id of files to the
+    # id of committed versions
+    def copy_committed_version_id_from_commit(commit)
+      # Left join files on committed versions
+      files_with_new_committed_versions = files.joins(
+        "LEFT JOIN (#{commit.committed_versions.to_sql}) new_versions " \
+        'ON (new_versions.file_id = vcs_file_in_branches.file_id)'
+      ).select('new_versions.id, vcs_file_in_branches.file_id')
+
+      # Perform the update
+      files
+        .where('new_committed_versions.file_id = vcs_file_in_branches.file_id')
+        .update_all('committed_version_id = new_committed_versions.id ' \
+                    "FROM (#{files_with_new_committed_versions.to_sql}) " \
+                    'new_committed_versions')
+    end
+
     def mime_type_class
       "Providers::#{provider}::MimeType".constantize
     end
@@ -141,4 +182,5 @@ module VCS
       "Providers::#{provider}::FileSync".constantize
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/app/models/vcs/commit.rb
+++ b/app/models/vcs/commit.rb
@@ -102,6 +102,15 @@ module VCS
       )
     end
 
+    # Copy committed files from the given commit over to self
+    def copy_committed_files_from(commit)
+      committed_files.delete_all
+      VCS::CommittedFile.insert_from_select_query(
+        %i[commit_id version_id],
+        commit.committed_files.select(id, :version_id)
+      )
+    end
+
     # Return the array of individual changes of this revision
     def file_changes
       file_diffs.flat_map(&:changes)

--- a/app/models/vcs/commit.rb
+++ b/app/models/vcs/commit.rb
@@ -67,7 +67,7 @@ module VCS
     validates :title, presence: true, if: :is_published
 
     validate :parent_must_belong_to_same_repository, if: :parent_id
-    validate :can_only_have_one_revision_with_parent, if: :parent_id
+    validate :can_only_have_one_revision_with_parent_per_branch, if: :parent_id
     validate :can_only_have_one_origin_revision_per_branch, unless: :parent_id
     validate :selected_file_changes_must_be_valid,
              if: :publishing?, unless: :select_all_file_changes
@@ -202,8 +202,8 @@ module VCS
       errors.add(:base, 'An origin revision already exists for this branch')
     end
 
-    def can_only_have_one_revision_with_parent
-      return unless published_revision_with_parent_exists?
+    def can_only_have_one_revision_with_parent_per_branch
+      return unless published_revision_with_parent_exists_for_branch?
 
       errors.add(:base,
                  'Someone has captured changes to this branch since you ' \
@@ -232,8 +232,9 @@ module VCS
       self.class.exists?(branch_id: branch_id, parent: nil, is_published: true)
     end
 
-    def published_revision_with_parent_exists?
-      self.class.exists?(parent_id: parent_id, is_published: true)
+    def published_revision_with_parent_exists_for_branch?
+      self.class.exists?(branch_id: branch_id, parent_id: parent_id,
+                         is_published: true)
     end
 
     # Return true if revision is currently being published

--- a/app/models/vcs/operations/restore_files_from_diffs.rb
+++ b/app/models/vcs/operations/restore_files_from_diffs.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module VCS
+  module Operations
+    # Revert the staged files in the branch to the provided diffs
+    class RestoreFilesFromDiffs
+      # Attributes
+      attr_accessor :diffs_to_restore, :target_branch
+
+      def self.restore(*attributes)
+        new(*attributes).restore
+      end
+
+      def initialize(file_diffs:, target_branch:)
+        self.diffs_to_restore = file_diffs.clone.to_a
+        self.target_branch    = target_branch
+      end
+
+      # Perform the restoration
+      def restore
+        # TODO: Optimize by only doing this for diffs_to_restore that are
+        # =>    folders and additions
+        until diffs_to_restore.empty?
+          diffs_to_restore.each do |diff|
+            # check if the diff has a parent
+            next unless diff_without_parent?(diff, diffs_to_restore)
+
+            # schedule restoration
+            restore_file_from_diff(diff)
+
+            diffs_to_restore.delete(diff)
+          end
+        end
+      end
+
+      private
+
+      # Return true if the diff has no parent among all diffs
+      # Return false if one of the all_diffs has a file record ID that is the
+      # diff's file record parent ID.
+      def diff_without_parent?(diff, all_diffs)
+        return true if diff.current_version.nil?
+
+        all_diffs.map(&:current_file_id).exclude?(diff.current_parent_id)
+      end
+
+      # Schedule the file restoration$
+      def restore_file_from_diff(diff)
+        FileRestoreJob.perform_later(
+          reference: target_branch,
+          version_id: diff.new_version&.id,
+          file_id: diff.file_id
+        )
+      end
+    end
+  end
+end

--- a/app/views/contributions/reviews/_review_and_accept_file_changes_form.slim
+++ b/app/views/contributions/reviews/_review_and_accept_file_changes_form.slim
@@ -27,7 +27,7 @@
         / HACK: Technically not a validation error, but the styling is appropriate
         .validation-errors
           = render partial: 'error',
-                            object: 'Have you captured all changes in this project? When accepting this contribution, you will lose any uncaptured changes.',
+                            object: '<b>When you accept this contribution, you will overwrite all uncaptured changes on files listed above.</b>'.html_safe,
                             as: :error
         button action='submit' class='btn btn-large primary-color primary-color-text'
           | Accept Changes

--- a/db/migrate/20190215234419_add_origin_revision_to_contributions.rb
+++ b/db/migrate/20190215234419_add_origin_revision_to_contributions.rb
@@ -1,0 +1,13 @@
+class AddOriginRevisionToContributions < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :contributions, :origin_revision,
+                  foreign_key: { to_table: :vcs_commits }
+
+    Contribution.reset_column_information
+    Contribution.includes(:project).find_each do |contribution|
+      contribution.update(origin_revision: contribution.project.revisions.last)
+    end
+
+    change_column_null :contributions, :origin_revision_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_12_095542) do
+ActiveRecord::Schema.define(version: 2019_02_15_234419) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -128,7 +128,9 @@ ActiveRecord::Schema.define(version: 2019_02_12_095542) do
     t.datetime "updated_at", null: false
     t.bigint "branch_id", null: false
     t.boolean "is_accepted", default: false, null: false
+    t.bigint "origin_revision_id", null: false
     t.index ["creator_id"], name: "index_contributions_on_creator_id"
+    t.index ["origin_revision_id"], name: "index_contributions_on_origin_revision_id"
     t.index ["project_id"], name: "index_contributions_on_project_id"
   end
 
@@ -388,6 +390,7 @@ ActiveRecord::Schema.define(version: 2019_02_12_095542) do
   add_foreign_key "contributions", "profiles", column: "creator_id"
   add_foreign_key "contributions", "projects"
   add_foreign_key "contributions", "vcs_branches", column: "branch_id"
+  add_foreign_key "contributions", "vcs_commits", column: "origin_revision_id"
   add_foreign_key "profiles", "accounts"
   add_foreign_key "project_setups", "projects"
   add_foreign_key "projects", "vcs_branches", column: "master_branch_id"

--- a/spec/controllers/contributions/acceptances_controller_spec.rb
+++ b/spec/controllers/contributions/acceptances_controller_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Contributions::AcceptancesController, type: :controller do
   let(:master_branch) { project.master_branch }
   let!(:contribution) { create :contribution, project: project }
   let!(:revision) do
-    create :vcs_commit, branch: contribution.branch, author: author
+    create :vcs_commit, branch: contribution.branch, author: author,
+                        parent: project.revisions.last
   end
   let(:default_params) do
     {
@@ -36,7 +37,6 @@ RSpec.describe Contributions::AcceptancesController, type: :controller do
     it_should_behave_like 'an authenticated action'
     it_should_behave_like 'raise 404 if non-existent', Project
     it_should_behave_like 'raise 404 if non-existent', Contribution
-    it_should_behave_like 'raise 404 if non-existent', VCS::Commit
     it_should_behave_like 'an authorized action' do
       let(:redirect_location) do
         profile_project_contribution_review_path(

--- a/spec/controllers/contributions_controller_spec.rb
+++ b/spec/controllers/contributions_controller_spec.rb
@@ -72,6 +72,9 @@ RSpec.describe ContributionsController, type: :controller do
       }
     end
     let(:fork) { create :vcs_branch }
+    let!(:origin_revision) do
+      create :vcs_commit, :published, branch: project.master_branch
+    end
 
     before do
       allow_any_instance_of(VCS::Branch)

--- a/spec/factories/contributions.rb
+++ b/spec/factories/contributions.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
         project.repository.branches.create!.tap do |fork|
           create :vcs_file_in_branch, :root,
                  file: project.master_branch.root.file, branch: fork
-          fork.copy_committed_files_from(project.master_branch)
+          fork.mark_files_as_committed(origin_revision)
 
           fork.files.without_root.each do |file|
             remote_file_id = Faker::Crypto.unique.sha1

--- a/spec/factories/contributions.rb
+++ b/spec/factories/contributions.rb
@@ -5,6 +5,16 @@ FactoryBot.define do
     association :project, :skip_archive_setup, :with_repository
     association :creator, factory: :user
     branch      { build :vcs_branch, repository: project.repository }
+    origin_revision do
+      # HACK: Use stub strategy for origin revision if contribution is being
+      # =>    stubbed.
+      if @build_strategy.is_a?(FactoryBot::Strategy::Stub)
+        build_stubbed(:vcs_commit, :published, branch: project.master_branch)
+      else
+        project.revisions.last ||
+          create(:vcs_commit, :published, branch: project.master_branch)
+      end
+    end
     title       { Faker::HarryPotter.quote }
     description { Faker::Lorem.paragraph }
 

--- a/spec/factories/vcs/vcs_commits.rb
+++ b/spec/factories/vcs/vcs_commits.rb
@@ -19,11 +19,5 @@ FactoryBot.define do
     trait :with_parent do
       parent { create(:vcs_commit, branch: branch) }
     end
-
-    after(:build) do |commit|
-      next if commit.parent&.branch.nil?
-
-      commit.branch = commit.parent.branch
-    end
   end
 end

--- a/spec/factories/vcs/vcs_commits.rb
+++ b/spec/factories/vcs/vcs_commits.rb
@@ -19,5 +19,13 @@ FactoryBot.define do
     trait :with_parent do
       parent { create(:vcs_commit, branch: branch) }
     end
+
+    trait :commit_files do
+      after(:create) do |commit|
+        commit.tap(&:commit_all_files_in_branch)
+              .tap(&:generate_diffs)
+              .update!(is_published: true)
+      end
+    end
   end
 end

--- a/spec/features/contributions/acceptances_spec.rb
+++ b/spec/features/contributions/acceptances_spec.rb
@@ -122,6 +122,9 @@ feature 'Contributions: Acceptances', :vcr do
     expect(subfile_in_master.remote.parent_id)
       .to eq folder_in_master.remote_file_id
 
+    # it has one uncaptured change
+    expect(project.reload.uncaptured_changes_count).to eq 1
+
     # and it creates a new commit with contribution title & description
     click_on 'Revisions'
     within ".revision[id='#{project.revisions.reload.last.id}']" do

--- a/spec/features/contributions/acceptances_spec.rb
+++ b/spec/features/contributions/acceptances_spec.rb
@@ -2,6 +2,9 @@
 
 feature 'Contributions: Acceptances', :vcr do
   let(:api_connection) { Providers::GoogleDrive::ApiConnection.new(user_acct) }
+  let(:contributor_api_connection) do
+    Providers::GoogleDrive::ApiConnection.new(contributor_acct)
+  end
   let(:user_acct)         { ENV['GOOGLE_DRIVE_USER_ACCOUNT'] }
   let(:tracking_acct)     { ENV['GOOGLE_DRIVE_TRACKING_ACCOUNT'] }
   let(:collaborator_acct) { ENV['GOOGLE_DRIVE_COLLABORATOR_ACCOUNT'] }
@@ -10,6 +13,7 @@ feature 'Contributions: Acceptances', :vcr do
   before do
     # create test folder
     prepare_google_drive_test(api_connection)
+    refresh_google_drive_authorization(contributor_api_connection)
 
     # share test folder
     api_connection
@@ -29,6 +33,7 @@ feature 'Contributions: Acceptances', :vcr do
   end
   let(:contribution) do
     create :contribution, :setup,
+           origin_revision: project.revisions.last,
            creator: contribution_creator, project: project
   end
 
@@ -46,14 +51,39 @@ feature 'Contributions: Acceptances', :vcr do
     # and a contribution
     contribution
 
-    # with a few suggested changes
+    # and the master has some new changes committed
+    file2_in_master = project.files.find_by!(name: 'File 2')
+    file2_in_master.remote.update_content('cool content')
+    file2_in_master.pull
+    create :vcs_commit, :commit_files, parent: project.revisions.last,
+                                       branch: project.master_branch
+
+    # and some unsaved changes
+    file1_in_master = project.files.find_by!(name: 'File 1')
+    file1_in_master.remote.rename('File 1 (new)')
+    file2_in_master.remote.rename('File 2 (new)')
+
+    file1_in_master.pull
+    file2_in_master.pull
+
+    # and the contribution has suggested changes
+    contribution_folder_id = contribution.files.root.remote_file_id
+    folder_in_contribution = create_file(
+      name: 'Folder',
+      mime_type: Providers::GoogleDrive::MimeType.folder,
+      parent_id: contribution_folder_id,
+      api: contributor_api_connection
+    )
     file1_in_contribution = contribution.files.find_by!(name: 'File 1')
-    file2_in_contribution = contribution.files.find_by!(name: 'File 2')
-    file1_in_contribution.remote.rename('File 1 Updated')
-    file2_in_contribution.remote.update_content('cool content')
+    file1_in_contribution.remote.relocate(to: folder_in_contribution.id,
+                                          from: contribution_folder_id)
+    create_file(name: 'Subfile', parent_id: folder_in_contribution.id,
+                api: contributor_api_connection)
 
     # and pull each file in stage
-    contribution.files.reload.each(&:pull)
+    contribution.files.root.pull_children
+    contribution.files.reload.without_root.folders.each(&:pull_children)
+    file1_in_contribution.pull
 
     # when I go to review the changes
     sign_in_as current_account
@@ -74,19 +104,36 @@ feature 'Contributions: Acceptances', :vcr do
     expect(contribution.reload).to be_accepted
 
     # and it updates remote files
-    file1_in_master =
-      project.master_branch.files.find_by!(name: 'File 1 Updated')
-    expect(file1_in_master.remote.name).to eq 'File 1 Updated'
-    file2_in_master = project.master_branch.files.find_by!(name: 'File 2')
+    folder_in_master = project.files.find_by!(name: 'Folder')
+    expect(folder_in_master.remote.name).to eq 'Folder'
+    file1_in_master = project.files.find_by!(
+      name: 'File 1', parent: folder_in_master.file
+    )
+    expect(file1_in_master.remote.name).to eq 'File 1'
+    expect(file1_in_master.remote.parent_id)
+      .to eq folder_in_master.remote_file_id
+    file2_in_master = project.files.find_by!(name: 'File 2 (new)')
+    expect(file2_in_master.remote.name).to eq 'File 2 (new)'
     expect(file2_in_master.remote.content).to eq 'cool content'
+    subfile_in_master = project.files.find_by!(
+      name: 'Subfile', parent: folder_in_master.file
+    )
+    expect(subfile_in_master.remote.name).to eq 'Subfile'
+    expect(subfile_in_master.remote.parent_id)
+      .to eq folder_in_master.remote_file_id
 
     # and it creates a new commit with contribution title & description
     click_on 'Revisions'
-    expect(page).to have_text contribution.creator.name
-    expect(page).to have_text contribution.title
-    expect(page).to have_text contribution.description
-    expect(page).to have_text "File 1 Updated renamed from 'File 1'"
-    expect(page).to have_text 'File 2 modified in Home'
+    within ".revision[id='#{project.revisions.reload.last.id}']" do
+      expect(page).to have_text contribution.creator.name
+      expect(page).to have_text contribution.title
+      expect(page).to have_text contribution.description
+      expect(page).to have_text 'Folder added to Home'
+      expect(page).to have_text 'Subfile added to Folder'
+      expect(page).to have_text 'File 1 moved to Folder'
+      expect(page).not_to have_text 'File 1 renamed'
+      expect(page).not_to have_text 'File 2'
+    end
 
     # TODO: it emails the contribution creator and my fellow project maintainers
   end
@@ -102,13 +149,12 @@ def in_contribution(file)
   contribution.files.find_by!(file_id: file.file_id)
 end
 
-def create_file(name:, parent: nil, parent_id: nil, content: nil)
-  parent_id ||= parent&.id
+def create_file(name:, parent_id: nil, content: nil, mime_type: nil, api: nil)
   Providers::GoogleDrive::FileSync.create(
     name: name,
     parent_id: parent_id,
-    mime_type: Providers::GoogleDrive::MimeType.document,
-    api_connection: api_connection
+    mime_type: mime_type || Providers::GoogleDrive::MimeType.document,
+    api_connection: api || api_connection
   ).tap do |file|
     file.update_content(content) if content.present?
   end

--- a/spec/integrations/contribution_spec.rb
+++ b/spec/integrations/contribution_spec.rb
@@ -17,7 +17,9 @@ RSpec.describe Contribution, type: :model do
     let!(:root)   { create :vcs_file_in_branch, :root, branch: master_branch }
     let(:master_branch) { project.master_branch }
 
-    before { allow(master_branch).to receive(:restore_commit) }
+    before do
+      allow(VCS::Operations::RestoreFilesFromDiffs).to receive(:restore)
+    end
 
     it 'publishes the revision on the master branch' do
       accept
@@ -30,9 +32,10 @@ RSpec.describe Contribution, type: :model do
 
     it 'applies suggested changes to the master branch' do
       accept
-      expect(master_branch)
-        .to have_received(:restore_commit)
-        .with(revision, author: creator)
+      expect(VCS::Operations::RestoreFilesFromDiffs)
+        .to have_received(:restore)
+        .with(file_diffs: revision.file_diffs.includes(:version),
+              target_branch: master_branch)
     end
 
     it 'marks the contribution as accepted' do

--- a/spec/integrations/contribution_spec.rb
+++ b/spec/integrations/contribution_spec.rb
@@ -42,6 +42,19 @@ RSpec.describe Contribution, type: :model do
       accept
       expect(contribution).to be_accepted
     end
+
+    context 'when new files are added in the contribution' do
+      let!(:new_files) { create_list :vcs_committed_file, 3, commit: revision }
+
+      before { revision.reload && revision.committed_files.reload }
+
+      it 'copies the files over to master branch and marks them committed' do
+        accept
+        expect(master_branch.reload.files.without_root.count).to eq 3
+        expect(master_branch.files.without_root.map(&:committed_version_id))
+          .to match_array(new_files.map(&:version_id))
+      end
+    end
   end
 
   describe '#prepare_revision_for_acceptance(author:)' do

--- a/spec/integrations/vcs/commit_spec.rb
+++ b/spec/integrations/vcs/commit_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe VCS::Commit, type: :model do
     end
   end
 
-  describe 'validation: can have only one commit with parent' do
+  describe 'validation: can have only one commit with parent per branch' do
     subject(:commit)    { build(:vcs_commit, parent: parent, branch: branch) }
     let(:parent)        { create(:vcs_commit, branch: branch) }
     let(:branch)        { create(:vcs_branch) }
@@ -109,7 +109,16 @@ RSpec.describe VCS::Commit, type: :model do
         create :vcs_commit, :published, parent: parent, branch: branch
       end
 
-      it                { is_expected.to be_invalid }
+      it { is_expected.to be_invalid }
+    end
+
+    context 'when commit with same parent exists in another branch' do
+      let!(:existing) do
+        create :vcs_commit, :published, parent: parent, branch: other_branch
+      end
+      let(:other_branch) { create :vcs_branch, repository: branch.repository }
+
+      it { is_expected.to be_valid }
     end
 
     context 'when commit with same parent is not published' do

--- a/spec/integrations/vcs/commit_spec.rb
+++ b/spec/integrations/vcs/commit_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe VCS::Commit, type: :model do
     end
 
     context 'when commit with same parent is not published' do
-      let!(:existing) { create :vcs_commit, parent: parent }
+      let!(:existing) { create :vcs_commit, parent: parent, branch: branch }
       it              { is_expected.to be_valid }
     end
 

--- a/spec/integrations/vcs/operations/restore_files_from_diffs_spec.rb
+++ b/spec/integrations/vcs/operations/restore_files_from_diffs_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+RSpec.describe VCS::Operations::RestoreFilesFromDiffs, type: :model do
+  subject(:restorer) do
+    described_class.new(file_diffs: file_diffs, target_branch: branch)
+  end
+
+  let(:branch)        { create :vcs_branch }
+  let(:file_diffs)    { [file1_diff, file2_diff, folder_diff] }
+  let!(:file1_diff)   { create :vcs_file_diff, new_version: file1_v }
+  let!(:file2_diff)   { create :vcs_file_diff, new_version: file2_v }
+  let!(:folder_diff)  { create :vcs_file_diff, new_version: folder_v }
+
+  let(:file1_v)       { create :vcs_version, parent_id: folder_v.file_id }
+  let(:file2_v)       { create :vcs_version, parent_id: folder_v.file_id }
+  let(:folder_v)      { create :vcs_version }
+
+  describe '#restore', :delayed_job do
+    before { restorer.restore }
+
+    let(:file_restore_jobs) do
+      Delayed::Job.where(queue: FileRestoreJob.queue_name)
+    end
+
+    let(:folder_restore_job) do
+      file_restore_job_where(
+        file_id: folder_diff.file_id,
+        version_id: folder_diff.new_version_id
+      )
+    end
+    let(:file1_restore_job) do
+      file_restore_job_where(
+        file_id: file1_diff.file_id,
+        version_id: file1_diff.new_version_id
+      )
+    end
+    let(:file2_restore_job) do
+      file_restore_job_where(
+        file_id: file2_diff.file_id,
+        version_id: file2_diff.new_version_id
+      )
+    end
+
+    it 'creates file restore jobs for each file diff' do
+      expect(file_restore_jobs.count).to eq 3
+      expect(folder_restore_job).to be_present
+      expect(file1_restore_job).to be_present
+      expect(file2_restore_job).to be_present
+    end
+
+    it 'creates file restore jobs in correct order' do
+      expect(folder_restore_job.id).to be < file1_restore_job.id
+      expect(folder_restore_job.id).to be < file2_restore_job.id
+    end
+
+    context 'when passing an active record relation' do
+      let(:file_diffs) { VCS::FileDiff.all }
+
+      it 'still works' do
+        expect(file_restore_jobs.count).to eq 3
+      end
+    end
+  end
+end
+
+def file_restore_job_where(file_id:, version_id:)
+  file_restore_jobs
+    .where("handler LIKE '%file_id: #{file_id}\n%'")
+    .where("handler LIKE '%version_id: #{version_id}\n%'")
+    .first
+end

--- a/spec/models/contribution_spec.rb
+++ b/spec/models/contribution_spec.rb
@@ -85,9 +85,11 @@ RSpec.describe Contribution, type: :model do
   describe '#accept(revision:)' do
     subject(:accept) { contribution.accept(revision: revision) }
 
-    let(:revision)      { instance_double VCS::Commit }
-    let(:master_branch) { instance_double VCS::Branch }
-    let(:creator)       { contribution.creator }
+    let(:revision)                    { instance_double VCS::Commit }
+    let(:master_branch)               { instance_double VCS::Branch }
+    let(:file_diffs)                  { class_double VCS::FileDiff }
+    let(:file_diffs_with_new_version) { class_double VCS::FileDiff }
+    let(:creator)                     { contribution.creator }
     let!(:contribution) do
       create :contribution, project: project
     end
@@ -100,7 +102,12 @@ RSpec.describe Contribution, type: :model do
       allow(project).to receive(:master_branch_id).and_return 'master_branch_id'
       allow(contribution.origin_revision)
         .to receive(:branch_id).and_return 'master_branch_id'
-      allow(master_branch).to receive(:restore_commit)
+      allow(VCS::Operations::RestoreFilesFromDiffs).to receive(:restore)
+      allow(revision).to receive(:file_diffs).and_return file_diffs
+      allow(file_diffs)
+        .to receive(:includes)
+        .with(:new_version)
+        .and_return file_diffs_with_new_version
     end
 
     it { is_expected.to be true }
@@ -116,9 +123,10 @@ RSpec.describe Contribution, type: :model do
 
     it 'applies changes to the master branch' do
       accept
-      expect(master_branch)
-        .to have_received(:restore_commit)
-        .with(revision, author: creator)
+      expect(VCS::Operations::RestoreFilesFromDiffs)
+        .to have_received(:restore)
+        .with(file_diffs: file_diffs_with_new_version,
+              target_branch: master_branch)
     end
 
     it 'updates the contribution to accepted' do
@@ -144,7 +152,8 @@ RSpec.describe Contribution, type: :model do
 
       it 'does not apply changes to the master branch' do
         accept
-        expect(master_branch).not_to have_received(:restore_commit)
+        expect(VCS::Operations::RestoreFilesFromDiffs)
+          .not_to have_received(:restore)
       end
     end
 
@@ -155,7 +164,8 @@ RSpec.describe Contribution, type: :model do
 
       it 'does not apply changes to the master branch' do
         accept
-        expect(master_branch).not_to have_received(:restore_commit)
+        expect(VCS::Operations::RestoreFilesFromDiffs)
+          .not_to have_received(:restore)
       end
 
       it 'does not persist contribution' do

--- a/spec/models/vcs/branch_spec.rb
+++ b/spec/models/vcs/branch_spec.rb
@@ -121,9 +121,11 @@ RSpec.describe VCS::Branch, type: :model do
     end
   end
 
-  describe '#create_fork(creator:, remote_parent_id:)' do
+  describe '#create_fork(creator:, remote_parent_id:, commit:)' do
     subject(:create_fork) do
-      branch.create_fork(creator: 'creator', remote_parent_id: 'remote-id')
+      branch.create_fork(
+        creator: 'creator', remote_parent_id: 'remote-id', commit: 'commit'
+      )
     end
 
     let(:fork)          { instance_double described_class }
@@ -132,9 +134,8 @@ RSpec.describe VCS::Branch, type: :model do
     before do
       allow(branch).to receive(:repository_branches).and_return repo_branches
       allow(repo_branches).to receive(:create!).and_return fork
-      allow(branch).to receive(:commits).and_return %w[1st 2nd last]
       allow(fork).to receive(:create_remote_root_folder)
-      allow(fork).to receive(:copy_committed_files_from)
+      allow(fork).to receive(:mark_files_as_committed)
       allow(fork).to receive(:restore_commit)
 
       create_fork
@@ -146,11 +147,11 @@ RSpec.describe VCS::Branch, type: :model do
         .with(remote_parent_id: 'remote-id')
     end
     it do
-      expect(fork).to have_received(:copy_committed_files_from).with(branch)
+      expect(fork).to have_received(:mark_files_as_committed).with('commit')
     end
     it do
       expect(fork)
-        .to have_received(:restore_commit).with('last', author: 'creator')
+        .to have_received(:restore_commit).with('commit', author: 'creator')
     end
   end
 

--- a/spec/models/vcs/commit_spec.rb
+++ b/spec/models/vcs/commit_spec.rb
@@ -303,4 +303,17 @@ RSpec.describe VCS::Commit, type: :model do
       end
     end
   end
+
+  describe '#update_files_in_branch' do
+    subject(:update_files) { commit.send :update_files_in_branch }
+
+    let(:branch) { commit.branch }
+
+    before { allow(branch).to receive(:mark_files_as_committed) }
+
+    it 'calls #mark_files_as_committed on branch' do
+      update_files
+      expect(branch).to have_received(:mark_files_as_committed).with(commit)
+    end
+  end
 end

--- a/spec/support/fixtures/vcr_cassettes/Contribution/_setup/copies_files_from_origin_revision.yml
+++ b/spec/support/fixtures/vcr_cassettes/Contribution/_setup/copies_files_from_origin_revision.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 06 Dec 2018 23:30:01 GMT
+      - Sat, 16 Feb 2019 00:01:30 GMT
       Server:
       - ESF
       Cache-Control:
@@ -40,7 +40,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:01 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:30 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 06 Dec 2018 23:30:01 GMT
+      - Sat, 16 Feb 2019 00:01:30 GMT
       Server:
       - ESF
       Cache-Control:
@@ -94,7 +94,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:01 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:30 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2018-12-06
-        23:30:01 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2019-02-16
+        00:01:30 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:01 GMT
+      - Sat, 16 Feb 2019 00:01:30 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 06 Dec 2018 23:30:02 GMT
+      - Sat, 16 Feb 2019 00:01:31 GMT
       Vary:
       - Origin
       - X-Origin
@@ -157,15 +157,15 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1FGoyxTrkyRTu-P0bT3eGvDlDpGX099vT",
-         "name": "Test @ 2018-12-06 23:30:01 UTC",
+         "id": "12EwfeG-s6D8Za-Ku46k-53y4ZMZRFd_b",
+         "name": "Test @ 2019-02-16 00:01:30 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:02 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:32 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1FGoyxTrkyRTu-P0bT3eGvDlDpGX099vT/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/12EwfeG-s6D8Za-Ku46k-53y4ZMZRFd_b/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +200,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:02 GMT
+      - Sat, 16 Feb 2019 00:01:32 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +217,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 06 Dec 2018 23:30:03 GMT
+      - Sat, 16 Feb 2019 00:01:32 GMT
       Vary:
       - Origin
       - X-Origin
@@ -234,7 +234,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
@@ -247,13 +247,13 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:03 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:32 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1FGoyxTrkyRTu-P0bT3eGvDlDpGX099vT"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["12EwfeG-s6D8Za-Ku46k-53y4ZMZRFd_b"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -262,7 +262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:03 GMT
+      - Sat, 16 Feb 2019 00:01:32 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -279,7 +279,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 06 Dec 2018 23:30:04 GMT
+      - Sat, 16 Feb 2019 00:01:33 GMT
       Vary:
       - Origin
       - X-Origin
@@ -296,19 +296,19 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1QSc6dY504hLVLOHaz9uOEphAt27hIhwg",
+         "id": "1VWPdQZzWSMh42XanBhpNfnOUCR8z3pLM",
          "name": "Folder",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1FGoyxTrkyRTu-P0bT3eGvDlDpGX099vT"
+          "12EwfeG-s6D8Za-Ku46k-53y4ZMZRFd_b"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -333,13 +333,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:04 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:33 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File 1","parents":["1QSc6dY504hLVLOHaz9uOEphAt27hIhwg"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File 1","parents":["1VWPdQZzWSMh42XanBhpNfnOUCR8z3pLM"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -348,7 +348,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:04 GMT
+      - Sat, 16 Feb 2019 00:01:33 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -365,7 +365,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 06 Dec 2018 23:30:06 GMT
+      - Sat, 16 Feb 2019 00:01:35 GMT
       Vary:
       - Origin
       - X-Origin
@@ -382,19 +382,19 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1dX3qjnHC8AsYbT9GuzXALVKoS8P6UVX3b9H4Iww6LrM",
+         "id": "1VzeqabAjT1dGM9dyq5yxivuZ-AJ4_7t8RhP5ZA2lqwc",
          "name": "File 1",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1QSc6dY504hLVLOHaz9uOEphAt27hIhwg"
+          "1VWPdQZzWSMh42XanBhpNfnOUCR8z3pLM"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -419,13 +419,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:06 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:35 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File 2","parents":["1QSc6dY504hLVLOHaz9uOEphAt27hIhwg"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File 2","parents":["1VWPdQZzWSMh42XanBhpNfnOUCR8z3pLM"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -434,7 +434,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:06 GMT
+      - Sat, 16 Feb 2019 00:01:35 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -451,7 +451,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 06 Dec 2018 23:30:08 GMT
+      - Sat, 16 Feb 2019 00:01:36 GMT
       Vary:
       - Origin
       - X-Origin
@@ -468,19 +468,19 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1mGRD-I6kwnyAADEpZvKOmowRkiDRie_kCtajzJ8dNzs",
+         "id": "1UOcqyDd2uYnxG-h3OY0S-mFVVmQXN_4qHz5BTvm19v0",
          "name": "File 2",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1QSc6dY504hLVLOHaz9uOEphAt27hIhwg"
+          "1VWPdQZzWSMh42XanBhpNfnOUCR8z3pLM"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -505,14 +505,14 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:08 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:37 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"83 Billion
-        Year Bunker (Archive)","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"5 Golgafrinchan
+        Ark Fleet Ship B (Archive)","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -521,7 +521,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:08 GMT
+      - Sat, 16 Feb 2019 00:01:37 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -538,7 +538,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 06 Dec 2018 23:30:08 GMT
+      - Sat, 16 Feb 2019 00:01:38 GMT
       Vary:
       - Origin
       - X-Origin
@@ -555,15 +555,15 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1oSbLD0y4C6jXrMypj5P6KnM7N2K-lPwy",
-         "name": "83 Billion Year Bunker (Archive)",
+         "id": "16AzvHPbZT1aVs6MqCwZ_aSRmwVIkrtNw",
+         "name": "5 Golgafrinchan Ark Fleet Ship B (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -583,10 +583,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:08 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:38 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1oSbLD0y4C6jXrMypj5P6KnM7N2K-lPwy/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/16AzvHPbZT1aVs6MqCwZ_aSRmwVIkrtNw/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -598,7 +598,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:08 GMT
+      - Sat, 16 Feb 2019 00:01:38 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -615,7 +615,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 06 Dec 2018 23:30:09 GMT
+      - Sat, 16 Feb 2019 00:01:39 GMT
       Vary:
       - Origin
       - X-Origin
@@ -632,7 +632,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
@@ -645,10 +645,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:09 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:39 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1FGoyxTrkyRTu-P0bT3eGvDlDpGX099vT?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/12EwfeG-s6D8Za-Ku46k-53y4ZMZRFd_b?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -660,7 +660,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:09 GMT
+      - Sat, 16 Feb 2019 00:01:39 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -671,9 +671,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 06 Dec 2018 23:30:09 GMT
+      - Sat, 16 Feb 2019 00:01:39 GMT
       Date:
-      - Thu, 06 Dec 2018 23:30:09 GMT
+      - Sat, 16 Feb 2019 00:01:39 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -692,15 +692,15 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1FGoyxTrkyRTu-P0bT3eGvDlDpGX099vT",
-         "name": "Test @ 2018-12-06 23:30:01 UTC",
+         "id": "12EwfeG-s6D8Za-Ku46k-53y4ZMZRFd_b",
+         "name": "Test @ 2019-02-16 00:01:30 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -726,10 +726,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:09 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:39 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1FGoyxTrkyRTu-P0bT3eGvDlDpGX099vT/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/12EwfeG-s6D8Za-Ku46k-53y4ZMZRFd_b/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -741,7 +741,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:09 GMT
+      - Sat, 16 Feb 2019 00:01:39 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -759,9 +759,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 06 Dec 2018 23:30:09 GMT
+      - Sat, 16 Feb 2019 00:01:39 GMT
       Expires:
-      - Thu, 06 Dec 2018 23:30:09 GMT
+      - Sat, 16 Feb 2019 00:01:39 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -773,7 +773,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
@@ -793,10 +793,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:09 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:40 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271FGoyxTrkyRTu-P0bT3eGvDlDpGX099vT%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%2712EwfeG-s6D8Za-Ku46k-53y4ZMZRFd_b%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -808,7 +808,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:09 GMT
+      - Sat, 16 Feb 2019 00:01:40 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -819,9 +819,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 06 Dec 2018 23:30:10 GMT
+      - Sat, 16 Feb 2019 00:01:40 GMT
       Date:
-      - Thu, 06 Dec 2018 23:30:10 GMT
+      - Sat, 16 Feb 2019 00:01:40 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -840,7 +840,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
@@ -849,12 +849,12 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1QSc6dY504hLVLOHaz9uOEphAt27hIhwg",
+           "id": "1VWPdQZzWSMh42XanBhpNfnOUCR8z3pLM",
            "name": "Folder",
            "mimeType": "application/vnd.google-apps.folder",
            "trashed": false,
            "parents": [
-            "1FGoyxTrkyRTu-P0bT3eGvDlDpGX099vT"
+            "12EwfeG-s6D8Za-Ku46k-53y4ZMZRFd_b"
            ],
            "thumbnailVersion": "0",
            "permissions": [
@@ -881,10 +881,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:10 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:40 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1QSc6dY504hLVLOHaz9uOEphAt27hIhwg/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1VWPdQZzWSMh42XanBhpNfnOUCR8z3pLM/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -896,7 +896,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:10 GMT
+      - Sat, 16 Feb 2019 00:01:40 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -914,9 +914,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 06 Dec 2018 23:30:10 GMT
+      - Sat, 16 Feb 2019 00:01:40 GMT
       Expires:
-      - Thu, 06 Dec 2018 23:30:10 GMT
+      - Sat, 16 Feb 2019 00:01:40 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -928,7 +928,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
@@ -948,10 +948,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:10 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:40 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271QSc6dY504hLVLOHaz9uOEphAt27hIhwg%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271VWPdQZzWSMh42XanBhpNfnOUCR8z3pLM%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -963,7 +963,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:10 GMT
+      - Sat, 16 Feb 2019 00:01:40 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -974,9 +974,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 06 Dec 2018 23:30:10 GMT
+      - Sat, 16 Feb 2019 00:01:41 GMT
       Date:
-      - Thu, 06 Dec 2018 23:30:10 GMT
+      - Sat, 16 Feb 2019 00:01:41 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -995,7 +995,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
@@ -1004,14 +1004,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1mGRD-I6kwnyAADEpZvKOmowRkiDRie_kCtajzJ8dNzs",
+           "id": "1UOcqyDd2uYnxG-h3OY0S-mFVVmQXN_4qHz5BTvm19v0",
            "name": "File 2",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1QSc6dY504hLVLOHaz9uOEphAt27hIhwg"
+            "1VWPdQZzWSMh42XanBhpNfnOUCR8z3pLM"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1mGRD-I6kwnyAADEpZvKOmowRkiDRie_kCtajzJ8dNzs&v=1&s=AMedNnoAAAAAXAnNIuSGRAXcDdCogqvVBMomZoXya0DM&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1UOcqyDd2uYnxG-h3OY0S-mFVVmQXN_4qHz5BTvm19v0&v=1&s=AMedNnoAAAAAXGdvBTg8FcQzA-gRz0wIXv4RBSpVDio1&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -1035,14 +1035,15 @@ http_interactions:
            ]
           },
           {
-           "id": "1dX3qjnHC8AsYbT9GuzXALVKoS8P6UVX3b9H4Iww6LrM",
+           "id": "1VzeqabAjT1dGM9dyq5yxivuZ-AJ4_7t8RhP5ZA2lqwc",
            "name": "File 1",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1QSc6dY504hLVLOHaz9uOEphAt27hIhwg"
+            "1VWPdQZzWSMh42XanBhpNfnOUCR8z3pLM"
            ],
-           "thumbnailVersion": "0",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1VzeqabAjT1dGM9dyq5yxivuZ-AJ4_7t8RhP5ZA2lqwc&v=1&s=AMedNnoAAAAAXGdvBRstFW6CtCAKaGmarp2_5UKzecJL&sz=s220",
+           "thumbnailVersion": "1",
            "permissions": [
             {
              "kind": "drive#permission",
@@ -1067,10 +1068,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:10 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:41 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1mGRD-I6kwnyAADEpZvKOmowRkiDRie_kCtajzJ8dNzs/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1UOcqyDd2uYnxG-h3OY0S-mFVVmQXN_4qHz5BTvm19v0/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1082,7 +1083,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:10 GMT
+      - Sat, 16 Feb 2019 00:01:41 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1093,9 +1094,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 06 Dec 2018 23:30:10 GMT
+      - Sat, 16 Feb 2019 00:01:41 GMT
       Date:
-      - Thu, 06 Dec 2018 23:30:10 GMT
+      - Sat, 16 Feb 2019 00:01:41 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1114,7 +1115,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
@@ -1124,13 +1125,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-12-06T23:30:07.213Z"
+         "modifiedTime": "2019-02-16T00:01:35.941Z"
         }
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:10 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:41 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1mGRD-I6kwnyAADEpZvKOmowRkiDRie_kCtajzJ8dNzs&s=AMedNnoAAAAAXAnNIuSGRAXcDdCogqvVBMomZoXya0DM&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1UOcqyDd2uYnxG-h3OY0S-mFVVmQXN_4qHz5BTvm19v0&s=AMedNnoAAAAAXGdvBTg8FcQzA-gRz0wIXv4RBSpVDio1&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1142,7 +1143,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:10 GMT
+      - Sat, 16 Feb 2019 00:01:41 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1173,7 +1174,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 06 Dec 2018 23:30:11 GMT
+      - Sat, 16 Feb 2019 00:01:41 GMT
       Server:
       - fife
       Content-Length:
@@ -1181,19 +1182,19 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
     body:
       encoding: ASCII-8BIT
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:11 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:42 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1mGRD-I6kwnyAADEpZvKOmowRkiDRie_kCtajzJ8dNzs/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1UOcqyDd2uYnxG-h3OY0S-mFVVmQXN_4qHz5BTvm19v0/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"File 2","parents":["1oSbLD0y4C6jXrMypj5P6KnM7N2K-lPwy"]}'
+      string: '{"name":"File 2","parents":["16AzvHPbZT1aVs6MqCwZ_aSRmwVIkrtNw"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1202,7 +1203,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:11 GMT
+      - Sat, 16 Feb 2019 00:01:42 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1219,7 +1220,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 06 Dec 2018 23:30:16 GMT
+      - Sat, 16 Feb 2019 00:01:44 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1236,19 +1237,19 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "18_7WGJsOq_gp36l-I8b8PUvFN0I395enZ2ML1WYi16I",
+         "id": "1Gcd7Nl0f03tNuhOzp2OFxKKtJUjTFiRT2utjMc8HrpU",
          "name": "File 2",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1oSbLD0y4C6jXrMypj5P6KnM7N2K-lPwy"
+          "16AzvHPbZT1aVs6MqCwZ_aSRmwVIkrtNw"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1273,10 +1274,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:17 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:44 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/18_7WGJsOq_gp36l-I8b8PUvFN0I395enZ2ML1WYi16I?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1Gcd7Nl0f03tNuhOzp2OFxKKtJUjTFiRT2utjMc8HrpU?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1288,7 +1289,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:17 GMT
+      - Sat, 16 Feb 2019 00:01:44 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1299,9 +1300,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 06 Dec 2018 23:30:17 GMT
+      - Sat, 16 Feb 2019 00:01:44 GMT
       Date:
-      - Thu, 06 Dec 2018 23:30:17 GMT
+      - Sat, 16 Feb 2019 00:01:44 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1320,19 +1321,19 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "18_7WGJsOq_gp36l-I8b8PUvFN0I395enZ2ML1WYi16I",
+         "id": "1Gcd7Nl0f03tNuhOzp2OFxKKtJUjTFiRT2utjMc8HrpU",
          "name": "File 2",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1oSbLD0y4C6jXrMypj5P6KnM7N2K-lPwy"
+          "16AzvHPbZT1aVs6MqCwZ_aSRmwVIkrtNw"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1357,10 +1358,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:17 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:45 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/18_7WGJsOq_gp36l-I8b8PUvFN0I395enZ2ML1WYi16I/export?alt=media&mimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document
+    uri: https://www.googleapis.com/drive/v3/files/1Gcd7Nl0f03tNuhOzp2OFxKKtJUjTFiRT2utjMc8HrpU/export?alt=media&mimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document
     body:
       encoding: UTF-8
       string: ''
@@ -1372,7 +1373,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:17 GMT
+      - Sat, 16 Feb 2019 00:01:45 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
   response:
@@ -1381,9 +1382,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 06 Dec 2018 23:30:17 GMT
+      - Sat, 16 Feb 2019 00:01:45 GMT
       Date:
-      - Thu, 06 Dec 2018 23:30:17 GMT
+      - Sat, 16 Feb 2019 00:01:45 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Disposition:
@@ -1400,24 +1401,24 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       Content-Length:
-      - '6092'
+      - '6061'
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        UEsDBBQACAgIAMh7hk0AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICADIe4ZNAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAyHuGTQAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAyHuGTQAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkOotKpadZs0ddPaXcDBMcSqY1u2A2VXPzufkIQpDZXo4Af42Od9ncfHsa9uXhM62mCpCGcLZ3zpOSPMEI8IWy+c388PFzNnpDSwCChneOHssHJurj9dbedK7yhWI5PP1DxBCyfWWsxdV6EYJ6AuucDMdK64TECbply7CciXVFwgngjQZEko0TvX97ypU8jwhZNKNi8kLhKCJFd8pW3KnK9WBOHip8yQfXzzlHuO0gQznTm6ElMzB85UTIQq1ZKhaqYzLkU2/3qITULLcVvRxy2SsDWLkdDcaMtlJCRHWCkTvc87K8Wx1wOglagy+kzh0LOcSQKEVTK2NBpClfel8S6gZVL1g9QsFO0zkbzrO1lKkLv2LGAAz/18QXpVcUPBZOlUVgU5RALFIHUpQIcoUI5ecHQHbANVMUfrXuXcUIoIrCUkdZGqN63s2GuUy1MMAtdq69PUvkieirrcwyFqeztwPHmbgF8KXJsXYMTRPV5BSrWyTflTFs2ilf08cKbVaDsHhQhZOLeSgLHfzpHaa2BQ+lYR2AvFt0xV410rpf6Y8AbMRvH9MnKnmjEKbF3GMLMxt5iM25yiaLYyTQGIZBKU2E3tf546ReNXSk0AUs1zK2QeDb/qFOhTlZT5jgtbUdjuG7ktbtk5YlL1Thh5AdLWn4ita9b1LVo4j7ZeMy5RnmlNbDKDBJe2LB+Ue2epbXkNS4oPpJ9tpJd+NnL02MOl+yG+YrDHals4zjtG45zrEhSOfrCytzY0WYZ3V7xYvBeMxePekELQhr+bBVSNeL3WsNLYnKRj37MzXmLzfjCPEXpe99q7lWNR5nVthl67NvPYXh0OweYfxeZ/MGzBtC+2ZansNbd40LHF89iJGIOjGINzY5wdUvSHUkScclnVXmC/rTforOMNOnsHvOFRvOHHwuvP+uI9wDnNPi2cYQfO8B1wTo7inHwwnOF74jx6vp+Ic3oU5/R/xUkawmfB+0y0uVW07gtZ9Mxcpwdc336eTzpgTU6C9ZQudSevquPMyAJ/ELN3vOpXRd11onUXddBx7wqO3LvKf+r6L1BLBwidKXMALAMAAP8RAABQSwMEFAAICAgAyHuGTQAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWV227bMAyGn2DvEOg+sR2kW2HU6cWCDQO2IWi6B2Ak2RaqEyg5afb0k+NTDkXhZrkhSIoff8mM9PD4quRkx9EJozOSzGIy4ZoaJnSRkT/P36b3ZOI8aAbSaJ6RA3fkcfnpYZ8yQyvFtZ8EgnapohkpvbdpFDlacgVuZizXIZkbVOCDi0WkAF8qO6VGWfBiK6Twh2gex59JizEZqVCnLWKqBEXjTO7rktTkuaC8NV0FjunblKxayceOEXIZNBjtSmFdR1O30kKy7CC79zaxU7Jbt7djujGEffgcSjaN9gaZRUO5cyG6apI9MYlHHGCN6CvGSDjv2SlRIHSPqYfjAtT3noXe7aEdUcNGhrNwcoyQJvVTbBHwcK0CbjjP03orRk3xBSFU+Qr7gbwFQUtA3wHkLQRp6AtnX0HvoB9mVowa5wsSE1AgqGFI3Ye+bBJfjMumBMsHWvF/tO9oKjuM++IW2sk/MLn7GGDeAZbhCtwadqitnezTcIOyp4zE7Y+0oRWX18H1dehpxXOopH8js8azYLJILSD8YCfRo4g11oYa7fmrr0BuLNBwYAGzg1oEieo8rjHYqF+P7wl9Y0Pnclri0Xh51ipqM7VtGtarHKe+WW+Lzd9QUIZX5+5+ceSHuyiZzxetUlv8glrd1nhvwiAni2aVN3ZwJM/94KEoyhO35MB4kPtlfnRzY3znth1+V+r5YHlIhkcO69JWeqcz6r5yNLx4y39QSwcI8i6p7SYCAAA2BwAAUEsDBBQACAgIAMh7hk0AAAAAAAAAAAAAAAAcAAAAd29yZC9fcmVscy9kb2N1bWVudC54bWwucmVsc62STWrDMBCFT9A7iNnXstMfSomcTQhkW9wDKPL4h1ojIU1KffuKlCQOBNOFl++JefPNjNabHzuIbwyxd6SgyHIQSMbVPbUKPqvd4xuIyJpqPThCBSNG2JQP6w8cNKea2PU+ihRCUUHH7N+ljKZDq2PmPFJ6aVywmpMMrfTafOkW5SrPX2WYZkB5kyn2tYKwrwsQ1ejxP9muaXqDW2eOFonvtJCcajEF6tAiKzjJP7PIUhjI+wyrJRkiMqflxivG2ZlDeFoSoXHElT4Mk1VcrDmI5yUh6GgPGNLcV4iLNQfxsugxeBxweoqTPreXN5+8/AVQSwcIkACr6/EAAAAsAwAAUEsDBBQACAgIAMh7hk0AAAAAAAAAAAAAAAALAAAAX3JlbHMvLnJlbHONzzsOwjAMBuATcIfIO03LgBBq0gUhdUXlAFHiphHNQ0l49PZkYADEwGj792e57R52JjeMyXjHoKlqIOikV8ZpBufhuN4BSVk4JWbvkMGCCTq+ak84i1x20mRCIgVxicGUc9hTmuSEVqTKB3RlMvpoRS5l1DQIeREa6aautzS+G8A/TNIrBrFXDZBhCfiP7cfRSDx4ebXo8o8TX4kii6gxM7j7qKh6tavCAuUt/XiRPwFQSwcILWjPIrEAAAAqAQAAUEsDBBQACAgIAMh7hk0AAAAAAAAAAAAAAAAVAAAAd29yZC90aGVtZS90aGVtZTEueG1s7VlLb9s2HL8P2HcgdG9l2VbqBHWK2LHbrU0bJG6HHmmJlthQokDSSXwb2uOAAcO6YYcV2G2HYVuBFtil+zTZOmwd0K+wvx6WKZvOo023Dq0PNkn9/u8HSfnylcOIoX0iJOVx23Iu1ixEYo/7NA7a1u1B/0LLQlLh2MeMx6RtTYi0rqx/+MFlvKZCEhEE9LFcw20rVCpZs23pwTKWF3lCYng24iLCCqYisH2BD4BvxOx6rbZiR5jGFopxBGxvjUbUI2iQsrTWp8x7DL5iJdMFj4ldL5OoU2RYf89Jf+REdplA+5i1LZDj84MBOVQWYlgqeNC2atnHstcv2yURU0toNbp+9inoCgJ/r57RiWBYEjr95uqlzZJ/Pee/iOv1et2eU/LLANjzwFJnAdvst5zOlKcGyoeLvLs1t9as4jX+jQX8aqfTcVcr+MYM31zAt2orzY16Bd+c4d1F/Tsb3e5KBe/O8CsL+P6l1ZVmFZ+BQkbjvQV0Gs8yMiVkxNk1I7wF8NY0AWYoW8uunD5Wy3Itwve46AMgCy5WNEZqkpAR9gDXxYwOBU0F4DWCtSf5kicXllJZSHqCJqptfZxgqIgZ5OWzH18+e4KO7j89uv/L0YMHR/d/NlBdw3GgU734/ou/H32K/nry3YuHX5nxUsf//tNnv/36pRmodODzrx//8fTx828+//OHhwb4hsBDHT6gEZHoJjlAOzwCwwwCyFCcjWIQYqpTbMSBxDFOaQzongor6JsTzLAB1yFVD94R0AJMwKvjexWFd0MxVtQAvB5GFeAW56zDhdGm66ks3QvjODALF2Mdt4Pxvkl2dy6+vXECuUxNLLshqai5zSDkOCAxUSh9xvcIMZDdpbTi1y3qCS75SKG7FHUwNbpkQIfKTHSNRhCXiUlBiHfFN1t3UIczE/tNsl9FQlVgZmJJWMWNV/FY4cioMY6YjryBVWhScncivIrDpYJIB4Rx1POJlCaaW2JSUfc6tA5z2LfYJKoihaJ7JuQNzLmO3OR73RBHiVFnGoc69iO5BymK0TZXRiV4tULSOcQBx0vDfYcSdbbavk2D0Jwg6ZOxMJUE4dV6nLARJnHR4Su9OqLxcY07gr6Nz7txQ6t8/u2j/1HL3gAnmGpmvlEvw8235y4XPn37u/MmHsfbBArifXN+35zfxea8rJ7PvyXPurCtH7QzNtHSU/eIMrarJozckFn/lmCe34fFbJIRlYf8JIRhIa6CCwTOxkhw9QlV4W6IExDjZBICWbAOJEq4hKuFtZR3dj+lYHO25k4vlYDGaov7+XJDv2yWbLJZIHVBjZTBaYU1Lr2eMCcHnlKa45qlucdKszVvQt0gnL5KcFbquWhIFMyIn/o9ZzANyxsMkVPTYhRinxiWNfucxhvxpnsmJc7HybUFJ9uL1cTi6gwdtK1Vt+5ayMNJ2xrBaQmGUQL8ZNppMAvituWp3MCTa3HO4lVzVjk1d5nBFRGJkGoTyzCnyh5NX6XEM/3rbjP1w/kYYGgmp9Oi0XL+Qy3s+dCS0Yh4asnKbFo842NFxG7oH6AhG4sdDHo38+zyqYROX59OBOR2s0i8auEWtTH/yqaoGcySEBfZ3tJin8OzcalDNtPUs5fo/oqmNM7RFPfdNSXNXDifNvzs0gS7uMAozdG2xYUKOXShJKReX8C+n8kCvRCURaoSYukL6FRXsj/rWzmPvMkFodqhARIUOp0KBSHbqrDzBGZOXd8ep4yKPlOqK5P8d0j2CRuk1buS2m+hcNpNCkdkuPmg2abqGgb9t/jg0nyljWcmqHmWza+pNX1tK1h9PRVOswFr4upmi+vu0p1nfqtN4JaB0i9o3FR4bHY8HfAdiD4q93kEiXihVZRfuTgEnVuacSmrf+sU1FoS7/M8O2rObixx9vHiXt3ZrsHX7vGuthdL1NbuIdls4Y8oPrwHsjfhejNm+YpMYJYPtkVm8JD7k2LIZN4SckdMWzqLd8gIUf9wGtY5jxb/9JSb+U4uILW9JGycTFjgZ5tISVw/mbikmN7xSuLsFmdiwGaSc3we5bJFlp5i8eu47BTKm11mzN7TuuwUgXoFl6nD411WeMo2JR45VAJ3p39dQf7as5Rd/wdQSwcIIVqihCwGAADbHQAAUEsDBBQACAgIAMh7hk0AAAAAAAAAAAAAAAATAAAAW0NvbnRlbnRfVHlwZXNdLnhtbLWTTW7CMBCFT9A7RN5WxNBFVVUEFv1Ztl3QAwzOBKz6T56Bwu07CZAFAqmVmo1l+82893kkT+c774otZrIxVGpSjlWBwcTahlWlPhevowdVEEOowcWAldojqfnsZrrYJ6RCmgNVas2cHrUms0YPVMaEQZQmZg8sx7zSCcwXrFDfjcf32sTAGHjErYeaTZ+xgY3j4ulw31pXClJy1gALlxYzVbzsRDxgtmf9i75tqM9gRkeQMqPramhtE92eB4hKbcK7TCbbGv8UEZvGGqyj2XhpKb9jrlOOBolkqN6VhMyyO6Z+QOY38GKr20p9UsvjI4dB4L3DawCdNmh8I14LWDq8TNDLg0KEjV9ilv1liF4eFKJXPNhwGaQv+UcOlo96ZfiddFgnp0jd/fbZD1BLBwgzrw+3LAEAAC0EAABQSwECFAAUAAgICADIe4ZNSRNDf2gBAAA9BQAAEgAAAAAAAAAAAAAAAAAAAAAAd29yZC9udW1iZXJpbmcueG1sUEsBAhQAFAAICAgAyHuGTY/2kL8FAgAA6gYAABEAAAAAAAAAAAAAAAAAqAEAAHdvcmQvc2V0dGluZ3MueG1sUEsBAhQAFAAICAgAyHuGTa2HbQB5AQAAWgUAABIAAAAAAAAAAAAAAAAA7AMAAHdvcmQvZm9udFRhYmxlLnhtbFBLAQIUABQACAgIAMh7hk2dKXMALAMAAP8RAAAPAAAAAAAAAAAAAAAAAKUFAAB3b3JkL3N0eWxlcy54bWxQSwECFAAUAAgICADIe4ZN8i6p7SYCAAA2BwAAEQAAAAAAAAAAAAAAAAAOCQAAd29yZC9kb2N1bWVudC54bWxQSwECFAAUAAgICADIe4ZNkACr6/EAAAAsAwAAHAAAAAAAAAAAAAAAAABzCwAAd29yZC9fcmVscy9kb2N1bWVudC54bWwucmVsc1BLAQIUABQACAgIAMh7hk0taM8isQAAACoBAAALAAAAAAAAAAAAAAAAAK4MAABfcmVscy8ucmVsc1BLAQIUABQACAgIAMh7hk0hWqKELAYAANsdAAAVAAAAAAAAAAAAAAAAAJgNAAB3b3JkL3RoZW1lL3RoZW1lMS54bWxQSwECFAAUAAgICADIe4ZNM68PtywBAAAtBAAAEwAAAAAAAAAAAAAAAAAHFAAAW0NvbnRlbnRfVHlwZXNdLnhtbFBLBQYAAAAACQAJAEICAAB0FQAAAAA=
+        UEsDBBQACAgIADaAT04AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICAA2gE9OAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgANoBPTgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgANoBPTgAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgANoBPTgAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgANoBPTgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgANoBPTgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgANoBPTgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgANoBPTgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIADaAT05JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICAA2gE9Oj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICAA2gE9OrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgANoBPTojORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIADaAT04B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIADaAT06QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgANoBPTi1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgANoBPTiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIADaAT04zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:17 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:45 GMT
 - request:
     method: put
     uri: http://localhost:9998/tika
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        UEsDBBQACAgIAMh7hk0AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICADIe4ZNAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAyHuGTQAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAyHuGTQAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkOotKpadZs0ddPaXcDBMcSqY1u2A2VXPzufkIQpDZXo4Af42Od9ncfHsa9uXhM62mCpCGcLZ3zpOSPMEI8IWy+c388PFzNnpDSwCChneOHssHJurj9dbedK7yhWI5PP1DxBCyfWWsxdV6EYJ6AuucDMdK64TECbply7CciXVFwgngjQZEko0TvX97ypU8jwhZNKNi8kLhKCJFd8pW3KnK9WBOHip8yQfXzzlHuO0gQznTm6ElMzB85UTIQq1ZKhaqYzLkU2/3qITULLcVvRxy2SsDWLkdDcaMtlJCRHWCkTvc87K8Wx1wOglagy+kzh0LOcSQKEVTK2NBpClfel8S6gZVL1g9QsFO0zkbzrO1lKkLv2LGAAz/18QXpVcUPBZOlUVgU5RALFIHUpQIcoUI5ecHQHbANVMUfrXuXcUIoIrCUkdZGqN63s2GuUy1MMAtdq69PUvkieirrcwyFqeztwPHmbgF8KXJsXYMTRPV5BSrWyTflTFs2ilf08cKbVaDsHhQhZOLeSgLHfzpHaa2BQ+lYR2AvFt0xV410rpf6Y8AbMRvH9MnKnmjEKbF3GMLMxt5iM25yiaLYyTQGIZBKU2E3tf546ReNXSk0AUs1zK2QeDb/qFOhTlZT5jgtbUdjuG7ktbtk5YlL1Thh5AdLWn4ita9b1LVo4j7ZeMy5RnmlNbDKDBJe2LB+Ue2epbXkNS4oPpJ9tpJd+NnL02MOl+yG+YrDHals4zjtG45zrEhSOfrCytzY0WYZ3V7xYvBeMxePekELQhr+bBVSNeL3WsNLYnKRj37MzXmLzfjCPEXpe99q7lWNR5nVthl67NvPYXh0OweYfxeZ/MGzBtC+2ZansNbd40LHF89iJGIOjGINzY5wdUvSHUkScclnVXmC/rTforOMNOnsHvOFRvOHHwuvP+uI9wDnNPi2cYQfO8B1wTo7inHwwnOF74jx6vp+Ic3oU5/R/xUkawmfB+0y0uVW07gtZ9Mxcpwdc336eTzpgTU6C9ZQudSevquPMyAJ/ELN3vOpXRd11onUXddBx7wqO3LvKf+r6L1BLBwidKXMALAMAAP8RAABQSwMEFAAICAgAyHuGTQAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWV227bMAyGn2DvEOg+sR2kW2HU6cWCDQO2IWi6B2Ak2RaqEyg5afb0k+NTDkXhZrkhSIoff8mM9PD4quRkx9EJozOSzGIy4ZoaJnSRkT/P36b3ZOI8aAbSaJ6RA3fkcfnpYZ8yQyvFtZ8EgnapohkpvbdpFDlacgVuZizXIZkbVOCDi0WkAF8qO6VGWfBiK6Twh2gex59JizEZqVCnLWKqBEXjTO7rktTkuaC8NV0FjunblKxayceOEXIZNBjtSmFdR1O30kKy7CC79zaxU7Jbt7djujGEffgcSjaN9gaZRUO5cyG6apI9MYlHHGCN6CvGSDjv2SlRIHSPqYfjAtT3noXe7aEdUcNGhrNwcoyQJvVTbBHwcK0CbjjP03orRk3xBSFU+Qr7gbwFQUtA3wHkLQRp6AtnX0HvoB9mVowa5wsSE1AgqGFI3Ye+bBJfjMumBMsHWvF/tO9oKjuM++IW2sk/MLn7GGDeAZbhCtwadqitnezTcIOyp4zE7Y+0oRWX18H1dehpxXOopH8js8azYLJILSD8YCfRo4g11oYa7fmrr0BuLNBwYAGzg1oEieo8rjHYqF+P7wl9Y0Pnclri0Xh51ipqM7VtGtarHKe+WW+Lzd9QUIZX5+5+ceSHuyiZzxetUlv8glrd1nhvwiAni2aVN3ZwJM/94KEoyhO35MB4kPtlfnRzY3znth1+V+r5YHlIhkcO69JWeqcz6r5yNLx4y39QSwcI8i6p7SYCAAA2BwAAUEsDBBQACAgIAMh7hk0AAAAAAAAAAAAAAAAcAAAAd29yZC9fcmVscy9kb2N1bWVudC54bWwucmVsc62STWrDMBCFT9A7iNnXstMfSomcTQhkW9wDKPL4h1ojIU1KffuKlCQOBNOFl++JefPNjNabHzuIbwyxd6SgyHIQSMbVPbUKPqvd4xuIyJpqPThCBSNG2JQP6w8cNKea2PU+ihRCUUHH7N+ljKZDq2PmPFJ6aVywmpMMrfTafOkW5SrPX2WYZkB5kyn2tYKwrwsQ1ejxP9muaXqDW2eOFonvtJCcajEF6tAiKzjJP7PIUhjI+wyrJRkiMqflxivG2ZlDeFoSoXHElT4Mk1VcrDmI5yUh6GgPGNLcV4iLNQfxsugxeBxweoqTPreXN5+8/AVQSwcIkACr6/EAAAAsAwAAUEsDBBQACAgIAMh7hk0AAAAAAAAAAAAAAAALAAAAX3JlbHMvLnJlbHONzzsOwjAMBuATcIfIO03LgBBq0gUhdUXlAFHiphHNQ0l49PZkYADEwGj792e57R52JjeMyXjHoKlqIOikV8ZpBufhuN4BSVk4JWbvkMGCCTq+ak84i1x20mRCIgVxicGUc9hTmuSEVqTKB3RlMvpoRS5l1DQIeREa6aautzS+G8A/TNIrBrFXDZBhCfiP7cfRSDx4ebXo8o8TX4kii6gxM7j7qKh6tavCAuUt/XiRPwFQSwcILWjPIrEAAAAqAQAAUEsDBBQACAgIAMh7hk0AAAAAAAAAAAAAAAAVAAAAd29yZC90aGVtZS90aGVtZTEueG1s7VlLb9s2HL8P2HcgdG9l2VbqBHWK2LHbrU0bJG6HHmmJlthQokDSSXwb2uOAAcO6YYcV2G2HYVuBFtil+zTZOmwd0K+wvx6WKZvOo023Dq0PNkn9/u8HSfnylcOIoX0iJOVx23Iu1ixEYo/7NA7a1u1B/0LLQlLh2MeMx6RtTYi0rqx/+MFlvKZCEhEE9LFcw20rVCpZs23pwTKWF3lCYng24iLCCqYisH2BD4BvxOx6rbZiR5jGFopxBGxvjUbUI2iQsrTWp8x7DL5iJdMFj4ldL5OoU2RYf89Jf+REdplA+5i1LZDj84MBOVQWYlgqeNC2atnHstcv2yURU0toNbp+9inoCgJ/r57RiWBYEjr95uqlzZJ/Pee/iOv1et2eU/LLANjzwFJnAdvst5zOlKcGyoeLvLs1t9as4jX+jQX8aqfTcVcr+MYM31zAt2orzY16Bd+c4d1F/Tsb3e5KBe/O8CsL+P6l1ZVmFZ+BQkbjvQV0Gs8yMiVkxNk1I7wF8NY0AWYoW8uunD5Wy3Itwve46AMgCy5WNEZqkpAR9gDXxYwOBU0F4DWCtSf5kicXllJZSHqCJqptfZxgqIgZ5OWzH18+e4KO7j89uv/L0YMHR/d/NlBdw3GgU734/ou/H32K/nry3YuHX5nxUsf//tNnv/36pRmodODzrx//8fTx828+//OHhwb4hsBDHT6gEZHoJjlAOzwCwwwCyFCcjWIQYqpTbMSBxDFOaQzongor6JsTzLAB1yFVD94R0AJMwKvjexWFd0MxVtQAvB5GFeAW56zDhdGm66ks3QvjODALF2Mdt4Pxvkl2dy6+vXECuUxNLLshqai5zSDkOCAxUSh9xvcIMZDdpbTi1y3qCS75SKG7FHUwNbpkQIfKTHSNRhCXiUlBiHfFN1t3UIczE/tNsl9FQlVgZmJJWMWNV/FY4cioMY6YjryBVWhScncivIrDpYJIB4Rx1POJlCaaW2JSUfc6tA5z2LfYJKoihaJ7JuQNzLmO3OR73RBHiVFnGoc69iO5BymK0TZXRiV4tULSOcQBx0vDfYcSdbbavk2D0Jwg6ZOxMJUE4dV6nLARJnHR4Su9OqLxcY07gr6Nz7txQ6t8/u2j/1HL3gAnmGpmvlEvw8235y4XPn37u/MmHsfbBArifXN+35zfxea8rJ7PvyXPurCtH7QzNtHSU/eIMrarJozckFn/lmCe34fFbJIRlYf8JIRhIa6CCwTOxkhw9QlV4W6IExDjZBICWbAOJEq4hKuFtZR3dj+lYHO25k4vlYDGaov7+XJDv2yWbLJZIHVBjZTBaYU1Lr2eMCcHnlKa45qlucdKszVvQt0gnL5KcFbquWhIFMyIn/o9ZzANyxsMkVPTYhRinxiWNfucxhvxpnsmJc7HybUFJ9uL1cTi6gwdtK1Vt+5ayMNJ2xrBaQmGUQL8ZNppMAvituWp3MCTa3HO4lVzVjk1d5nBFRGJkGoTyzCnyh5NX6XEM/3rbjP1w/kYYGgmp9Oi0XL+Qy3s+dCS0Yh4asnKbFo842NFxG7oH6AhG4sdDHo38+zyqYROX59OBOR2s0i8auEWtTH/yqaoGcySEBfZ3tJin8OzcalDNtPUs5fo/oqmNM7RFPfdNSXNXDifNvzs0gS7uMAozdG2xYUKOXShJKReX8C+n8kCvRCURaoSYukL6FRXsj/rWzmPvMkFodqhARIUOp0KBSHbqrDzBGZOXd8ep4yKPlOqK5P8d0j2CRuk1buS2m+hcNpNCkdkuPmg2abqGgb9t/jg0nyljWcmqHmWza+pNX1tK1h9PRVOswFr4upmi+vu0p1nfqtN4JaB0i9o3FR4bHY8HfAdiD4q93kEiXihVZRfuTgEnVuacSmrf+sU1FoS7/M8O2rObixx9vHiXt3ZrsHX7vGuthdL1NbuIdls4Y8oPrwHsjfhejNm+YpMYJYPtkVm8JD7k2LIZN4SckdMWzqLd8gIUf9wGtY5jxb/9JSb+U4uILW9JGycTFjgZ5tISVw/mbikmN7xSuLsFmdiwGaSc3we5bJFlp5i8eu47BTKm11mzN7TuuwUgXoFl6nD411WeMo2JR45VAJ3p39dQf7as5Rd/wdQSwcIIVqihCwGAADbHQAAUEsDBBQACAgIAMh7hk0AAAAAAAAAAAAAAAATAAAAW0NvbnRlbnRfVHlwZXNdLnhtbLWTTW7CMBCFT9A7RN5WxNBFVVUEFv1Ztl3QAwzOBKz6T56Bwu07CZAFAqmVmo1l+82893kkT+c774otZrIxVGpSjlWBwcTahlWlPhevowdVEEOowcWAldojqfnsZrrYJ6RCmgNVas2cHrUms0YPVMaEQZQmZg8sx7zSCcwXrFDfjcf32sTAGHjErYeaTZ+xgY3j4ulw31pXClJy1gALlxYzVbzsRDxgtmf9i75tqM9gRkeQMqPramhtE92eB4hKbcK7TCbbGv8UEZvGGqyj2XhpKb9jrlOOBolkqN6VhMyyO6Z+QOY38GKr20p9UsvjI4dB4L3DawCdNmh8I14LWDq8TNDLg0KEjV9ilv1liF4eFKJXPNhwGaQv+UcOlo96ZfiddFgnp0jd/fbZD1BLBwgzrw+3LAEAAC0EAABQSwECFAAUAAgICADIe4ZNSRNDf2gBAAA9BQAAEgAAAAAAAAAAAAAAAAAAAAAAd29yZC9udW1iZXJpbmcueG1sUEsBAhQAFAAICAgAyHuGTY/2kL8FAgAA6gYAABEAAAAAAAAAAAAAAAAAqAEAAHdvcmQvc2V0dGluZ3MueG1sUEsBAhQAFAAICAgAyHuGTa2HbQB5AQAAWgUAABIAAAAAAAAAAAAAAAAA7AMAAHdvcmQvZm9udFRhYmxlLnhtbFBLAQIUABQACAgIAMh7hk2dKXMALAMAAP8RAAAPAAAAAAAAAAAAAAAAAKUFAAB3b3JkL3N0eWxlcy54bWxQSwECFAAUAAgICADIe4ZN8i6p7SYCAAA2BwAAEQAAAAAAAAAAAAAAAAAOCQAAd29yZC9kb2N1bWVudC54bWxQSwECFAAUAAgICADIe4ZNkACr6/EAAAAsAwAAHAAAAAAAAAAAAAAAAABzCwAAd29yZC9fcmVscy9kb2N1bWVudC54bWwucmVsc1BLAQIUABQACAgIAMh7hk0taM8isQAAACoBAAALAAAAAAAAAAAAAAAAAK4MAABfcmVscy8ucmVsc1BLAQIUABQACAgIAMh7hk0hWqKELAYAANsdAAAVAAAAAAAAAAAAAAAAAJgNAAB3b3JkL3RoZW1lL3RoZW1lMS54bWxQSwECFAAUAAgICADIe4ZNM68PtywBAAAtBAAAEwAAAAAAAAAAAAAAAAAHFAAAW0NvbnRlbnRfVHlwZXNdLnhtbFBLBQYAAAAACQAJAEICAAB0FQAAAAA=
+        UEsDBBQACAgIADaAT04AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICAA2gE9OAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgANoBPTgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgANoBPTgAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgANoBPTgAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgANoBPTgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgANoBPTgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgANoBPTgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgANoBPTgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIADaAT05JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICAA2gE9Oj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICAA2gE9OrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgANoBPTojORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIADaAT04B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIADaAT06QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgANoBPTi1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgANoBPTiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIADaAT04zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -1435,7 +1436,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 06 Dec 2018 23:30:17 GMT
+      - Sat, 16 Feb 2019 00:01:45 GMT
       Content-Type:
       - text/html
       Transfer-Encoding:
@@ -1458,10 +1459,10 @@ http_interactions:
         </body>
         </html>
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:17 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:46 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1dX3qjnHC8AsYbT9GuzXALVKoS8P6UVX3b9H4Iww6LrM/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1VzeqabAjT1dGM9dyq5yxivuZ-AJ4_7t8RhP5ZA2lqwc/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1473,7 +1474,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:17 GMT
+      - Sat, 16 Feb 2019 00:01:46 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1484,9 +1485,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 06 Dec 2018 23:30:18 GMT
+      - Sat, 16 Feb 2019 00:01:46 GMT
       Date:
-      - Thu, 06 Dec 2018 23:30:18 GMT
+      - Sat, 16 Feb 2019 00:01:46 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1505,7 +1506,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
@@ -1515,16 +1516,16 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-12-06T23:30:05.470Z"
+         "modifiedTime": "2019-02-16T00:01:34.405Z"
         }
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:18 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:46 GMT
 - request:
-    method: post
-    uri: https://www.googleapis.com/drive/v3/files/1dX3qjnHC8AsYbT9GuzXALVKoS8P6UVX3b9H4Iww6LrM/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1VzeqabAjT1dGM9dyq5yxivuZ-AJ4_7t8RhP5ZA2lqwc&s=AMedNnoAAAAAXGdvBRstFW6CtCAKaGmarp2_5UKzecJL&sz=s350&v=1
     body:
       encoding: UTF-8
-      string: '{"name":"File 1","parents":["1oSbLD0y4C6jXrMypj5P6KnM7N2K-lPwy"]}'
+      string: ''
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1533,7 +1534,67 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:18 GMT
+      - Sat, 16 Feb 2019 00:01:46 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 16 Feb 2019 00:01:47 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 00:01:47 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1VzeqabAjT1dGM9dyq5yxivuZ-AJ4_7t8RhP5ZA2lqwc/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"File 1","parents":["16AzvHPbZT1aVs6MqCwZ_aSRmwVIkrtNw"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 00:01:47 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1550,7 +1611,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 06 Dec 2018 23:30:19 GMT
+      - Sat, 16 Feb 2019 00:01:50 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1567,19 +1628,19 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1Oe9T-3-b4p8-hsPF5BYLZee4YhICPdF45pwnAVPIqvA",
+         "id": "1d4kACqSD00nzh8HxVLwKIoeTiS9IykiJq-JtNVcTNdQ",
          "name": "File 1",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1oSbLD0y4C6jXrMypj5P6KnM7N2K-lPwy"
+          "16AzvHPbZT1aVs6MqCwZ_aSRmwVIkrtNw"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1604,10 +1665,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:19 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:50 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Oe9T-3-b4p8-hsPF5BYLZee4YhICPdF45pwnAVPIqvA?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1d4kACqSD00nzh8HxVLwKIoeTiS9IykiJq-JtNVcTNdQ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1619,7 +1680,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:19 GMT
+      - Sat, 16 Feb 2019 00:01:50 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1630,9 +1691,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 06 Dec 2018 23:30:19 GMT
+      - Sat, 16 Feb 2019 00:01:50 GMT
       Date:
-      - Thu, 06 Dec 2018 23:30:19 GMT
+      - Sat, 16 Feb 2019 00:01:50 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1651,19 +1712,19 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1Oe9T-3-b4p8-hsPF5BYLZee4YhICPdF45pwnAVPIqvA",
+         "id": "1d4kACqSD00nzh8HxVLwKIoeTiS9IykiJq-JtNVcTNdQ",
          "name": "File 1",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1oSbLD0y4C6jXrMypj5P6KnM7N2K-lPwy"
+          "16AzvHPbZT1aVs6MqCwZ_aSRmwVIkrtNw"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1688,10 +1749,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:19 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:50 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Oe9T-3-b4p8-hsPF5BYLZee4YhICPdF45pwnAVPIqvA/export?alt=media&mimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document
+    uri: https://www.googleapis.com/drive/v3/files/1d4kACqSD00nzh8HxVLwKIoeTiS9IykiJq-JtNVcTNdQ/export?alt=media&mimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document
     body:
       encoding: UTF-8
       string: ''
@@ -1703,7 +1764,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:19 GMT
+      - Sat, 16 Feb 2019 00:01:50 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
   response:
@@ -1712,9 +1773,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 06 Dec 2018 23:30:20 GMT
+      - Sat, 16 Feb 2019 00:01:51 GMT
       Date:
-      - Thu, 06 Dec 2018 23:30:20 GMT
+      - Sat, 16 Feb 2019 00:01:51 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Disposition:
@@ -1731,24 +1792,24 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       Content-Length:
-      - '6092'
+      - '6061'
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        UEsDBBQACAgIAMp7hk0AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICADKe4ZNAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAynuGTQAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAynuGTQAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkOotKpadZs0ddPaXcDBMcSqY1u2A2VXPzufkIQpDZXo4Af42Od9ncfHsa9uXhM62mCpCGcLZ3zpOSPMEI8IWy+c388PFzNnpDSwCChneOHssHJurj9dbedK7yhWI5PP1DxBCyfWWsxdV6EYJ6AuucDMdK64TECbply7CciXVFwgngjQZEko0TvX97ypU8jwhZNKNi8kLhKCJFd8pW3KnK9WBOHip8yQfXzzlHuO0gQznTm6ElMzB85UTIQq1ZKhaqYzLkU2/3qITULLcVvRxy2SsDWLkdDcaMtlJCRHWCkTvc87K8Wx1wOglagy+kzh0LOcSQKEVTK2NBpClfel8S6gZVL1g9QsFO0zkbzrO1lKkLv2LGAAz/18QXpVcUPBZOlUVgU5RALFIHUpQIcoUI5ecHQHbANVMUfrXuXcUIoIrCUkdZGqN63s2GuUy1MMAtdq69PUvkieirrcwyFqeztwPHmbgF8KXJsXYMTRPV5BSrWyTflTFs2ilf08cKbVaDsHhQhZOLeSgLHfzpHaa2BQ+lYR2AvFt0xV410rpf6Y8AbMRvH9MnKnmjEKbF3GMLMxt5iM25yiaLYyTQGIZBKU2E3tf546ReNXSk0AUs1zK2QeDb/qFOhTlZT5jgtbUdjuG7ktbtk5YlL1Thh5AdLWn4ita9b1LVo4j7ZeMy5RnmlNbDKDBJe2LB+Ue2epbXkNS4oPpJ9tpJd+NnL02MOl+yG+YrDHals4zjtG45zrEhSOfrCytzY0WYZ3V7xYvBeMxePekELQhr+bBVSNeL3WsNLYnKRj37MzXmLzfjCPEXpe99q7lWNR5nVthl67NvPYXh0OweYfxeZ/MGzBtC+2ZansNbd40LHF89iJGIOjGINzY5wdUvSHUkScclnVXmC/rTforOMNOnsHvOFRvOHHwuvP+uI9wDnNPi2cYQfO8B1wTo7inHwwnOF74jx6vp+Ic3oU5/R/xUkawmfB+0y0uVW07gtZ9Mxcpwdc336eTzpgTU6C9ZQudSevquPMyAJ/ELN3vOpXRd11onUXddBx7wqO3LvKf+r6L1BLBwidKXMALAMAAP8RAABQSwMEFAAICAgAynuGTQAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWV227bMAyGn2DvEOg+sR2kW2HU6cWCDQO2IWi6B2Ak2RaqEyg5afb0k+NTDkXhZrkhSIoff8mM9PD4quRkx9EJozOSzGIy4ZoaJnSRkT/P36b3ZOI8aAbSaJ6RA3fkcfnpYZ8yQyvFtZ8EgnapohkpvbdpFDlacgVuZizXIZkbVOCDi0WkAF8qO6VGWfBiK6Twh2gex59JizEZqVCnLWKqBEXjTO7rktTkuaC8NV0FjunblKxayceOEXIZNBjtSmFdR1O30kKy7CC79zaxU7Jbt7djujGEffgcSjaN9gaZRUO5cyG6apI9MYlHHGCN6CvGSDjv2SlRIHSPqYfjAtT3noXe7aEdUcNGhrNwcoyQJvVTbBHwcK0CbjjP03orRk3xBSFU+Qr7gbwFQUtA3wHkLQRp6AtnX0HvoB9mVowa5wsSE1AgqGFI3Ye+bBJfjMumBMsHWvF/tO9oKjuM++IW2sk/MLn7GGDeAZbhCtwadqitnezTcIOyp4zE7Y+0oRWX18H1dehpxXOopH8js8azYLJILSD8YCfRo4g11oYa7fmrr0BuLNBwYAGzg1oEieo8rjHYqF+P7wl9Y0Pnclri0Xh51ipqM7VtGtarHKe+WW+Lzd9QUIZX5+5+ceSHuyiZzxetUlv8glrd1nhvwiAni2aVN3ZwJM/94KEoyhO35MB4kPtlfnRzY3znth1+V+r5YHlIhkcO69JWeqcz6r5yNLx4y39QSwcI8i6p7SYCAAA2BwAAUEsDBBQACAgIAMp7hk0AAAAAAAAAAAAAAAAcAAAAd29yZC9fcmVscy9kb2N1bWVudC54bWwucmVsc62STWrDMBCFT9A7iNnXstMfSomcTQhkW9wDKPL4h1ojIU1KffuKlCQOBNOFl++JefPNjNabHzuIbwyxd6SgyHIQSMbVPbUKPqvd4xuIyJpqPThCBSNG2JQP6w8cNKea2PU+ihRCUUHH7N+ljKZDq2PmPFJ6aVywmpMMrfTafOkW5SrPX2WYZkB5kyn2tYKwrwsQ1ejxP9muaXqDW2eOFonvtJCcajEF6tAiKzjJP7PIUhjI+wyrJRkiMqflxivG2ZlDeFoSoXHElT4Mk1VcrDmI5yUh6GgPGNLcV4iLNQfxsugxeBxweoqTPreXN5+8/AVQSwcIkACr6/EAAAAsAwAAUEsDBBQACAgIAMp7hk0AAAAAAAAAAAAAAAALAAAAX3JlbHMvLnJlbHONzzsOwjAMBuATcIfIO03LgBBq0gUhdUXlAFHiphHNQ0l49PZkYADEwGj792e57R52JjeMyXjHoKlqIOikV8ZpBufhuN4BSVk4JWbvkMGCCTq+ak84i1x20mRCIgVxicGUc9hTmuSEVqTKB3RlMvpoRS5l1DQIeREa6aautzS+G8A/TNIrBrFXDZBhCfiP7cfRSDx4ebXo8o8TX4kii6gxM7j7qKh6tavCAuUt/XiRPwFQSwcILWjPIrEAAAAqAQAAUEsDBBQACAgIAMp7hk0AAAAAAAAAAAAAAAAVAAAAd29yZC90aGVtZS90aGVtZTEueG1s7VlLb9s2HL8P2HcgdG9l2VbqBHWK2LHbrU0bJG6HHmmJlthQokDSSXwb2uOAAcO6YYcV2G2HYVuBFtil+zTZOmwd0K+wvx6WKZvOo023Dq0PNkn9/u8HSfnylcOIoX0iJOVx23Iu1ixEYo/7NA7a1u1B/0LLQlLh2MeMx6RtTYi0rqx/+MFlvKZCEhEE9LFcw20rVCpZs23pwTKWF3lCYng24iLCCqYisH2BD4BvxOx6rbZiR5jGFopxBGxvjUbUI2iQsrTWp8x7DL5iJdMFj4ldL5OoU2RYf89Jf+REdplA+5i1LZDj84MBOVQWYlgqeNC2atnHstcv2yURU0toNbp+9inoCgJ/r57RiWBYEjr95uqlzZJ/Pee/iOv1et2eU/LLANjzwFJnAdvst5zOlKcGyoeLvLs1t9as4jX+jQX8aqfTcVcr+MYM31zAt2orzY16Bd+c4d1F/Tsb3e5KBe/O8CsL+P6l1ZVmFZ+BQkbjvQV0Gs8yMiVkxNk1I7wF8NY0AWYoW8uunD5Wy3Itwve46AMgCy5WNEZqkpAR9gDXxYwOBU0F4DWCtSf5kicXllJZSHqCJqptfZxgqIgZ5OWzH18+e4KO7j89uv/L0YMHR/d/NlBdw3GgU734/ou/H32K/nry3YuHX5nxUsf//tNnv/36pRmodODzrx//8fTx828+//OHhwb4hsBDHT6gEZHoJjlAOzwCwwwCyFCcjWIQYqpTbMSBxDFOaQzongor6JsTzLAB1yFVD94R0AJMwKvjexWFd0MxVtQAvB5GFeAW56zDhdGm66ks3QvjODALF2Mdt4Pxvkl2dy6+vXECuUxNLLshqai5zSDkOCAxUSh9xvcIMZDdpbTi1y3qCS75SKG7FHUwNbpkQIfKTHSNRhCXiUlBiHfFN1t3UIczE/tNsl9FQlVgZmJJWMWNV/FY4cioMY6YjryBVWhScncivIrDpYJIB4Rx1POJlCaaW2JSUfc6tA5z2LfYJKoihaJ7JuQNzLmO3OR73RBHiVFnGoc69iO5BymK0TZXRiV4tULSOcQBx0vDfYcSdbbavk2D0Jwg6ZOxMJUE4dV6nLARJnHR4Su9OqLxcY07gr6Nz7txQ6t8/u2j/1HL3gAnmGpmvlEvw8235y4XPn37u/MmHsfbBArifXN+35zfxea8rJ7PvyXPurCtH7QzNtHSU/eIMrarJozckFn/lmCe34fFbJIRlYf8JIRhIa6CCwTOxkhw9QlV4W6IExDjZBICWbAOJEq4hKuFtZR3dj+lYHO25k4vlYDGaov7+XJDv2yWbLJZIHVBjZTBaYU1Lr2eMCcHnlKa45qlucdKszVvQt0gnL5KcFbquWhIFMyIn/o9ZzANyxsMkVPTYhRinxiWNfucxhvxpnsmJc7HybUFJ9uL1cTi6gwdtK1Vt+5ayMNJ2xrBaQmGUQL8ZNppMAvituWp3MCTa3HO4lVzVjk1d5nBFRGJkGoTyzCnyh5NX6XEM/3rbjP1w/kYYGgmp9Oi0XL+Qy3s+dCS0Yh4asnKbFo842NFxG7oH6AhG4sdDHo38+zyqYROX59OBOR2s0i8auEWtTH/yqaoGcySEBfZ3tJin8OzcalDNtPUs5fo/oqmNM7RFPfdNSXNXDifNvzs0gS7uMAozdG2xYUKOXShJKReX8C+n8kCvRCURaoSYukL6FRXsj/rWzmPvMkFodqhARIUOp0KBSHbqrDzBGZOXd8ep4yKPlOqK5P8d0j2CRuk1buS2m+hcNpNCkdkuPmg2abqGgb9t/jg0nyljWcmqHmWza+pNX1tK1h9PRVOswFr4upmi+vu0p1nfqtN4JaB0i9o3FR4bHY8HfAdiD4q93kEiXihVZRfuTgEnVuacSmrf+sU1FoS7/M8O2rObixx9vHiXt3ZrsHX7vGuthdL1NbuIdls4Y8oPrwHsjfhejNm+YpMYJYPtkVm8JD7k2LIZN4SckdMWzqLd8gIUf9wGtY5jxb/9JSb+U4uILW9JGycTFjgZ5tISVw/mbikmN7xSuLsFmdiwGaSc3we5bJFlp5i8eu47BTKm11mzN7TuuwUgXoFl6nD411WeMo2JR45VAJ3p39dQf7as5Rd/wdQSwcIIVqihCwGAADbHQAAUEsDBBQACAgIAMp7hk0AAAAAAAAAAAAAAAATAAAAW0NvbnRlbnRfVHlwZXNdLnhtbLWTTW7CMBCFT9A7RN5WxNBFVVUEFv1Ztl3QAwzOBKz6T56Bwu07CZAFAqmVmo1l+82893kkT+c774otZrIxVGpSjlWBwcTahlWlPhevowdVEEOowcWAldojqfnsZrrYJ6RCmgNVas2cHrUms0YPVMaEQZQmZg8sx7zSCcwXrFDfjcf32sTAGHjErYeaTZ+xgY3j4ulw31pXClJy1gALlxYzVbzsRDxgtmf9i75tqM9gRkeQMqPramhtE92eB4hKbcK7TCbbGv8UEZvGGqyj2XhpKb9jrlOOBolkqN6VhMyyO6Z+QOY38GKr20p9UsvjI4dB4L3DawCdNmh8I14LWDq8TNDLg0KEjV9ilv1liF4eFKJXPNhwGaQv+UcOlo96ZfiddFgnp0jd/fbZD1BLBwgzrw+3LAEAAC0EAABQSwECFAAUAAgICADKe4ZNSRNDf2gBAAA9BQAAEgAAAAAAAAAAAAAAAAAAAAAAd29yZC9udW1iZXJpbmcueG1sUEsBAhQAFAAICAgAynuGTY/2kL8FAgAA6gYAABEAAAAAAAAAAAAAAAAAqAEAAHdvcmQvc2V0dGluZ3MueG1sUEsBAhQAFAAICAgAynuGTa2HbQB5AQAAWgUAABIAAAAAAAAAAAAAAAAA7AMAAHdvcmQvZm9udFRhYmxlLnhtbFBLAQIUABQACAgIAMp7hk2dKXMALAMAAP8RAAAPAAAAAAAAAAAAAAAAAKUFAAB3b3JkL3N0eWxlcy54bWxQSwECFAAUAAgICADKe4ZN8i6p7SYCAAA2BwAAEQAAAAAAAAAAAAAAAAAOCQAAd29yZC9kb2N1bWVudC54bWxQSwECFAAUAAgICADKe4ZNkACr6/EAAAAsAwAAHAAAAAAAAAAAAAAAAABzCwAAd29yZC9fcmVscy9kb2N1bWVudC54bWwucmVsc1BLAQIUABQACAgIAMp7hk0taM8isQAAACoBAAALAAAAAAAAAAAAAAAAAK4MAABfcmVscy8ucmVsc1BLAQIUABQACAgIAMp7hk0hWqKELAYAANsdAAAVAAAAAAAAAAAAAAAAAJgNAAB3b3JkL3RoZW1lL3RoZW1lMS54bWxQSwECFAAUAAgICADKe4ZNM68PtywBAAAtBAAAEwAAAAAAAAAAAAAAAAAHFAAAW0NvbnRlbnRfVHlwZXNdLnhtbFBLBQYAAAAACQAJAEICAAB0FQAAAAA=
+        UEsDBBQACAgIADmAT04AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICAA5gE9OAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAOYBPTgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAOYBPTgAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgAOYBPTgAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgAOYBPTgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgAOYBPTgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgAOYBPTgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgAOYBPTgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIADmAT05JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICAA5gE9Oj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICAA5gE9OrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAOYBPTojORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIADmAT04B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIADmAT06QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgAOYBPTi1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgAOYBPTiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIADmAT04zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:20 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:51 GMT
 - request:
     method: put
     uri: http://localhost:9998/tika
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        UEsDBBQACAgIAMp7hk0AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICADKe4ZNAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAynuGTQAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAynuGTQAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkOotKpadZs0ddPaXcDBMcSqY1u2A2VXPzufkIQpDZXo4Af42Od9ncfHsa9uXhM62mCpCGcLZ3zpOSPMEI8IWy+c388PFzNnpDSwCChneOHssHJurj9dbedK7yhWI5PP1DxBCyfWWsxdV6EYJ6AuucDMdK64TECbply7CciXVFwgngjQZEko0TvX97ypU8jwhZNKNi8kLhKCJFd8pW3KnK9WBOHip8yQfXzzlHuO0gQznTm6ElMzB85UTIQq1ZKhaqYzLkU2/3qITULLcVvRxy2SsDWLkdDcaMtlJCRHWCkTvc87K8Wx1wOglagy+kzh0LOcSQKEVTK2NBpClfel8S6gZVL1g9QsFO0zkbzrO1lKkLv2LGAAz/18QXpVcUPBZOlUVgU5RALFIHUpQIcoUI5ecHQHbANVMUfrXuXcUIoIrCUkdZGqN63s2GuUy1MMAtdq69PUvkieirrcwyFqeztwPHmbgF8KXJsXYMTRPV5BSrWyTflTFs2ilf08cKbVaDsHhQhZOLeSgLHfzpHaa2BQ+lYR2AvFt0xV410rpf6Y8AbMRvH9MnKnmjEKbF3GMLMxt5iM25yiaLYyTQGIZBKU2E3tf546ReNXSk0AUs1zK2QeDb/qFOhTlZT5jgtbUdjuG7ktbtk5YlL1Thh5AdLWn4ita9b1LVo4j7ZeMy5RnmlNbDKDBJe2LB+Ue2epbXkNS4oPpJ9tpJd+NnL02MOl+yG+YrDHals4zjtG45zrEhSOfrCytzY0WYZ3V7xYvBeMxePekELQhr+bBVSNeL3WsNLYnKRj37MzXmLzfjCPEXpe99q7lWNR5nVthl67NvPYXh0OweYfxeZ/MGzBtC+2ZansNbd40LHF89iJGIOjGINzY5wdUvSHUkScclnVXmC/rTforOMNOnsHvOFRvOHHwuvP+uI9wDnNPi2cYQfO8B1wTo7inHwwnOF74jx6vp+Ic3oU5/R/xUkawmfB+0y0uVW07gtZ9Mxcpwdc336eTzpgTU6C9ZQudSevquPMyAJ/ELN3vOpXRd11onUXddBx7wqO3LvKf+r6L1BLBwidKXMALAMAAP8RAABQSwMEFAAICAgAynuGTQAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWV227bMAyGn2DvEOg+sR2kW2HU6cWCDQO2IWi6B2Ak2RaqEyg5afb0k+NTDkXhZrkhSIoff8mM9PD4quRkx9EJozOSzGIy4ZoaJnSRkT/P36b3ZOI8aAbSaJ6RA3fkcfnpYZ8yQyvFtZ8EgnapohkpvbdpFDlacgVuZizXIZkbVOCDi0WkAF8qO6VGWfBiK6Twh2gex59JizEZqVCnLWKqBEXjTO7rktTkuaC8NV0FjunblKxayceOEXIZNBjtSmFdR1O30kKy7CC79zaxU7Jbt7djujGEffgcSjaN9gaZRUO5cyG6apI9MYlHHGCN6CvGSDjv2SlRIHSPqYfjAtT3noXe7aEdUcNGhrNwcoyQJvVTbBHwcK0CbjjP03orRk3xBSFU+Qr7gbwFQUtA3wHkLQRp6AtnX0HvoB9mVowa5wsSE1AgqGFI3Ye+bBJfjMumBMsHWvF/tO9oKjuM++IW2sk/MLn7GGDeAZbhCtwadqitnezTcIOyp4zE7Y+0oRWX18H1dehpxXOopH8js8azYLJILSD8YCfRo4g11oYa7fmrr0BuLNBwYAGzg1oEieo8rjHYqF+P7wl9Y0Pnclri0Xh51ipqM7VtGtarHKe+WW+Lzd9QUIZX5+5+ceSHuyiZzxetUlv8glrd1nhvwiAni2aVN3ZwJM/94KEoyhO35MB4kPtlfnRzY3znth1+V+r5YHlIhkcO69JWeqcz6r5yNLx4y39QSwcI8i6p7SYCAAA2BwAAUEsDBBQACAgIAMp7hk0AAAAAAAAAAAAAAAAcAAAAd29yZC9fcmVscy9kb2N1bWVudC54bWwucmVsc62STWrDMBCFT9A7iNnXstMfSomcTQhkW9wDKPL4h1ojIU1KffuKlCQOBNOFl++JefPNjNabHzuIbwyxd6SgyHIQSMbVPbUKPqvd4xuIyJpqPThCBSNG2JQP6w8cNKea2PU+ihRCUUHH7N+ljKZDq2PmPFJ6aVywmpMMrfTafOkW5SrPX2WYZkB5kyn2tYKwrwsQ1ejxP9muaXqDW2eOFonvtJCcajEF6tAiKzjJP7PIUhjI+wyrJRkiMqflxivG2ZlDeFoSoXHElT4Mk1VcrDmI5yUh6GgPGNLcV4iLNQfxsugxeBxweoqTPreXN5+8/AVQSwcIkACr6/EAAAAsAwAAUEsDBBQACAgIAMp7hk0AAAAAAAAAAAAAAAALAAAAX3JlbHMvLnJlbHONzzsOwjAMBuATcIfIO03LgBBq0gUhdUXlAFHiphHNQ0l49PZkYADEwGj792e57R52JjeMyXjHoKlqIOikV8ZpBufhuN4BSVk4JWbvkMGCCTq+ak84i1x20mRCIgVxicGUc9hTmuSEVqTKB3RlMvpoRS5l1DQIeREa6aautzS+G8A/TNIrBrFXDZBhCfiP7cfRSDx4ebXo8o8TX4kii6gxM7j7qKh6tavCAuUt/XiRPwFQSwcILWjPIrEAAAAqAQAAUEsDBBQACAgIAMp7hk0AAAAAAAAAAAAAAAAVAAAAd29yZC90aGVtZS90aGVtZTEueG1s7VlLb9s2HL8P2HcgdG9l2VbqBHWK2LHbrU0bJG6HHmmJlthQokDSSXwb2uOAAcO6YYcV2G2HYVuBFtil+zTZOmwd0K+wvx6WKZvOo023Dq0PNkn9/u8HSfnylcOIoX0iJOVx23Iu1ixEYo/7NA7a1u1B/0LLQlLh2MeMx6RtTYi0rqx/+MFlvKZCEhEE9LFcw20rVCpZs23pwTKWF3lCYng24iLCCqYisH2BD4BvxOx6rbZiR5jGFopxBGxvjUbUI2iQsrTWp8x7DL5iJdMFj4ldL5OoU2RYf89Jf+REdplA+5i1LZDj84MBOVQWYlgqeNC2atnHstcv2yURU0toNbp+9inoCgJ/r57RiWBYEjr95uqlzZJ/Pee/iOv1et2eU/LLANjzwFJnAdvst5zOlKcGyoeLvLs1t9as4jX+jQX8aqfTcVcr+MYM31zAt2orzY16Bd+c4d1F/Tsb3e5KBe/O8CsL+P6l1ZVmFZ+BQkbjvQV0Gs8yMiVkxNk1I7wF8NY0AWYoW8uunD5Wy3Itwve46AMgCy5WNEZqkpAR9gDXxYwOBU0F4DWCtSf5kicXllJZSHqCJqptfZxgqIgZ5OWzH18+e4KO7j89uv/L0YMHR/d/NlBdw3GgU734/ou/H32K/nry3YuHX5nxUsf//tNnv/36pRmodODzrx//8fTx828+//OHhwb4hsBDHT6gEZHoJjlAOzwCwwwCyFCcjWIQYqpTbMSBxDFOaQzongor6JsTzLAB1yFVD94R0AJMwKvjexWFd0MxVtQAvB5GFeAW56zDhdGm66ks3QvjODALF2Mdt4Pxvkl2dy6+vXECuUxNLLshqai5zSDkOCAxUSh9xvcIMZDdpbTi1y3qCS75SKG7FHUwNbpkQIfKTHSNRhCXiUlBiHfFN1t3UIczE/tNsl9FQlVgZmJJWMWNV/FY4cioMY6YjryBVWhScncivIrDpYJIB4Rx1POJlCaaW2JSUfc6tA5z2LfYJKoihaJ7JuQNzLmO3OR73RBHiVFnGoc69iO5BymK0TZXRiV4tULSOcQBx0vDfYcSdbbavk2D0Jwg6ZOxMJUE4dV6nLARJnHR4Su9OqLxcY07gr6Nz7txQ6t8/u2j/1HL3gAnmGpmvlEvw8235y4XPn37u/MmHsfbBArifXN+35zfxea8rJ7PvyXPurCtH7QzNtHSU/eIMrarJozckFn/lmCe34fFbJIRlYf8JIRhIa6CCwTOxkhw9QlV4W6IExDjZBICWbAOJEq4hKuFtZR3dj+lYHO25k4vlYDGaov7+XJDv2yWbLJZIHVBjZTBaYU1Lr2eMCcHnlKa45qlucdKszVvQt0gnL5KcFbquWhIFMyIn/o9ZzANyxsMkVPTYhRinxiWNfucxhvxpnsmJc7HybUFJ9uL1cTi6gwdtK1Vt+5ayMNJ2xrBaQmGUQL8ZNppMAvituWp3MCTa3HO4lVzVjk1d5nBFRGJkGoTyzCnyh5NX6XEM/3rbjP1w/kYYGgmp9Oi0XL+Qy3s+dCS0Yh4asnKbFo842NFxG7oH6AhG4sdDHo38+zyqYROX59OBOR2s0i8auEWtTH/yqaoGcySEBfZ3tJin8OzcalDNtPUs5fo/oqmNM7RFPfdNSXNXDifNvzs0gS7uMAozdG2xYUKOXShJKReX8C+n8kCvRCURaoSYukL6FRXsj/rWzmPvMkFodqhARIUOp0KBSHbqrDzBGZOXd8ep4yKPlOqK5P8d0j2CRuk1buS2m+hcNpNCkdkuPmg2abqGgb9t/jg0nyljWcmqHmWza+pNX1tK1h9PRVOswFr4upmi+vu0p1nfqtN4JaB0i9o3FR4bHY8HfAdiD4q93kEiXihVZRfuTgEnVuacSmrf+sU1FoS7/M8O2rObixx9vHiXt3ZrsHX7vGuthdL1NbuIdls4Y8oPrwHsjfhejNm+YpMYJYPtkVm8JD7k2LIZN4SckdMWzqLd8gIUf9wGtY5jxb/9JSb+U4uILW9JGycTFjgZ5tISVw/mbikmN7xSuLsFmdiwGaSc3we5bJFlp5i8eu47BTKm11mzN7TuuwUgXoFl6nD411WeMo2JR45VAJ3p39dQf7as5Rd/wdQSwcIIVqihCwGAADbHQAAUEsDBBQACAgIAMp7hk0AAAAAAAAAAAAAAAATAAAAW0NvbnRlbnRfVHlwZXNdLnhtbLWTTW7CMBCFT9A7RN5WxNBFVVUEFv1Ztl3QAwzOBKz6T56Bwu07CZAFAqmVmo1l+82893kkT+c774otZrIxVGpSjlWBwcTahlWlPhevowdVEEOowcWAldojqfnsZrrYJ6RCmgNVas2cHrUms0YPVMaEQZQmZg8sx7zSCcwXrFDfjcf32sTAGHjErYeaTZ+xgY3j4ulw31pXClJy1gALlxYzVbzsRDxgtmf9i75tqM9gRkeQMqPramhtE92eB4hKbcK7TCbbGv8UEZvGGqyj2XhpKb9jrlOOBolkqN6VhMyyO6Z+QOY38GKr20p9UsvjI4dB4L3DawCdNmh8I14LWDq8TNDLg0KEjV9ilv1liF4eFKJXPNhwGaQv+UcOlo96ZfiddFgnp0jd/fbZD1BLBwgzrw+3LAEAAC0EAABQSwECFAAUAAgICADKe4ZNSRNDf2gBAAA9BQAAEgAAAAAAAAAAAAAAAAAAAAAAd29yZC9udW1iZXJpbmcueG1sUEsBAhQAFAAICAgAynuGTY/2kL8FAgAA6gYAABEAAAAAAAAAAAAAAAAAqAEAAHdvcmQvc2V0dGluZ3MueG1sUEsBAhQAFAAICAgAynuGTa2HbQB5AQAAWgUAABIAAAAAAAAAAAAAAAAA7AMAAHdvcmQvZm9udFRhYmxlLnhtbFBLAQIUABQACAgIAMp7hk2dKXMALAMAAP8RAAAPAAAAAAAAAAAAAAAAAKUFAAB3b3JkL3N0eWxlcy54bWxQSwECFAAUAAgICADKe4ZN8i6p7SYCAAA2BwAAEQAAAAAAAAAAAAAAAAAOCQAAd29yZC9kb2N1bWVudC54bWxQSwECFAAUAAgICADKe4ZNkACr6/EAAAAsAwAAHAAAAAAAAAAAAAAAAABzCwAAd29yZC9fcmVscy9kb2N1bWVudC54bWwucmVsc1BLAQIUABQACAgIAMp7hk0taM8isQAAACoBAAALAAAAAAAAAAAAAAAAAK4MAABfcmVscy8ucmVsc1BLAQIUABQACAgIAMp7hk0hWqKELAYAANsdAAAVAAAAAAAAAAAAAAAAAJgNAAB3b3JkL3RoZW1lL3RoZW1lMS54bWxQSwECFAAUAAgICADKe4ZNM68PtywBAAAtBAAAEwAAAAAAAAAAAAAAAAAHFAAAW0NvbnRlbnRfVHlwZXNdLnhtbFBLBQYAAAAACQAJAEICAAB0FQAAAAA=
+        UEsDBBQACAgIADmAT04AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICAA5gE9OAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAOYBPTgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAOYBPTgAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgAOYBPTgAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgAOYBPTgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgAOYBPTgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgAOYBPTgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgAOYBPTgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIADmAT05JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICAA5gE9Oj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICAA5gE9OrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAOYBPTojORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIADmAT04B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIADmAT06QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgAOYBPTi1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgAOYBPTiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIADmAT04zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -1766,7 +1827,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 06 Dec 2018 23:30:20 GMT
+      - Sat, 16 Feb 2019 00:01:51 GMT
       Content-Type:
       - text/html
       Transfer-Encoding:
@@ -1789,13 +1850,13 @@ http_interactions:
         </body>
         </html>
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:20 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:51 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File 3","parents":["1FGoyxTrkyRTu-P0bT3eGvDlDpGX099vT"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File 3","parents":["12EwfeG-s6D8Za-Ku46k-53y4ZMZRFd_b"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1804,7 +1865,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:20 GMT
+      - Sat, 16 Feb 2019 00:01:51 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1821,7 +1882,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 06 Dec 2018 23:30:21 GMT
+      - Sat, 16 Feb 2019 00:01:53 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1838,19 +1899,19 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1wRBoziqoa8BSDw2siiKwMSmGhHexDP4kAcIf7Kb7_V0",
+         "id": "1c6woFODcwmwJO3d7vHYyLZe9vDX3ACQkXhIGJyoQe6Q",
          "name": "File 3",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1FGoyxTrkyRTu-P0bT3eGvDlDpGX099vT"
+          "12EwfeG-s6D8Za-Ku46k-53y4ZMZRFd_b"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1875,13 +1936,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:21 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:53 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Branch #266","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Branch #10","parents":["16AzvHPbZT1aVs6MqCwZ_aSRmwVIkrtNw"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1890,7 +1951,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:21 GMT
+      - Sat, 16 Feb 2019 00:01:53 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1907,7 +1968,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 06 Dec 2018 23:30:22 GMT
+      - Sat, 16 Feb 2019 00:01:54 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1924,22 +1985,31 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1R2SYtd0Lx4sRBVbBd6K-EF-v5jM1V_nZ",
-         "name": "Branch #266",
+         "id": "1-3-wF6pW_Q1bLviglzrL2OOsTGVlcGfg",
+         "name": "Branch #10",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
+          "16AzvHPbZT1aVs6MqCwZ_aSRmwVIkrtNw"
          ],
          "thumbnailVersion": "0",
          "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
           {
            "kind": "drive#permission",
            "id": "11673017242486491425",
@@ -1952,10 +2022,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:22 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:54 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1R2SYtd0Lx4sRBVbBd6K-EF-v5jM1V_nZ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1-3-wF6pW_Q1bLviglzrL2OOsTGVlcGfg?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1967,7 +2037,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:22 GMT
+      - Sat, 16 Feb 2019 00:01:54 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1978,9 +2048,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 06 Dec 2018 23:30:22 GMT
+      - Sat, 16 Feb 2019 00:01:54 GMT
       Date:
-      - Thu, 06 Dec 2018 23:30:22 GMT
+      - Sat, 16 Feb 2019 00:01:54 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1999,22 +2069,31 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
       encoding: UTF-8
       string: |
         {
-         "id": "1R2SYtd0Lx4sRBVbBd6K-EF-v5jM1V_nZ",
-         "name": "Branch #266",
+         "id": "1-3-wF6pW_Q1bLviglzrL2OOsTGVlcGfg",
+         "name": "Branch #10",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
+          "16AzvHPbZT1aVs6MqCwZ_aSRmwVIkrtNw"
          ],
          "thumbnailVersion": "0",
          "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
           {
            "kind": "drive#permission",
            "id": "11673017242486491425",
@@ -2027,10 +2106,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:22 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:54 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1R2SYtd0Lx4sRBVbBd6K-EF-v5jM1V_nZ/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1-3-wF6pW_Q1bLviglzrL2OOsTGVlcGfg/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -2042,7 +2121,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:22 GMT
+      - Sat, 16 Feb 2019 00:01:54 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2060,9 +2139,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 06 Dec 2018 23:30:22 GMT
+      - Sat, 16 Feb 2019 00:01:55 GMT
       Expires:
-      - Thu, 06 Dec 2018 23:30:22 GMT
+      - Sat, 16 Feb 2019 00:01:55 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -2074,7 +2153,7 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
@@ -2094,13 +2173,13 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:22 GMT
+  recorded_at: Sat, 16 Feb 2019 00:01:55 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1R2SYtd0Lx4sRBVbBd6K-EF-v5jM1V_nZ/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"writer","type":"user"}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1-3-wF6pW_Q1bLviglzrL2OOsTGVlcGfg"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -2109,7 +2188,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:22 GMT
+      - Sat, 16 Feb 2019 00:01:55 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -2126,7 +2205,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 06 Dec 2018 23:30:23 GMT
+      - Sat, 16 Feb 2019 00:01:56 GMT
       Vary:
       - Origin
       - X-Origin
@@ -2143,7 +2222,452 @@ http_interactions:
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1gGUJhk0HvaFF_kQZAecNy2sINisDkJHj",
+         "name": "Folder",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "1-3-wF6pW_Q1bLviglzrL2OOsTGVlcGfg"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 00:01:56 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1gGUJhk0HvaFF_kQZAecNy2sINisDkJHj/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 00:01:56 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Sat, 16 Feb 2019 00:01:56 GMT
+      Expires:
+      - Sat, 16 Feb 2019 00:01:56 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 00:01:56 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1d4kACqSD00nzh8HxVLwKIoeTiS9IykiJq-JtNVcTNdQ/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"File 1","parents":["1gGUJhk0HvaFF_kQZAecNy2sINisDkJHj"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 00:01:56 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 16 Feb 2019 00:01:59 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1swOpZhvPojWLcxgl-D1k5I_Y4QmnJQo_xsLZGXnGtDQ",
+         "name": "File 1",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1gGUJhk0HvaFF_kQZAecNy2sINisDkJHj"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 00:01:59 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1swOpZhvPojWLcxgl-D1k5I_Y4QmnJQo_xsLZGXnGtDQ/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 00:01:59 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 16 Feb 2019 00:01:59 GMT
+      Date:
+      - Sat, 16 Feb 2019 00:01:59 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2019-02-16T00:01:58.270Z"
+        }
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 00:02:00 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1Gcd7Nl0f03tNuhOzp2OFxKKtJUjTFiRT2utjMc8HrpU/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"File 2","parents":["1gGUJhk0HvaFF_kQZAecNy2sINisDkJHj"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 00:02:00 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 16 Feb 2019 00:02:02 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1CFpAUC7QxJxWA_xr6wnhbDofFLVEgrOM-rm7XSHgTe0",
+         "name": "File 2",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1gGUJhk0HvaFF_kQZAecNy2sINisDkJHj"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 00:02:02 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1CFpAUC7QxJxWA_xr6wnhbDofFLVEgrOM-rm7XSHgTe0/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 00:02:02 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 16 Feb 2019 00:02:02 GMT
+      Date:
+      - Sat, 16 Feb 2019 00:02:02 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2019-02-16T00:02:01.462Z"
+        }
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 00:02:02 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1-3-wF6pW_Q1bLviglzrL2OOsTGVlcGfg/permissions?sendNotificationEmail=false
+    body:
+      encoding: UTF-8
+      string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"writer","type":"user"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 00:02:03 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 16 Feb 2019 00:02:03 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
       Transfer-Encoding:
       - chunked
     body:
@@ -2156,455 +2680,10 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:23 GMT
-- request:
-    method: post
-    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1R2SYtd0Lx4sRBVbBd6K-EF-v5jM1V_nZ"]}'
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 06 Dec 2018 23:30:23 GMT
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Thu, 06 Dec 2018 23:30:23 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1p2rRSoqGoQlokB9UKglo1vm_orP8hEh5",
-         "name": "Folder",
-         "mimeType": "application/vnd.google-apps.folder",
-         "trashed": false,
-         "parents": [
-          "1R2SYtd0Lx4sRBVbBd6K-EF-v5jM1V_nZ"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "writer",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:24 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1p2rRSoqGoQlokB9UKglo1vm_orP8hEh5/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 06 Dec 2018 23:30:24 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      Date:
-      - Thu, 06 Dec 2018 23:30:24 GMT
-      Expires:
-      - Thu, 06 Dec 2018 23:30:24 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "global",
-            "reason": "revisionsNotSupported",
-            "message": "The file does not support revisions."
-           }
-          ],
-          "code": 403,
-          "message": "The file does not support revisions."
-         }
-        }
-    http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:24 GMT
-- request:
-    method: post
-    uri: https://www.googleapis.com/drive/v3/files/1Oe9T-3-b4p8-hsPF5BYLZee4YhICPdF45pwnAVPIqvA/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: '{"name":"File 1","parents":["1p2rRSoqGoQlokB9UKglo1vm_orP8hEh5"]}'
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 06 Dec 2018 23:30:24 GMT
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Thu, 06 Dec 2018 23:30:25 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "16_5oxJFOpAbgWhDfbIaoN2bbwRcKWST_DLiWk1bt5Yk",
-         "name": "File 1",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1p2rRSoqGoQlokB9UKglo1vm_orP8hEh5"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "writer",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:26 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/16_5oxJFOpAbgWhDfbIaoN2bbwRcKWST_DLiWk1bt5Yk/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 06 Dec 2018 23:30:26 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Thu, 06 Dec 2018 23:30:26 GMT
-      Date:
-      - Thu, 06 Dec 2018 23:30:26 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "kind": "drive#revision",
-         "id": "1",
-         "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-12-06T23:30:25.266Z"
-        }
-    http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:26 GMT
-- request:
-    method: post
-    uri: https://www.googleapis.com/drive/v3/files/18_7WGJsOq_gp36l-I8b8PUvFN0I395enZ2ML1WYi16I/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: '{"name":"File 2","parents":["1p2rRSoqGoQlokB9UKglo1vm_orP8hEh5"]}'
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 06 Dec 2018 23:30:26 GMT
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Thu, 06 Dec 2018 23:30:27 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1wz-CCNOdhpKdrhSn-uVrmHnsHH5zs5aJW6cHqMIMQ7Q",
-         "name": "File 2",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1p2rRSoqGoQlokB9UKglo1vm_orP8hEh5"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "writer",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:28 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1wz-CCNOdhpKdrhSn-uVrmHnsHH5zs5aJW6cHqMIMQ7Q/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 06 Dec 2018 23:30:28 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Thu, 06 Dec 2018 23:30:28 GMT
-      Date:
-      - Thu, 06 Dec 2018 23:30:28 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "kind": "drive#revision",
-         "id": "1",
-         "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2018-12-06T23:30:27.265Z"
-        }
-    http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:28 GMT
+  recorded_at: Sat, 16 Feb 2019 00:02:03 GMT
 - request:
     method: delete
-    uri: https://www.googleapis.com/drive/v3/files/1FGoyxTrkyRTu-P0bT3eGvDlDpGX099vT
+    uri: https://www.googleapis.com/drive/v3/files/12EwfeG-s6D8Za-Ku46k-53y4ZMZRFd_b
     body:
       encoding: UTF-8
       string: ''
@@ -2616,7 +2695,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 06 Dec 2018 23:30:28 GMT
+      - Sat, 16 Feb 2019 00:02:03 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR USER ACCOUNT>
       Content-Type:
@@ -2633,17 +2712,17 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 06 Dec 2018 23:30:28 GMT
+      - Sat, 16 Feb 2019 00:02:04 GMT
       Vary:
       - Origin
       - X-Origin
       Server:
       - GSE
       Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39,35"
+      - quic=":443"; ma=2592000; v="44,43,39"
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 06 Dec 2018 23:30:28 GMT
+  recorded_at: Sat, 16 Feb 2019 00:02:04 GMT
 recorded_with: VCR 4.0.0

--- a/spec/support/fixtures/vcr_cassettes/Contributions_Acceptances/User_can_accept_suggested_changes.yml
+++ b/spec/support/fixtures/vcr_cassettes/Contributions_Acceptances/User_can_accept_suggested_changes.yml
@@ -28,7 +28,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 31 Jan 2019 08:14:19 GMT
+      - Sat, 16 Feb 2019 14:28:20 GMT
       Server:
       - ESF
       Cache-Control:
@@ -53,7 +53,7 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:19 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:20 GMT
 - request:
     method: post
     uri: https://oauth2.googleapis.com/token
@@ -82,7 +82,7 @@ http_interactions:
       - Referer
       - X-Origin
       Date:
-      - Thu, 31 Jan 2019 08:14:19 GMT
+      - Sat, 16 Feb 2019 14:28:20 GMT
       Server:
       - ESF
       Cache-Control:
@@ -107,14 +107,14 @@ http_interactions:
           "token_type": "Bearer"
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:19 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:20 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2019-01-31
-        08:14:19 UTC","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Test @ 2019-02-16
+        14:28:20 UTC","parents":["root"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -123,7 +123,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:19 GMT
+      - Sat, 16 Feb 2019 14:28:20 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -140,7 +140,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:20 GMT
+      - Sat, 16 Feb 2019 14:28:21 GMT
       Vary:
       - Origin
       - X-Origin
@@ -164,8 +164,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1l0pRWchdouxaP6-fvnhX8xjtjYeNFsmP",
-         "name": "Test @ 2019-01-31 08:14:19 UTC",
+         "id": "1C0Tu4qvNOjnR7zggDWwDzPE9H-6qE0W-",
+         "name": "Test @ 2019-02-16 14:28:20 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
@@ -185,10 +185,64 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:20 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:21 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1l0pRWchdouxaP6-fvnhX8xjtjYeNFsmP/permissions?sendNotificationEmail=false
+    uri: https://oauth2.googleapis.com/token
+    body:
+      encoding: ASCII-8BIT
+      string: grant_type=refresh_token&refresh_token=<REFRESH TOKEN FOR CONTRIBUTOR
+        ACCOUNT>&client_id=<CLIENT ID>&client_secret=<CLIENT SECRET>
+    headers:
+      User-Agent:
+      - Faraday v0.15.3
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Sat, 16 Feb 2019 14:28:21 GMT
+      Server:
+      - ESF
+      Cache-Control:
+      - private
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "access_token": "<ACCESS TOKEN FOR CONTRIBUTOR ACCOUNT>",
+          "expires_in": 3600,
+          "scope": "https://www.googleapis.com/auth/drive",
+          "token_type": "Bearer"
+        }
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 14:28:21 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1C0Tu4qvNOjnR7zggDWwDzPE9H-6qE0W-/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR TRACKING ACCOUNT>","role":"writer","type":"user"}'
@@ -200,7 +254,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:20 GMT
+      - Sat, 16 Feb 2019 14:28:21 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -217,7 +271,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:21 GMT
+      - Sat, 16 Feb 2019 14:28:22 GMT
       Vary:
       - Origin
       - X-Origin
@@ -247,13 +301,13 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:21 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:22 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File 1","parents":["1l0pRWchdouxaP6-fvnhX8xjtjYeNFsmP"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File 1","parents":["1C0Tu4qvNOjnR7zggDWwDzPE9H-6qE0W-"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -262,7 +316,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:21 GMT
+      - Sat, 16 Feb 2019 14:28:22 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -279,7 +333,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:23 GMT
+      - Sat, 16 Feb 2019 14:28:25 GMT
       Vary:
       - Origin
       - X-Origin
@@ -303,12 +357,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1kpqOzQCX3NIVwRSb6TTdLdCgnf4U3Te1U4YJP8nx37s",
+         "id": "1Dy_98XfeKpZkdDtJg4o2URGm5d1nc3u5T40ddkJS4Kg",
          "name": "File 1",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1l0pRWchdouxaP6-fvnhX8xjtjYeNFsmP"
+          "1C0Tu4qvNOjnR7zggDWwDzPE9H-6qE0W-"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -333,13 +387,13 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:23 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:25 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.document","name":"File 2","parents":["1l0pRWchdouxaP6-fvnhX8xjtjYeNFsmP"]}'
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"File 2","parents":["1C0Tu4qvNOjnR7zggDWwDzPE9H-6qE0W-"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -348,7 +402,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:23 GMT
+      - Sat, 16 Feb 2019 14:28:25 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -365,7 +419,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:24 GMT
+      - Sat, 16 Feb 2019 14:28:26 GMT
       Vary:
       - Origin
       - X-Origin
@@ -389,12 +443,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1wNZfJJYR2DdEuC_jbhDGgzNQv5inOfs-h6F_6KBN2rI",
+         "id": "1Bko8cwAWUDzpSd3z58BgACIvschFXF0RkLqbplg7D7g",
          "name": "File 2",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1l0pRWchdouxaP6-fvnhX8xjtjYeNFsmP"
+          "1C0Tu4qvNOjnR7zggDWwDzPE9H-6qE0W-"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -419,7 +473,7 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:24 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:26 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
@@ -434,7 +488,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:25 GMT
+      - Sat, 16 Feb 2019 14:28:27 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -451,7 +505,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:26 GMT
+      - Sat, 16 Feb 2019 14:28:28 GMT
       Vary:
       - Origin
       - X-Origin
@@ -475,7 +529,7 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1zhSGWT_eHjq1BqOI8m7nLLiwLCIMFqum",
+         "id": "1vxHubTssy190XAZQARfHmWxnl7Peu4_M",
          "name": "1 RW6 (Archive)",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
@@ -496,10 +550,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:26 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:28 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1zhSGWT_eHjq1BqOI8m7nLLiwLCIMFqum/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1vxHubTssy190XAZQARfHmWxnl7Peu4_M/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR USER ACCOUNT>","role":"reader","type":"user"}'
@@ -511,7 +565,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:26 GMT
+      - Sat, 16 Feb 2019 14:28:28 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -528,7 +582,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:26 GMT
+      - Sat, 16 Feb 2019 14:28:30 GMT
       Vary:
       - Origin
       - X-Origin
@@ -558,10 +612,10 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:27 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:30 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1zhSGWT_eHjq1BqOI8m7nLLiwLCIMFqum/permissions
+    uri: https://www.googleapis.com/drive/v3/files/1vxHubTssy190XAZQARfHmWxnl7Peu4_M/permissions
     body:
       encoding: UTF-8
       string: '{"role":"reader","type":"anyone"}'
@@ -573,7 +627,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:27 GMT
+      - Sat, 16 Feb 2019 14:28:30 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -590,7 +644,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:28 GMT
+      - Sat, 16 Feb 2019 14:28:33 GMT
       Vary:
       - Origin
       - X-Origin
@@ -621,10 +675,10 @@ http_interactions:
          "allowFileDiscovery": false
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:28 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:33 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1l0pRWchdouxaP6-fvnhX8xjtjYeNFsmP?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1C0Tu4qvNOjnR7zggDWwDzPE9H-6qE0W-?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -636,7 +690,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:28 GMT
+      - Sat, 16 Feb 2019 14:28:33 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -647,9 +701,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 31 Jan 2019 08:14:28 GMT
+      - Sat, 16 Feb 2019 14:28:34 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:28 GMT
+      - Sat, 16 Feb 2019 14:28:34 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -675,8 +729,8 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1l0pRWchdouxaP6-fvnhX8xjtjYeNFsmP",
-         "name": "Test @ 2019-01-31 08:14:19 UTC",
+         "id": "1C0Tu4qvNOjnR7zggDWwDzPE9H-6qE0W-",
+         "name": "Test @ 2019-02-16 14:28:20 UTC",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "thumbnailVersion": "0",
@@ -702,10 +756,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:28 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:34 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1l0pRWchdouxaP6-fvnhX8xjtjYeNFsmP/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1C0Tu4qvNOjnR7zggDWwDzPE9H-6qE0W-/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -717,7 +771,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:28 GMT
+      - Sat, 16 Feb 2019 14:28:34 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -735,9 +789,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 31 Jan 2019 08:14:29 GMT
+      - Sat, 16 Feb 2019 14:28:34 GMT
       Expires:
-      - Thu, 31 Jan 2019 08:14:29 GMT
+      - Sat, 16 Feb 2019 14:28:34 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -769,10 +823,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:29 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:34 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271l0pRWchdouxaP6-fvnhX8xjtjYeNFsmP%27%20in%20parents
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271C0Tu4qvNOjnR7zggDWwDzPE9H-6qE0W-%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -784,7 +838,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:29 GMT
+      - Sat, 16 Feb 2019 14:28:34 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -795,9 +849,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 31 Jan 2019 08:14:29 GMT
+      - Sat, 16 Feb 2019 14:28:35 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:29 GMT
+      - Sat, 16 Feb 2019 14:28:35 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -825,14 +879,14 @@ http_interactions:
         {
          "files": [
           {
-           "id": "1wNZfJJYR2DdEuC_jbhDGgzNQv5inOfs-h6F_6KBN2rI",
+           "id": "1Bko8cwAWUDzpSd3z58BgACIvschFXF0RkLqbplg7D7g",
            "name": "File 2",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1l0pRWchdouxaP6-fvnhX8xjtjYeNFsmP"
+            "1C0Tu4qvNOjnR7zggDWwDzPE9H-6qE0W-"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1wNZfJJYR2DdEuC_jbhDGgzNQv5inOfs-h6F_6KBN2rI&v=1&s=AMedNnoAAAAAXFLKhTQb-lwgZbVdRWADOgVqRmOb7VLz&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Bko8cwAWUDzpSd3z58BgACIvschFXF0RkLqbplg7D7g&v=1&s=AMedNnoAAAAAXGg6MvBQdNe4YnFHlsarKgtrZt1_1ByJ&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -856,14 +910,14 @@ http_interactions:
            ]
           },
           {
-           "id": "1kpqOzQCX3NIVwRSb6TTdLdCgnf4U3Te1U4YJP8nx37s",
+           "id": "1Dy_98XfeKpZkdDtJg4o2URGm5d1nc3u5T40ddkJS4Kg",
            "name": "File 1",
            "mimeType": "application/vnd.google-apps.document",
            "trashed": false,
            "parents": [
-            "1l0pRWchdouxaP6-fvnhX8xjtjYeNFsmP"
+            "1C0Tu4qvNOjnR7zggDWwDzPE9H-6qE0W-"
            ],
-           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1kpqOzQCX3NIVwRSb6TTdLdCgnf4U3Te1U4YJP8nx37s&v=1&s=AMedNnoAAAAAXFLKhY0Bx_VidtIRWNVU_8InXnTiqa39&sz=s220",
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Dy_98XfeKpZkdDtJg4o2URGm5d1nc3u5T40ddkJS4Kg&v=1&s=AMedNnoAAAAAXGg6MurPHutURrtiAw1vOLRV7IbE_MdI&sz=s220",
            "thumbnailVersion": "1",
            "permissions": [
             {
@@ -889,10 +943,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:30 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:35 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1wNZfJJYR2DdEuC_jbhDGgzNQv5inOfs-h6F_6KBN2rI/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1Bko8cwAWUDzpSd3z58BgACIvschFXF0RkLqbplg7D7g/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -904,7 +958,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:30 GMT
+      - Sat, 16 Feb 2019 14:28:35 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -915,9 +969,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 31 Jan 2019 08:14:30 GMT
+      - Sat, 16 Feb 2019 14:28:35 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:30 GMT
+      - Sat, 16 Feb 2019 14:28:35 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -946,13 +1000,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2019-01-31T08:14:23.711Z"
+         "modifiedTime": "2019-02-16T14:28:25.637Z"
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:30 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:35 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1wNZfJJYR2DdEuC_jbhDGgzNQv5inOfs-h6F_6KBN2rI&s=AMedNnoAAAAAXFLKhTQb-lwgZbVdRWADOgVqRmOb7VLz&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1Bko8cwAWUDzpSd3z58BgACIvschFXF0RkLqbplg7D7g&s=AMedNnoAAAAAXGg6MvBQdNe4YnFHlsarKgtrZt1_1ByJ&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -964,7 +1018,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:30 GMT
+      - Sat, 16 Feb 2019 14:28:35 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -995,7 +1049,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 31 Jan 2019 08:14:30 GMT
+      - Sat, 16 Feb 2019 14:28:36 GMT
       Server:
       - fife
       Content-Length:
@@ -1009,13 +1063,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:31 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:36 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1wNZfJJYR2DdEuC_jbhDGgzNQv5inOfs-h6F_6KBN2rI/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1Bko8cwAWUDzpSd3z58BgACIvschFXF0RkLqbplg7D7g/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"File 2","parents":["1zhSGWT_eHjq1BqOI8m7nLLiwLCIMFqum"]}'
+      string: '{"name":"File 2","parents":["1vxHubTssy190XAZQARfHmWxnl7Peu4_M"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1024,7 +1078,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:31 GMT
+      - Sat, 16 Feb 2019 14:28:36 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1041,7 +1095,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:33 GMT
+      - Sat, 16 Feb 2019 14:28:41 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1065,12 +1119,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1ZrLHkqNFgJTmz_0HKVZKagcd4_awFMN1dfoJigGBLu0",
+         "id": "11LesS6cDLCqG4M2YJN7x-ha_Mpz4_auM1zLlYSl9rZ4",
          "name": "File 2",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1zhSGWT_eHjq1BqOI8m7nLLiwLCIMFqum"
+          "1vxHubTssy190XAZQARfHmWxnl7Peu4_M"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1102,10 +1156,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:33 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:41 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1ZrLHkqNFgJTmz_0HKVZKagcd4_awFMN1dfoJigGBLu0?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/11LesS6cDLCqG4M2YJN7x-ha_Mpz4_auM1zLlYSl9rZ4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1117,7 +1171,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:33 GMT
+      - Sat, 16 Feb 2019 14:28:41 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1128,9 +1182,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 31 Jan 2019 08:14:33 GMT
+      - Sat, 16 Feb 2019 14:28:42 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:33 GMT
+      - Sat, 16 Feb 2019 14:28:42 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1156,12 +1210,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1ZrLHkqNFgJTmz_0HKVZKagcd4_awFMN1dfoJigGBLu0",
+         "id": "11LesS6cDLCqG4M2YJN7x-ha_Mpz4_auM1zLlYSl9rZ4",
          "name": "File 2",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1zhSGWT_eHjq1BqOI8m7nLLiwLCIMFqum"
+          "1vxHubTssy190XAZQARfHmWxnl7Peu4_M"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1193,10 +1247,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:33 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:42 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1ZrLHkqNFgJTmz_0HKVZKagcd4_awFMN1dfoJigGBLu0/export?alt=media&mimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document
+    uri: https://www.googleapis.com/drive/v3/files/11LesS6cDLCqG4M2YJN7x-ha_Mpz4_auM1zLlYSl9rZ4/export?alt=media&mimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document
     body:
       encoding: UTF-8
       string: ''
@@ -1208,7 +1262,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:33 GMT
+      - Sat, 16 Feb 2019 14:28:42 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
   response:
@@ -1217,9 +1271,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 31 Jan 2019 08:14:34 GMT
+      - Sat, 16 Feb 2019 14:28:42 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:34 GMT
+      - Sat, 16 Feb 2019 14:28:42 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Disposition:
@@ -1244,16 +1298,16 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        UEsDBBQACAgIANEBP04AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICADRAT9OAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgA0QE/TgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgA0QE/TgAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgA0QE/TgAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgA0QE/TgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgA0QE/TgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgA0QE/TgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgA0QE/TgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIANEBP05JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICADRAT9Oj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICADRAT9OrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgA0QE/TojORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIANEBP04B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIANEBP06QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgA0QE/Ti1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgA0QE/TiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIANEBP04zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
+        UEsDBBQACAgIAJUzUE4AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICACVM1BOAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAlTNQTgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAlTNQTgAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgAlTNQTgAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgAlTNQTgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgAlTNQTgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgAlTNQTgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgAlTNQTgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIAJUzUE5JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICACVM1BOj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICACVM1BOrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAlTNQTojORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAJUzUE4B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIAJUzUE6QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgAlTNQTi1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgAlTNQTiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIAJUzUE4zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:34 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:42 GMT
 - request:
     method: put
     uri: http://localhost:9998/tika
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        UEsDBBQACAgIANEBP04AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICADRAT9OAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgA0QE/TgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgA0QE/TgAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgA0QE/TgAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgA0QE/TgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgA0QE/TgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgA0QE/TgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgA0QE/TgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIANEBP05JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICADRAT9Oj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICADRAT9OrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgA0QE/TojORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIANEBP04B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIANEBP06QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgA0QE/Ti1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgA0QE/TiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIANEBP04zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
+        UEsDBBQACAgIAJUzUE4AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICACVM1BOAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAlTNQTgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAlTNQTgAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgAlTNQTgAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgAlTNQTgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgAlTNQTgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgAlTNQTgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgAlTNQTgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIAJUzUE5JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICACVM1BOj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICACVM1BOrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAlTNQTojORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAJUzUE4B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIAJUzUE6QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgAlTNQTi1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgAlTNQTiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIAJUzUE4zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -1271,7 +1325,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 31 Jan 2019 08:14:34 GMT
+      - Sat, 16 Feb 2019 14:28:42 GMT
       Content-Type:
       - text/html
       Transfer-Encoding:
@@ -1294,10 +1348,10 @@ http_interactions:
         </body>
         </html>
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:34 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:42 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1kpqOzQCX3NIVwRSb6TTdLdCgnf4U3Te1U4YJP8nx37s/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1Dy_98XfeKpZkdDtJg4o2URGm5d1nc3u5T40ddkJS4Kg/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1309,7 +1363,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:34 GMT
+      - Sat, 16 Feb 2019 14:28:42 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1320,9 +1374,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 31 Jan 2019 08:14:34 GMT
+      - Sat, 16 Feb 2019 14:28:43 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:34 GMT
+      - Sat, 16 Feb 2019 14:28:43 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1351,13 +1405,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2019-01-31T08:14:22.122Z"
+         "modifiedTime": "2019-02-16T14:28:23.706Z"
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:34 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:43 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1kpqOzQCX3NIVwRSb6TTdLdCgnf4U3Te1U4YJP8nx37s&s=AMedNnoAAAAAXFLKhY0Bx_VidtIRWNVU_8InXnTiqa39&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1Dy_98XfeKpZkdDtJg4o2URGm5d1nc3u5T40ddkJS4Kg&s=AMedNnoAAAAAXGg6MurPHutURrtiAw1vOLRV7IbE_MdI&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -1369,7 +1423,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:34 GMT
+      - Sat, 16 Feb 2019 14:28:43 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1400,7 +1454,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 31 Jan 2019 08:14:34 GMT
+      - Sat, 16 Feb 2019 14:28:43 GMT
       Server:
       - fife
       Content-Length:
@@ -1414,13 +1468,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:35 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:43 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1kpqOzQCX3NIVwRSb6TTdLdCgnf4U3Te1U4YJP8nx37s/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1Dy_98XfeKpZkdDtJg4o2URGm5d1nc3u5T40ddkJS4Kg/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"File 1","parents":["1zhSGWT_eHjq1BqOI8m7nLLiwLCIMFqum"]}'
+      string: '{"name":"File 1","parents":["1vxHubTssy190XAZQARfHmWxnl7Peu4_M"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1429,7 +1483,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:35 GMT
+      - Sat, 16 Feb 2019 14:28:43 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1446,7 +1500,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:36 GMT
+      - Sat, 16 Feb 2019 14:28:47 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1470,12 +1524,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1TUksRipY4ap3Sk8kHHQKbViDOpnFpxDTB35Z00dJpUs",
+         "id": "11I6xv_acfBoOtVxxteEYHzerOEXA6AZdTUpm2iC-uxs",
          "name": "File 1",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1zhSGWT_eHjq1BqOI8m7nLLiwLCIMFqum"
+          "1vxHubTssy190XAZQARfHmWxnl7Peu4_M"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1507,10 +1561,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:37 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:47 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1TUksRipY4ap3Sk8kHHQKbViDOpnFpxDTB35Z00dJpUs?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/11I6xv_acfBoOtVxxteEYHzerOEXA6AZdTUpm2iC-uxs?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1522,7 +1576,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:37 GMT
+      - Sat, 16 Feb 2019 14:28:47 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1533,9 +1587,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 31 Jan 2019 08:14:37 GMT
+      - Sat, 16 Feb 2019 14:28:48 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:37 GMT
+      - Sat, 16 Feb 2019 14:28:48 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1561,12 +1615,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1TUksRipY4ap3Sk8kHHQKbViDOpnFpxDTB35Z00dJpUs",
+         "id": "11I6xv_acfBoOtVxxteEYHzerOEXA6AZdTUpm2iC-uxs",
          "name": "File 1",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1zhSGWT_eHjq1BqOI8m7nLLiwLCIMFqum"
+          "1vxHubTssy190XAZQARfHmWxnl7Peu4_M"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -1598,10 +1652,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:37 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:48 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1TUksRipY4ap3Sk8kHHQKbViDOpnFpxDTB35Z00dJpUs/export?alt=media&mimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document
+    uri: https://www.googleapis.com/drive/v3/files/11I6xv_acfBoOtVxxteEYHzerOEXA6AZdTUpm2iC-uxs/export?alt=media&mimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document
     body:
       encoding: UTF-8
       string: ''
@@ -1613,7 +1667,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:37 GMT
+      - Sat, 16 Feb 2019 14:28:48 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
   response:
@@ -1622,9 +1676,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 31 Jan 2019 08:14:37 GMT
+      - Sat, 16 Feb 2019 14:28:48 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:37 GMT
+      - Sat, 16 Feb 2019 14:28:48 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Disposition:
@@ -1649,16 +1703,16 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        UEsDBBQACAgIANIBP04AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICADSAT9OAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgA0gE/TgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgA0gE/TgAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgA0gE/TgAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgA0gE/TgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgA0gE/TgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgA0gE/TgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgA0gE/TgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIANIBP05JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICADSAT9Oj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICADSAT9OrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgA0gE/TojORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIANIBP04B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIANIBP06QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgA0gE/Ti1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgA0gE/TiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIANIBP04zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
+        UEsDBBQACAgIAJgzUE4AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICACYM1BOAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAmDNQTgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAmDNQTgAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgAmDNQTgAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgAmDNQTgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgAmDNQTgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgAmDNQTgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgAmDNQTgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIAJgzUE5JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICACYM1BOj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICACYM1BOrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAmDNQTojORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAJgzUE4B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIAJgzUE6QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgAmDNQTi1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgAmDNQTiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIAJgzUE4zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:37 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:48 GMT
 - request:
     method: put
     uri: http://localhost:9998/tika
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        UEsDBBQACAgIANIBP04AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICADSAT9OAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgA0gE/TgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgA0gE/TgAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgA0gE/TgAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgA0gE/TgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgA0gE/TgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgA0gE/TgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgA0gE/TgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIANIBP05JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICADSAT9Oj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICADSAT9OrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgA0gE/TojORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIANIBP04B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIANIBP06QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgA0gE/Ti1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgA0gE/TiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIANIBP04zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
+        UEsDBBQACAgIAJgzUE4AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICACYM1BOAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAmDNQTgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgAmDNQTgAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlu1u2jAUhq9g94Dyv01IAkNRaVW16jap6qa1u4CDY4hVx7ZsB8qufs43JKFKAxId/AAf+7zHfvw6ztXNW0xHaywV4WxujS8da4QZ4iFhq7n15+XhYmaNlAYWAuUMz60tVtbN9ZerTaD0lmI1MvlMBTGaW5HWIrBthSIcg7rkAjPTueQyBm2acmXHIF8TcYF4LECTBaFEb23XcaZWIcPnViJZUEhcxARJrvhSpykBXy4JwsVPmSH71M1T7jlKYsx0VtGWmJo5cKYiIlSpFg9VM51RKbJ+bxHrmJbjNqJPtVDCxmxGTPNCGy5DITnCSpnofd5ZKY6dHgBTiSqjzxT2a5YziYGwSia1RkOoqn1pahfQMql6ITULRftMJO96JAsJctueBQzguZsvSC8XNxRMlk5kZcghEigCqUsBOkSBcvSKwztga6jMHK562bmhFBJYSYhrk6oP7ezYadjlOQKBa7XVcWrfJE9EbXd/iNrOCRxPPibglgLX5gEYcnSPl5BQrdKm/CWLZtHKfh4402q0CUAhQubWrSRgym8CpHYaGJS+VQR2QtEtU9V4O5VSf014DeaguG4ZuVPNGAW2KmOYpTG7mIzdnKJotjJNAYhkEpSkh9r9OrWKxu+EmgAkmheyopDdFbJbXLJ7wkjorTDpAmTqLxGlqlnXj3BuPaV+zNYd5pnmKsoYM4hxuRyWD8prZ6lteQ0LivekX9JIL/1s5OipR5XuRXzHkF6bbeEo7xiN8y1agMLhT1b21gVNFn7TXfFic14xFk87QwrBNPxoNkg14vVewlJjc1OOXSed8QKb82+W4TvO+3tb2bj2nu+0vZfHdnw2BJt7EJv7ybB5077YFqWy0zzCXscRzmNHYvQOYvTOjXG2T9EdShFxymXlPS/9tp6Qs44n5OwEeP2DeP3Phded9cW7h3OafVo4/Q6c/glwTg7inHwynP4pcR68v4/EOT2Ic/q/4iQN4bPgfSHavFW03hey6Jm5Tve4fvw+n3TAmhwF6zlZ6E5eVceZkXnuIGYnfJWvTN11o3Wb2ut47/IOvHeV/9T1P1BLBwiIzkUMHQMAAN8RAABQSwMEFAAICAgAmDNQTgAAAAAAAAAAAAAAABEAAAB3b3JkL2RvY3VtZW50LnhtbKWVWW7bMBCGT9A7GHy3JRlOGwiW81CjRYG2MLIcgCYpiQg3DCmr7ulLavUSBIrrF2K2b36RY3L98EeK2YGB5VplKFnEaMYU0ZSrIkMvz9/m92hmHVYUC61Yho7MoofNp3WdUk0qyZSbeYKyqSQZKp0zaRRZUjKJ7UIbpnww1yCx8yYUkcTwWpk50dJgx/dccHeMlnH8GXUYnaEKVNoh5pIT0FbnLpSkOs85Yd3SV8CUvm3JtpPcdIyACa9BK1tyY3uavJXmg2UPObz3EQcp+rzaTOlGAdf+OKRoG9UaqAFNmLXeu22DAzGJJ2xgQAwVUySc9+yVSMzVgAnDcQEaei98727TGtT4IeNeWDFFSBv6yfeA4XitAt+wn6f1hk+a4guCr3IVDAN5C4KUGFwPELcQhCavjH7F6oCHYabFpHG+IFGOC8ByHFL7oZNN4otxeSqxYSOt+D/ad9CVGcd9dQvt5B+Y3H0MsOwBG38F7jU9htXM6tTfoPQxQ3H3Q51ry8S1c3ftetyyHFfCvRHZwZkzWaUGA/5BT7yNiB2EBXYQbdbRaL8n5A3B5+06YrM44VMOOGBQ26KJhLVtGLIsI67NN8XTX19Q+lfl7n7V8P1dkyyXq6Y8JPzCQd1eO6f9oCarNstpMxqC5W60gBfliVkyTJmX+2XZmLnWrje7Dr8r+Xw0zAf9IwahtJPe64z6U4zGF23zD1BLBwgB+JVoFgIAABYHAABQSwMEFAAICAgAmDNQTgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgAmDNQTgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgAmDNQTgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgAmDNQTgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIAJgzUE5JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICACYM1BOj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICACYM1BOrYdtAHkBAABaBQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAmDNQTojORQwdAwAA3xEAAA8AAAAAAAAAAAAAAAAApQUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAJgzUE4B+JVoFgIAABYHAAARAAAAAAAAAAAAAAAAAP8IAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIAJgzUE6QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAFQLAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgAmDNQTi1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAjwwAAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgAmDNQTiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAeQ0AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIAJgzUE4zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAOgTAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAFUVAAAAAA==
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -1676,7 +1730,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 31 Jan 2019 08:14:37 GMT
+      - Sat, 16 Feb 2019 14:28:48 GMT
       Content-Type:
       - text/html
       Transfer-Encoding:
@@ -1699,10 +1753,10 @@ http_interactions:
         </body>
         </html>
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:37 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:48 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1zhSGWT_eHjq1BqOI8m7nLLiwLCIMFqum/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1vxHubTssy190XAZQARfHmWxnl7Peu4_M/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR COLLABORATOR ACCOUNT>","role":"reader","type":"user"}'
@@ -1714,7 +1768,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:38 GMT
+      - Sat, 16 Feb 2019 14:28:49 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1731,7 +1785,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:38 GMT
+      - Sat, 16 Feb 2019 14:28:50 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1761,13 +1815,13 @@ http_interactions:
          "role": "reader"
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:39 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:50 GMT
 - request:
     method: post
     uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Branch #2","parents":["root"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Branch #2","parents":["1vxHubTssy190XAZQARfHmWxnl7Peu4_M"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1776,7 +1830,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:39 GMT
+      - Sat, 16 Feb 2019 14:28:50 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -1793,7 +1847,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:39 GMT
+      - Sat, 16 Feb 2019 14:28:53 GMT
       Vary:
       - Origin
       - X-Origin
@@ -1817,15 +1871,40 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1WLQl2Yz05HGRSfAavZI41iPTr44AvSp4",
+         "id": "1TeEkA3PGkOyepfoKPGeh0_5C9C4KoGQX",
          "name": "Branch #2",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
+          "1vxHubTssy190XAZQARfHmWxnl7Peu4_M"
          ],
          "thumbnailVersion": "0",
          "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "05663488528055015696",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR COLLABORATOR ACCOUNT>",
+           "role": "reader",
+           "displayName": "Collaborator Openly",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "anyoneWithLink",
+           "type": "anyone",
+           "role": "reader",
+           "allowFileDiscovery": false
+          },
           {
            "kind": "drive#permission",
            "id": "11673017242486491425",
@@ -1838,10 +1917,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:39 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:53 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1WLQl2Yz05HGRSfAavZI41iPTr44AvSp4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1TeEkA3PGkOyepfoKPGeh0_5C9C4KoGQX?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -1853,7 +1932,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:39 GMT
+      - Sat, 16 Feb 2019 14:28:53 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1864,9 +1943,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 31 Jan 2019 08:14:40 GMT
+      - Sat, 16 Feb 2019 14:28:54 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:40 GMT
+      - Sat, 16 Feb 2019 14:28:54 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -1892,15 +1971,40 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1WLQl2Yz05HGRSfAavZI41iPTr44AvSp4",
+         "id": "1TeEkA3PGkOyepfoKPGeh0_5C9C4KoGQX",
          "name": "Branch #2",
          "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
+          "1vxHubTssy190XAZQARfHmWxnl7Peu4_M"
          ],
          "thumbnailVersion": "0",
          "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "05663488528055015696",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR COLLABORATOR ACCOUNT>",
+           "role": "reader",
+           "displayName": "Collaborator Openly",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "anyoneWithLink",
+           "type": "anyone",
+           "role": "reader",
+           "allowFileDiscovery": false
+          },
           {
            "kind": "drive#permission",
            "id": "11673017242486491425",
@@ -1913,10 +2017,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:40 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:54 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1WLQl2Yz05HGRSfAavZI41iPTr44AvSp4/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1TeEkA3PGkOyepfoKPGeh0_5C9C4KoGQX/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -1928,7 +2032,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:40 GMT
+      - Sat, 16 Feb 2019 14:28:54 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -1946,9 +2050,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 31 Jan 2019 08:14:40 GMT
+      - Sat, 16 Feb 2019 14:28:54 GMT
       Expires:
-      - Thu, 31 Jan 2019 08:14:40 GMT
+      - Sat, 16 Feb 2019 14:28:54 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -1980,13 +2084,13 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:40 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:54 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1ZrLHkqNFgJTmz_0HKVZKagcd4_awFMN1dfoJigGBLu0/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/11LesS6cDLCqG4M2YJN7x-ha_Mpz4_auM1zLlYSl9rZ4/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"File 2","parents":["1WLQl2Yz05HGRSfAavZI41iPTr44AvSp4"]}'
+      string: '{"name":"File 2","parents":["1TeEkA3PGkOyepfoKPGeh0_5C9C4KoGQX"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -1995,7 +2099,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:40 GMT
+      - Sat, 16 Feb 2019 14:28:54 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -2012,7 +2116,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:42 GMT
+      - Sat, 16 Feb 2019 14:28:58 GMT
       Vary:
       - Origin
       - X-Origin
@@ -2036,15 +2140,40 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1MAz1iqr2Foe28hoCoddjPo3QQ_5sKi4GARaM3GPcvzk",
+         "id": "1HUQAMNCyreWTIAJDfbhoykZo1VIHZTGlnUgyrWTPP9g",
          "name": "File 2",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1WLQl2Yz05HGRSfAavZI41iPTr44AvSp4"
+          "1TeEkA3PGkOyepfoKPGeh0_5C9C4KoGQX"
          ],
          "thumbnailVersion": "0",
          "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "05663488528055015696",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR COLLABORATOR ACCOUNT>",
+           "role": "reader",
+           "displayName": "Collaborator Openly",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "anyoneWithLink",
+           "type": "anyone",
+           "role": "reader",
+           "allowFileDiscovery": false
+          },
           {
            "kind": "drive#permission",
            "id": "11673017242486491425",
@@ -2057,10 +2186,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:42 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:58 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1MAz1iqr2Foe28hoCoddjPo3QQ_5sKi4GARaM3GPcvzk/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1HUQAMNCyreWTIAJDfbhoykZo1VIHZTGlnUgyrWTPP9g/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -2072,7 +2201,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:42 GMT
+      - Sat, 16 Feb 2019 14:28:58 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2083,9 +2212,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 31 Jan 2019 08:14:42 GMT
+      - Sat, 16 Feb 2019 14:28:59 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:42 GMT
+      - Sat, 16 Feb 2019 14:28:59 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -2114,16 +2243,16 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2019-01-31T08:14:41.480Z"
+         "modifiedTime": "2019-02-16T14:28:57.659Z"
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:42 GMT
+  recorded_at: Sat, 16 Feb 2019 14:28:59 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1TUksRipY4ap3Sk8kHHQKbViDOpnFpxDTB35Z00dJpUs/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/11I6xv_acfBoOtVxxteEYHzerOEXA6AZdTUpm2iC-uxs/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"File 1","parents":["1WLQl2Yz05HGRSfAavZI41iPTr44AvSp4"]}'
+      string: '{"name":"File 1","parents":["1TeEkA3PGkOyepfoKPGeh0_5C9C4KoGQX"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -2132,7 +2261,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:42 GMT
+      - Sat, 16 Feb 2019 14:28:59 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -2149,7 +2278,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:45 GMT
+      - Sat, 16 Feb 2019 14:29:02 GMT
       Vary:
       - Origin
       - X-Origin
@@ -2173,15 +2302,40 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1Kn9WZb3pVj2daeA56Q8BC3LqPYtdtMkcgZX1CwCgEzw",
+         "id": "1zfzaHahRN6QzmMlMocuaEE8aAWivOp-2evjtxpG38Rk",
          "name": "File 1",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1WLQl2Yz05HGRSfAavZI41iPTr44AvSp4"
+          "1TeEkA3PGkOyepfoKPGeh0_5C9C4KoGQX"
          ],
          "thumbnailVersion": "0",
          "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "05663488528055015696",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR COLLABORATOR ACCOUNT>",
+           "role": "reader",
+           "displayName": "Collaborator Openly",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "anyoneWithLink",
+           "type": "anyone",
+           "role": "reader",
+           "allowFileDiscovery": false
+          },
           {
            "kind": "drive#permission",
            "id": "11673017242486491425",
@@ -2194,10 +2348,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:45 GMT
+  recorded_at: Sat, 16 Feb 2019 14:29:02 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Kn9WZb3pVj2daeA56Q8BC3LqPYtdtMkcgZX1CwCgEzw/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1zfzaHahRN6QzmMlMocuaEE8aAWivOp-2evjtxpG38Rk/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -2209,7 +2363,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:45 GMT
+      - Sat, 16 Feb 2019 14:29:02 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2220,9 +2374,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 31 Jan 2019 08:14:45 GMT
+      - Sat, 16 Feb 2019 14:29:02 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:45 GMT
+      - Sat, 16 Feb 2019 14:29:02 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -2251,13 +2405,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2019-01-31T08:14:44.085Z"
+         "modifiedTime": "2019-02-16T14:29:01.237Z"
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:45 GMT
+  recorded_at: Sat, 16 Feb 2019 14:29:02 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1WLQl2Yz05HGRSfAavZI41iPTr44AvSp4/permissions?sendNotificationEmail=false
+    uri: https://www.googleapis.com/drive/v3/files/1TeEkA3PGkOyepfoKPGeh0_5C9C4KoGQX/permissions?sendNotificationEmail=false
     body:
       encoding: UTF-8
       string: '{"emailAddress":"<EMAIL ADDRESS FOR CONTRIBUTOR ACCOUNT>","role":"writer","type":"user"}'
@@ -2269,7 +2423,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:45 GMT
+      - Sat, 16 Feb 2019 14:29:02 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -2286,7 +2440,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:46 GMT
+      - Sat, 16 Feb 2019 14:29:03 GMT
       Vary:
       - Origin
       - X-Origin
@@ -2316,96 +2470,10 @@ http_interactions:
          "role": "writer"
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:46 GMT
+  recorded_at: Sat, 16 Feb 2019 14:29:03 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1Kn9WZb3pVj2daeA56Q8BC3LqPYtdtMkcgZX1CwCgEzw?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: '{"name":"File 1 Updated"}'
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 31 Jan 2019 08:14:46 GMT
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Thu, 31 Jan 2019 08:14:47 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1Kn9WZb3pVj2daeA56Q8BC3LqPYtdtMkcgZX1CwCgEzw",
-         "name": "File 1 Updated",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1WLQl2Yz05HGRSfAavZI41iPTr44AvSp4"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13769612645787867933",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR CONTRIBUTOR ACCOUNT>",
-           "role": "writer",
-           "displayName": "Contributor Openly",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:47 GMT
-- request:
-    method: patch
-    uri: https://www.googleapis.com/upload/drive/v3/files/1MAz1iqr2Foe28hoCoddjPo3QQ_5sKi4GARaM3GPcvzk
+    uri: https://www.googleapis.com/upload/drive/v3/files/1Bko8cwAWUDzpSd3z58BgACIvschFXF0RkLqbplg7D7g
     body:
       encoding: UTF-8
       string: ''
@@ -2417,7 +2485,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:47 GMT
+      - Sat, 16 Feb 2019 14:29:03 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       X-Goog-Upload-Protocol:
@@ -2436,22 +2504,22 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2Uq4CTahs0BmcuXK-aq7qiVIDHDE0p87rQKxvcs9eUdtlzwAFfB2ekm8-MA0YNXtVloEBUE6rlec5BF17P80ngp8acSGaAybESLWfj7y6q5JSxeBbEk
+      - AEnB2Uq7IxlUZeGGgS4PaXQrMrinhmo1ks-8X2GH2l9Tp1jwBxLldogSZr25rQWi-jnO5q1I8HFSnJH6Hc-qbt1hIP7NTy8mfw
       X-Goog-Upload-Status:
       - active
       X-Goog-Upload-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1MAz1iqr2Foe28hoCoddjPo3QQ_5sKi4GARaM3GPcvzk?upload_id=AEnB2Uq4CTahs0BmcuXK-aq7qiVIDHDE0p87rQKxvcs9eUdtlzwAFfB2ekm8-MA0YNXtVloEBUE6rlec5BF17P80ngp8acSGaAybESLWfj7y6q5JSxeBbEk&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1Bko8cwAWUDzpSd3z58BgACIvschFXF0RkLqbplg7D7g?upload_id=AEnB2Uq7IxlUZeGGgS4PaXQrMrinhmo1ks-8X2GH2l9Tp1jwBxLldogSZr25rQWi-jnO5q1I8HFSnJH6Hc-qbt1hIP7NTy8mfw&upload_protocol=resumable
       X-Goog-Upload-Control-Url:
-      - https://www.googleapis.com/upload/drive/v3/files/1MAz1iqr2Foe28hoCoddjPo3QQ_5sKi4GARaM3GPcvzk?upload_id=AEnB2Uq4CTahs0BmcuXK-aq7qiVIDHDE0p87rQKxvcs9eUdtlzwAFfB2ekm8-MA0YNXtVloEBUE6rlec5BF17P80ngp8acSGaAybESLWfj7y6q5JSxeBbEk&upload_protocol=resumable
+      - https://www.googleapis.com/upload/drive/v3/files/1Bko8cwAWUDzpSd3z58BgACIvschFXF0RkLqbplg7D7g?upload_id=AEnB2Uq7IxlUZeGGgS4PaXQrMrinhmo1ks-8X2GH2l9Tp1jwBxLldogSZr25rQWi-jnO5q1I8HFSnJH6Hc-qbt1hIP7NTy8mfw&upload_protocol=resumable
       X-Goog-Upload-Chunk-Granularity:
       - '262144'
       X-Goog-Upload-Header-Vary:
       - Origin
       - X-Origin
       X-Goog-Upload-Header-X-Google-Backends:
-      - oiau189:4413
+      - ooms17:4332
       X-Goog-Upload-Header-X-Google-Session-Info:
-      - CLrLzJuGFRoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqYARKEAXlhMjkuR2wyaUJ0dVp1YU5XR192RGRUVGpqVDZmZlY0TTVmMmdESDFmZkhGdU96Z0hnQ0JNazlpY1NHRUdURDF5eTB4UVZiZ0RlTmF4cks5MTdSVnd0R0xFaUVOSXNzSGRMdzZEMmtXZ1ZNSllqcWZkZTYtY2toNEZsakl4WFVsS3FYazAEOg0xLzJNM1JHd3dWbFp-
+      - CLrLzJuGFRoCGAY6fgoeZHJpdmUtZ2Vub2Etc2VydmVyLWFwaWFyeS1wcm9kEgVkcml2ZRiDqMHn7wUiSDIwMTgxMjEwNDE5NS1pcDNwN2xrcWE1N29lYm84NTkwZXJtZ2E3MjBpMW5uaC5hcHBzLmdvb2dsZXVzZXJjb250ZW50LmNvbTDxDjDvDkqYARKEAXlhMjkuR2wyeUJ1WVBIeVRsbXJJNTRwSWpCdGwwaFpVRXgyX1d1WG5GNklzaWc2V3pYTkNocnQ2ajhFZktzZE5pSEJGVENiWmd5VGdyUUxHWVc0Z3pyY2I5aEMzSEZJbVkxZFJGb3NHeFNPNGs3Z1pBNWRxcjBTYy1YS2tlUFVDLVdCczAEOg0xLzJNM1JHd3dWbFp-
       X-Goog-Upload-Header-Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
       X-Goog-Upload-Header-Pragma:
@@ -2459,11 +2527,11 @@ http_interactions:
       X-Goog-Upload-Header-Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       X-Goog-Upload-Header-Date:
-      - Thu, 31 Jan 2019 08:14:48 GMT
+      - Sat, 16 Feb 2019 14:29:04 GMT
       Content-Length:
       - '0'
       Date:
-      - Thu, 31 Jan 2019 08:14:48 GMT
+      - Sat, 16 Feb 2019 14:29:04 GMT
       Server:
       - UploadServer
       Content-Type:
@@ -2474,10 +2542,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:48 GMT
+  recorded_at: Sat, 16 Feb 2019 14:29:04 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/upload/drive/v3/files/1MAz1iqr2Foe28hoCoddjPo3QQ_5sKi4GARaM3GPcvzk?upload_id=AEnB2Uq4CTahs0BmcuXK-aq7qiVIDHDE0p87rQKxvcs9eUdtlzwAFfB2ekm8-MA0YNXtVloEBUE6rlec5BF17P80ngp8acSGaAybESLWfj7y6q5JSxeBbEk&upload_protocol=resumable
+    uri: https://www.googleapis.com/upload/drive/v3/files/1Bko8cwAWUDzpSd3z58BgACIvschFXF0RkLqbplg7D7g?upload_id=AEnB2Uq7IxlUZeGGgS4PaXQrMrinhmo1ks-8X2GH2l9Tp1jwBxLldogSZr25rQWi-jnO5q1I8HFSnJH6Hc-qbt1hIP7NTy8mfw&upload_protocol=resumable
     body:
       encoding: UTF-8
       string: cool content
@@ -2489,7 +2557,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:48 GMT
+      - Sat, 16 Feb 2019 14:29:04 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       X-Goog-Upload-Command:
@@ -2504,7 +2572,7 @@ http_interactions:
       message: OK
     headers:
       X-Guploader-Uploadid:
-      - AEnB2Uq4CTahs0BmcuXK-aq7qiVIDHDE0p87rQKxvcs9eUdtlzwAFfB2ekm8-MA0YNXtVloEBUE6rlec5BF17P80ngp8acSGaAybESLWfj7y6q5JSxeBbEk
+      - AEnB2Uq7IxlUZeGGgS4PaXQrMrinhmo1ks-8X2GH2l9Tp1jwBxLldogSZr25rQWi-jnO5q1I8HFSnJH6Hc-qbt1hIP7NTy8mfw
       X-Goog-Upload-Status:
       - final
       Vary:
@@ -2519,7 +2587,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:49 GMT
+      - Sat, 16 Feb 2019 14:29:05 GMT
       Content-Length:
       - '153'
       Server:
@@ -2531,15 +2599,15 @@ http_interactions:
       string: |
         {
          "kind": "drive#file",
-         "id": "1MAz1iqr2Foe28hoCoddjPo3QQ_5sKi4GARaM3GPcvzk",
+         "id": "1Bko8cwAWUDzpSd3z58BgACIvschFXF0RkLqbplg7D7g",
          "name": "File 2",
          "mimeType": "application/vnd.google-apps.document"
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:49 GMT
+  recorded_at: Sat, 16 Feb 2019 14:29:05 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1WLQl2Yz05HGRSfAavZI41iPTr44AvSp4?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1Bko8cwAWUDzpSd3z58BgACIvschFXF0RkLqbplg7D7g/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -2551,7 +2619,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:49 GMT
+      - Sat, 16 Feb 2019 14:29:05 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2562,9 +2630,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 31 Jan 2019 08:14:49 GMT
+      - Sat, 16 Feb 2019 14:29:06 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:49 GMT
+      - Sat, 16 Feb 2019 14:29:06 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -2590,23 +2658,395 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1WLQl2Yz05HGRSfAavZI41iPTr44AvSp4",
-         "name": "Branch #2",
-         "mimeType": "application/vnd.google-apps.folder",
+         "kind": "drive#revision",
+         "id": "3",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2019-02-16T14:29:05.126Z"
+        }
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 14:29:06 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/drive/v3/files/1Dy_98XfeKpZkdDtJg4o2URGm5d1nc3u5T40ddkJS4Kg?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"File 1 (new)"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 14:29:07 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 16 Feb 2019 14:29:08 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1Dy_98XfeKpZkdDtJg4o2URGm5d1nc3u5T40ddkJS4Kg",
+         "name": "File 1 (new)",
+         "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "0AIeK5UAEPQfeUk9PVA"
+          "1C0Tu4qvNOjnR7zggDWwDzPE9H-6qE0W-"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Dy_98XfeKpZkdDtJg4o2URGm5d1nc3u5T40ddkJS4Kg&v=2&s=AMedNnoAAAAAXGg6VPIi46kwRrNVU0PDkhGgm9uxlI9r&sz=s220",
+         "thumbnailVersion": "2",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 14:29:08 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/drive/v3/files/1Bko8cwAWUDzpSd3z58BgACIvschFXF0RkLqbplg7D7g?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"File 2 (new)"}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 14:29:08 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 16 Feb 2019 14:29:08 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1Bko8cwAWUDzpSd3z58BgACIvschFXF0RkLqbplg7D7g",
+         "name": "File 2 (new)",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1C0Tu4qvNOjnR7zggDWwDzPE9H-6qE0W-"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Bko8cwAWUDzpSd3z58BgACIvschFXF0RkLqbplg7D7g&v=2&s=AMedNnoAAAAAXGg6VG4OVAIvB-_8WVvAtxfRcZT4JNpl&sz=s220",
+         "thumbnailVersion": "2",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 14:29:09 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1Dy_98XfeKpZkdDtJg4o2URGm5d1nc3u5T40ddkJS4Kg/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 14:29:09 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 16 Feb 2019 14:29:09 GMT
+      Date:
+      - Sat, 16 Feb 2019 14:29:09 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2019-02-16T14:28:23.706Z"
+        }
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 14:29:09 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1Dy_98XfeKpZkdDtJg4o2URGm5d1nc3u5T40ddkJS4Kg&s=AMedNnoAAAAAXGg6VPIi46kwRrNVU0PDkhGgm9uxlI9r&sz=s350&v=2
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 14:29:09 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v2"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 16 Feb 2019 14:29:09 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 14:29:09 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1Dy_98XfeKpZkdDtJg4o2URGm5d1nc3u5T40ddkJS4Kg/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"File 1 (new)","parents":["1vxHubTssy190XAZQARfHmWxnl7Peu4_M"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 14:29:10 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 16 Feb 2019 14:29:12 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1wkbsz4g4puyYfuZhU-KvTrDNNKFrNH8BKSskXIETuys",
+         "name": "File 1 (new)",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1vxHubTssy190XAZQARfHmWxnl7Peu4_M"
          ],
          "thumbnailVersion": "0",
          "permissions": [
           {
            "kind": "drive#permission",
-           "id": "13769612645787867933",
+           "id": "13193959451567607887",
            "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR CONTRIBUTOR ACCOUNT>",
-           "role": "writer",
-           "displayName": "Contributor Openly",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
            "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "05663488528055015696",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR COLLABORATOR ACCOUNT>",
+           "role": "reader",
+           "displayName": "Collaborator Openly",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "anyoneWithLink",
+           "type": "anyone",
+           "role": "reader",
+           "allowFileDiscovery": false
           },
           {
            "kind": "drive#permission",
@@ -2620,10 +3060,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:49 GMT
+  recorded_at: Sat, 16 Feb 2019 14:29:12 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1WLQl2Yz05HGRSfAavZI41iPTr44AvSp4/revisions/head
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1Bko8cwAWUDzpSd3z58BgACIvschFXF0RkLqbplg7D7g&s=AMedNnoAAAAAXGg6VG4OVAIvB-_8WVvAtxfRcZT4JNpl&sz=s350&v=2
     body:
       encoding: UTF-8
       string: ''
@@ -2635,7 +3075,873 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:49 GMT
+      - Sat, 16 Feb 2019 14:29:12 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v2"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 16 Feb 2019 14:29:13 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 14:29:13 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1Bko8cwAWUDzpSd3z58BgACIvschFXF0RkLqbplg7D7g/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"File 2 (new)","parents":["1vxHubTssy190XAZQARfHmWxnl7Peu4_M"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 14:29:13 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 16 Feb 2019 14:29:16 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1hcUwti9HzUBAe9jypWDk0vlo6eFFnVnAkVtOuKRuDtg",
+         "name": "File 2 (new)",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1vxHubTssy190XAZQARfHmWxnl7Peu4_M"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "05663488528055015696",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR COLLABORATOR ACCOUNT>",
+           "role": "reader",
+           "displayName": "Collaborator Openly",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "anyoneWithLink",
+           "type": "anyone",
+           "role": "reader",
+           "allowFileDiscovery": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 14:29:16 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1hcUwti9HzUBAe9jypWDk0vlo6eFFnVnAkVtOuKRuDtg?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 14:29:16 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 16 Feb 2019 14:29:16 GMT
+      Date:
+      - Sat, 16 Feb 2019 14:29:16 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1hcUwti9HzUBAe9jypWDk0vlo6eFFnVnAkVtOuKRuDtg",
+         "name": "File 2 (new)",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1vxHubTssy190XAZQARfHmWxnl7Peu4_M"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "05663488528055015696",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR COLLABORATOR ACCOUNT>",
+           "role": "reader",
+           "displayName": "Collaborator Openly",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "anyoneWithLink",
+           "type": "anyone",
+           "role": "reader",
+           "allowFileDiscovery": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 14:29:16 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1hcUwti9HzUBAe9jypWDk0vlo6eFFnVnAkVtOuKRuDtg/export?alt=media&mimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 14:29:16 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 16 Feb 2019 14:29:16 GMT
+      Date:
+      - Sat, 16 Feb 2019 14:29:16 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Content-Disposition:
+      - attachment
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/vnd.openxmlformats-officedocument.wordprocessingml.document
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '6328'
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        UEsDBBQACAgIAKgzUE4AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICACoM1BOAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAqDNQTgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QVIBQ1rRAINuyAAwyOk1i1PdbYaejtcWl+SpFQGlZRPHnfG49fvNp8ahXtBDmJJmOLecIiYTjm0pQZe397mt2xyHkwOSg0ImN74dhmfbVq0gKNd1GQG5dqnrHKe5vGseOV0ODmaIUJxQJJgw+vVMYaaFvbGUdtwcsPqaTfx8skuWUtBjNWk0lbxExLTuiw8AdJikUhuWgfnYLG+B4lj8hrLYz/doxJqNADGldJ6zqankoLxaqD7P7axE6r7rvGjnHLCZpwFlodjRqk3BJy4VxYfTwWe+IiGTHAA6JXjGnhp2fXiQZpeswhGWeg3nsevNuhfaOGjQyzcGpMI8fSi/wgoP3vLmDCPE/1Vo5K8RkhqHxNfSCnIHgF5DuAmkJQyLcifwCzgz7MeTkqzmekXEJJoIeQuotOdpGcxeW1AisGWvk/2jNhbYe4X0+hnfyBi5vLAMsOsG7vv6hJDegQ/nuSoFj8a/1ZhBlLOFTi9spcfwFQSwcIrj+x2IABAAB0BQAAUEsDBBQACAgIAKgzUE4AAAAAAAAAAAAAAAAPAAAAd29yZC9zdHlsZXMueG1s3VdtTuMwED3B3qHKf0iahlBVBIRAsCshdrWwB5g6bmPh2JbttHRPv853mqQotJWotn/SmfG8GT+/dNyrm/eYjlZYKsJZYI3PHWuEGeIhYcvA+vP6cDa1RkoDC4FyhgNrg5V1c/3taj1TekOxGpl8pmYxCqxIazGzbYUiHIM65wIzE1xwGYM2plzaMci3RJwhHgvQZE4o0RvbdRzfKmB4YCWSzQqIs5ggyRVf6DRlxhcLgnDxKDPkkLp5yj1HSYyZziraElPTA2cqIkKVaPG+aCYYlSCrjzaximm5bi2GVAslrM1hxDQvtOYyFJIjrJTx3ufBCnHsDCAwhagyhrSwXbPsJAbCKphUGi2gqva5qV2QlkHVG6m5UHRII3noicwlyE23C9iDz2a+IINU3EIwWTqRlSD3gUARSF0C0H0QKEdvOLwDtoJKzOFykJxbSCGBpYS4Fqn61MmOnZZcXiIQuEZbHob2KHkiarl7+6A13sDxxecA3BLg2vwAhhzd4wUkVKvUlL9kYRZW9njgTKvRegYKERJYt5KAKb+eIdUwMCh9qwg0XNEtU9V6O4VSf417BeZFcd3Sc6e2fXZR2G63I9pWli8AGU4NBCXpC+xe+lZh/E6ocUCieQErCtgmkN3hIJsJBkJvhEkXIFMtiShFzUI/wsB6TrWX7THMM83YyfhkEONyOyxflNfOUrvwGuYUb0G/pp5B+NnK0fOAKv2b+I4hHZFd4CgPjMb5Ec1B4fAnK6N1QZOF33WfvzicN4zFc2NJAZi6n8wBqZa/PktYaGym4th10o7n2LzrZhve1Pn4bCvJztvIle68aVd3ua+hu31odHfS6H41jdMtFif+4SxO/C6Lue9AFic7WZycFovuEbTo9mjRPYYWvZ0sel/NorfNoncEFr0eFr0jsHixk8WLE2PRPQKLQ+bxPiz6O1n0T4xF5wgsOj0sOoew+Eq0uSB0Rn/m/f+m82WPCi8PUuFLMte9FFaBkxorw4dz+1b+iM0fIQLlvbxh1jfzhrO4m5eerDfS6hVxymXp87PPIdep8pu6/gdQSwcIqwTYwhcDAACyEQAAUEsDBBQACAgIAKgzUE4AAAAAAAAAAAAAAAARAAAAd29yZC9kb2N1bWVudC54bWztVttO4zAQ/YL9hyrvkLYqF1UUxIJYrcQiBOwHTJ1J4sWxrbHTUr5+7cROS0AodF+3L47ncmY8t87ZxUslRiskw5VcJJPDcTJCyVTGZbFIfj/dHJwmI2NBZiCUxEWyQZNcnH87W88zxeoKpR05BGnmFVskpbV6nqaGlViBOVQapWPmiiqw7kpFWgE91/qAqUqD5UsuuN2k0/H4OAkwapHUJOcB4qDijJRRufUqc5XnnGE4ogYNsduqXAeXG4spoXA+KGlKrk1Eq/ZFc8wygqw+e8SqElFurYdYywjWLh2VaA2tFWWaFENjHPW6ZXaIk/GAAHqITmOIC29tRk8q4LKD8cXRA+psHzrbIWgN1PYh21gYMcSRlnXLlwS0ee8F7BHPXX3NB1VxD8Fp2Zq6gtwHgpVANgKIfRCEYs+YXYFcQVfMWTGonHtIGYeCoNoWqflSZifjXrk8lqBxi1b8G9oPUrXelvtsH7SdDpwcfQ1gGgHO3QhcqmzjTz1az90EzR4WyTj8kkC6RvGeeP+e9HCNOdTCfsC5pzfEyWyugeBntkNtnLgnfzwj6jt8sU57Bd52kkbyLZdoevQ1z9T6SklLSvRY+nvWIFrl32c0MPQ8//0aPhpxyUWrIDC3wySXylpVDZMlXpRDYdGuEeUQ4XT7PlNmjplz4bhQW9WJMoFALbLHc8XnOJBbpAC4RNdG0YzgfgROT47j5aEWGBAbDC69HR+koNG8LHznnIy9bSBC+P+w6IdXCbFoc0w3LmE+k2AY54vkkjgIj8LMzgXB2EvDYYdUXkrTybch6yWd9+6mAiGuQPfrxljiz9gjMiUUdbS2NFvp10idTiPlyvRpdZcjt2oEsQG5cduLvRS8kJG3BIM+ASHPTdDSrkHos878oIPf9t//LOyTBRcs+3a8pF0YmwUyNqwmNEgrTM6ZcgOJuQi7DctL21anzWTjFDLbIuji0b+sdPvr0emsSZzbaibT6SxOsuIX+Ii0Y8exZq2Um2zbS9uY8RZ6M15LhKxr+1ypZgacTDv8u7p62mifCbcsk1cMj4xepvHfIt1uzud/AVBLBwhHOF0MIAMAAH4LAABQSwMEFAAICAgAqDNQTgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgAqDNQTgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgAqDNQTgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgAqDNQTgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIAKgzUE5JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICACoM1BOj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICACoM1BOrj+x2IABAAB0BQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAqDNQTqsE2MIXAwAAshEAAA8AAAAAAAAAAAAAAAAArAUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAKgzUE5HOF0MIAMAAH4LAAARAAAAAAAAAAAAAAAAAAAJAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIAKgzUE6QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAF8MAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgAqDNQTi1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAmg0AAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgAqDNQTiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAhA4AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIAKgzUE4zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAPMUAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAGAWAAAAAA==
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 14:29:16 GMT
+- request:
+    method: put
+    uri: http://localhost:9998/tika
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        UEsDBBQACAgIAKgzUE4AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICACoM1BOAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgAqDNQTgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QVIBQ1rRAINuyAAwyOk1i1PdbYaejtcWl+SpFQGlZRPHnfG49fvNp8ahXtBDmJJmOLecIiYTjm0pQZe397mt2xyHkwOSg0ImN74dhmfbVq0gKNd1GQG5dqnrHKe5vGseOV0ODmaIUJxQJJgw+vVMYaaFvbGUdtwcsPqaTfx8skuWUtBjNWk0lbxExLTuiw8AdJikUhuWgfnYLG+B4lj8hrLYz/doxJqNADGldJ6zqankoLxaqD7P7axE6r7rvGjnHLCZpwFlodjRqk3BJy4VxYfTwWe+IiGTHAA6JXjGnhp2fXiQZpeswhGWeg3nsevNuhfaOGjQyzcGpMI8fSi/wgoP3vLmDCPE/1Vo5K8RkhqHxNfSCnIHgF5DuAmkJQyLcifwCzgz7MeTkqzmekXEJJoIeQuotOdpGcxeW1AisGWvk/2jNhbYe4X0+hnfyBi5vLAMsOsG7vv6hJDegQ/nuSoFj8a/1ZhBlLOFTi9spcfwFQSwcIrj+x2IABAAB0BQAAUEsDBBQACAgIAKgzUE4AAAAAAAAAAAAAAAAPAAAAd29yZC9zdHlsZXMueG1s3VdtTuMwED3B3qHKf0iahlBVBIRAsCshdrWwB5g6bmPh2JbttHRPv853mqQotJWotn/SmfG8GT+/dNyrm/eYjlZYKsJZYI3PHWuEGeIhYcvA+vP6cDa1RkoDC4FyhgNrg5V1c/3taj1TekOxGpl8pmYxCqxIazGzbYUiHIM65wIzE1xwGYM2plzaMci3RJwhHgvQZE4o0RvbdRzfKmB4YCWSzQqIs5ggyRVf6DRlxhcLgnDxKDPkkLp5yj1HSYyZziraElPTA2cqIkKVaPG+aCYYlSCrjzaximm5bi2GVAslrM1hxDQvtOYyFJIjrJTx3ufBCnHsDCAwhagyhrSwXbPsJAbCKphUGi2gqva5qV2QlkHVG6m5UHRII3noicwlyE23C9iDz2a+IINU3EIwWTqRlSD3gUARSF0C0H0QKEdvOLwDtoJKzOFykJxbSCGBpYS4Fqn61MmOnZZcXiIQuEZbHob2KHkiarl7+6A13sDxxecA3BLg2vwAhhzd4wUkVKvUlL9kYRZW9njgTKvRegYKERJYt5KAKb+eIdUwMCh9qwg0XNEtU9V6O4VSf417BeZFcd3Sc6e2fXZR2G63I9pWli8AGU4NBCXpC+xe+lZh/E6ocUCieQErCtgmkN3hIJsJBkJvhEkXIFMtiShFzUI/wsB6TrWX7THMM83YyfhkEONyOyxflNfOUrvwGuYUb0G/pp5B+NnK0fOAKv2b+I4hHZFd4CgPjMb5Ec1B4fAnK6N1QZOF33WfvzicN4zFc2NJAZi6n8wBqZa/PktYaGym4th10o7n2LzrZhve1Pn4bCvJztvIle68aVd3ua+hu31odHfS6H41jdMtFif+4SxO/C6Lue9AFic7WZycFovuEbTo9mjRPYYWvZ0sel/NorfNoncEFr0eFr0jsHixk8WLE2PRPQKLQ+bxPiz6O1n0T4xF5wgsOj0sOoew+Eq0uSB0Rn/m/f+m82WPCi8PUuFLMte9FFaBkxorw4dz+1b+iM0fIQLlvbxh1jfzhrO4m5eerDfS6hVxymXp87PPIdep8pu6/gdQSwcIqwTYwhcDAACyEQAAUEsDBBQACAgIAKgzUE4AAAAAAAAAAAAAAAARAAAAd29yZC9kb2N1bWVudC54bWztVttO4zAQ/YL9hyrvkLYqF1UUxIJYrcQiBOwHTJ1J4sWxrbHTUr5+7cROS0AodF+3L47ncmY8t87ZxUslRiskw5VcJJPDcTJCyVTGZbFIfj/dHJwmI2NBZiCUxEWyQZNcnH87W88zxeoKpR05BGnmFVskpbV6nqaGlViBOVQapWPmiiqw7kpFWgE91/qAqUqD5UsuuN2k0/H4OAkwapHUJOcB4qDijJRRufUqc5XnnGE4ogYNsduqXAeXG4spoXA+KGlKrk1Eq/ZFc8wygqw+e8SqElFurYdYywjWLh2VaA2tFWWaFENjHPW6ZXaIk/GAAHqITmOIC29tRk8q4LKD8cXRA+psHzrbIWgN1PYh21gYMcSRlnXLlwS0ee8F7BHPXX3NB1VxD8Fp2Zq6gtwHgpVANgKIfRCEYs+YXYFcQVfMWTGonHtIGYeCoNoWqflSZifjXrk8lqBxi1b8G9oPUrXelvtsH7SdDpwcfQ1gGgHO3QhcqmzjTz1az90EzR4WyTj8kkC6RvGeeP+e9HCNOdTCfsC5pzfEyWyugeBntkNtnLgnfzwj6jt8sU57Bd52kkbyLZdoevQ1z9T6SklLSvRY+nvWIFrl32c0MPQ8//0aPhpxyUWrIDC3wySXylpVDZMlXpRDYdGuEeUQ4XT7PlNmjplz4bhQW9WJMoFALbLHc8XnOJBbpAC4RNdG0YzgfgROT47j5aEWGBAbDC69HR+koNG8LHznnIy9bSBC+P+w6IdXCbFoc0w3LmE+k2AY54vkkjgIj8LMzgXB2EvDYYdUXkrTybch6yWd9+6mAiGuQPfrxljiz9gjMiUUdbS2NFvp10idTiPlyvRpdZcjt2oEsQG5cduLvRS8kJG3BIM+ASHPTdDSrkHos878oIPf9t//LOyTBRcs+3a8pF0YmwUyNqwmNEgrTM6ZcgOJuQi7DctL21anzWTjFDLbIuji0b+sdPvr0emsSZzbaibT6SxOsuIX+Ii0Y8exZq2Um2zbS9uY8RZ6M15LhKxr+1ypZgacTDv8u7p62mifCbcsk1cMj4xepvHfIt1uzud/AVBLBwhHOF0MIAMAAH4LAABQSwMEFAAICAgAqDNQTgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgAqDNQTgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgAqDNQTgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgAqDNQTgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIAKgzUE5JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICACoM1BOj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICACoM1BOrj+x2IABAAB0BQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgAqDNQTqsE2MIXAwAAshEAAA8AAAAAAAAAAAAAAAAArAUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIAKgzUE5HOF0MIAMAAH4LAAARAAAAAAAAAAAAAAAAAAAJAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIAKgzUE6QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAF8MAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgAqDNQTi1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAmg0AAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgAqDNQTiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAhA4AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIAKgzUE4zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAPMUAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAGAWAAAAAA==
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - text/html
+      User-Agent:
+      - Ruby
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/octet-stream
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 16 Feb 2019 14:29:16 GMT
+      Content-Type:
+      - text/html
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - Jetty(9.4.z-SNAPSHOT)
+    body:
+      encoding: UTF-8
+      string: |
+        <html xmlns="http://www.w3.org/1999/xhtml">
+        <head>
+        <meta name="X-Parsed-By" content="org.apache.tika.parser.DefaultParser"/>
+        <meta name="X-Parsed-By" content="org.apache.tika.parser.microsoft.ooxml.OOXMLParser"/>
+        <meta name="Content-Type" content="application/vnd.openxmlformats-officedocument.wordprocessingml.document"/>
+        <title>
+        </title>
+        </head>
+        <body>
+        <p>cool content</p>
+        </body>
+        </html>
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 14:29:16 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1TeEkA3PGkOyepfoKPGeh0_5C9C4KoGQX"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 14:29:16 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR CONTRIBUTOR ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 16 Feb 2019 14:29:17 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1PNg1ekMnPbv6piVrkkJZGHTji0gJ_zr7",
+         "name": "Folder",
+         "mimeType": "application/vnd.google-apps.folder",
+         "trashed": false,
+         "parents": [
+          "1TeEkA3PGkOyepfoKPGeh0_5C9C4KoGQX"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "05663488528055015696",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR COLLABORATOR ACCOUNT>",
+           "role": "reader",
+           "displayName": "Collaborator Openly",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "anyoneWithLink",
+           "type": "anyone",
+           "role": "reader",
+           "allowFileDiscovery": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13769612645787867933",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR CONTRIBUTOR ACCOUNT>",
+           "role": "owner",
+           "displayName": "Contributor Openly",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 14:29:17 GMT
+- request:
+    method: patch
+    uri: https://www.googleapis.com/drive/v3/files/1zfzaHahRN6QzmMlMocuaEE8aAWivOp-2evjtxpG38Rk?addParents=1PNg1ekMnPbv6piVrkkJZGHTji0gJ_zr7&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1TeEkA3PGkOyepfoKPGeh0_5C9C4KoGQX
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 14:29:17 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 16 Feb 2019 14:29:18 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1zfzaHahRN6QzmMlMocuaEE8aAWivOp-2evjtxpG38Rk",
+         "name": "File 1",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1PNg1ekMnPbv6piVrkkJZGHTji0gJ_zr7"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1zfzaHahRN6QzmMlMocuaEE8aAWivOp-2evjtxpG38Rk&v=1&s=AMedNnoAAAAAXGg6XmezXOZjP2Q-U19Jo5h67BYAWnSg&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13769612645787867933",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR CONTRIBUTOR ACCOUNT>",
+           "role": "writer",
+           "displayName": "Contributor Openly",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "05663488528055015696",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR COLLABORATOR ACCOUNT>",
+           "role": "reader",
+           "displayName": "Collaborator Openly",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "anyoneWithLink",
+           "type": "anyone",
+           "role": "reader",
+           "allowFileDiscovery": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 14:29:18 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"mimeType":"application/vnd.google-apps.document","name":"Subfile","parents":["1PNg1ekMnPbv6piVrkkJZGHTji0gJ_zr7"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 14:29:18 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR CONTRIBUTOR ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 16 Feb 2019 14:29:20 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1rmxLZo09qYHtZ7vEKCtBaeVTxvQwk0gOKF8UfMs5m5Y",
+         "name": "Subfile",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1PNg1ekMnPbv6piVrkkJZGHTji0gJ_zr7"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "05663488528055015696",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR COLLABORATOR ACCOUNT>",
+           "role": "reader",
+           "displayName": "Collaborator Openly",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "anyoneWithLink",
+           "type": "anyone",
+           "role": "reader",
+           "allowFileDiscovery": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13769612645787867933",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR CONTRIBUTOR ACCOUNT>",
+           "role": "owner",
+           "displayName": "Contributor Openly",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 14:29:20 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271TeEkA3PGkOyepfoKPGeh0_5C9C4KoGQX%27%20in%20parents
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 14:29:20 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 16 Feb 2019 14:29:20 GMT
+      Date:
+      - Sat, 16 Feb 2019 14:29:20 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "files": [
+          {
+           "id": "1PNg1ekMnPbv6piVrkkJZGHTji0gJ_zr7",
+           "name": "Folder",
+           "mimeType": "application/vnd.google-apps.folder",
+           "trashed": false,
+           "parents": [
+            "1TeEkA3PGkOyepfoKPGeh0_5C9C4KoGQX"
+           ],
+           "thumbnailVersion": "0",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "writer",
+             "displayName": "Upshift One",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "13193959451567607887",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+             "role": "reader",
+             "displayName": "Testuser Upshift One",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "05663488528055015696",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR COLLABORATOR ACCOUNT>",
+             "role": "reader",
+             "displayName": "Collaborator Openly",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "anyoneWithLink",
+             "type": "anyone",
+             "role": "reader",
+             "allowFileDiscovery": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "13769612645787867933",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR CONTRIBUTOR ACCOUNT>",
+             "role": "owner",
+             "displayName": "Contributor Openly",
+             "deleted": false
+            }
+           ]
+          },
+          {
+           "id": "1HUQAMNCyreWTIAJDfbhoykZo1VIHZTGlnUgyrWTPP9g",
+           "name": "File 2",
+           "mimeType": "application/vnd.google-apps.document",
+           "trashed": false,
+           "parents": [
+            "1TeEkA3PGkOyepfoKPGeh0_5C9C4KoGQX"
+           ],
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1HUQAMNCyreWTIAJDfbhoykZo1VIHZTGlnUgyrWTPP9g&v=1&s=AMedNnoAAAAAXGg6YHvOqN_C6WNUUL3fMYy2EX72GX4Y&sz=s220",
+           "thumbnailVersion": "1",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "13769612645787867933",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR CONTRIBUTOR ACCOUNT>",
+             "role": "writer",
+             "displayName": "Contributor Openly",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "13193959451567607887",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+             "role": "reader",
+             "displayName": "Testuser Upshift One",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "05663488528055015696",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR COLLABORATOR ACCOUNT>",
+             "role": "reader",
+             "displayName": "Collaborator Openly",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "anyoneWithLink",
+             "type": "anyone",
+             "role": "reader",
+             "allowFileDiscovery": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "owner",
+             "displayName": "Upshift One",
+             "deleted": false
+            }
+           ]
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 14:29:20 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1PNg1ekMnPbv6piVrkkJZGHTji0gJ_zr7/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 14:29:20 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2653,9 +3959,9 @@ http_interactions:
       Content-Encoding:
       - gzip
       Date:
-      - Thu, 31 Jan 2019 08:14:50 GMT
+      - Sat, 16 Feb 2019 14:29:20 GMT
       Expires:
-      - Thu, 31 Jan 2019 08:14:50 GMT
+      - Sat, 16 Feb 2019 14:29:20 GMT
       Cache-Control:
       - private, max-age=0
       X-Content-Type-Options:
@@ -2687,10 +3993,10 @@ http_interactions:
          }
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:50 GMT
+  recorded_at: Sat, 16 Feb 2019 14:29:20 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1MAz1iqr2Foe28hoCoddjPo3QQ_5sKi4GARaM3GPcvzk?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1zfzaHahRN6QzmMlMocuaEE8aAWivOp-2evjtxpG38Rk?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -2702,7 +4008,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:50 GMT
+      - Sat, 16 Feb 2019 14:29:20 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2713,9 +4019,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 31 Jan 2019 08:14:50 GMT
+      - Sat, 16 Feb 2019 14:29:21 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:50 GMT
+      - Sat, 16 Feb 2019 14:29:21 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -2741,14 +4047,14 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1MAz1iqr2Foe28hoCoddjPo3QQ_5sKi4GARaM3GPcvzk",
-         "name": "File 2",
+         "id": "1zfzaHahRN6QzmMlMocuaEE8aAWivOp-2evjtxpG38Rk",
+         "name": "File 1",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1WLQl2Yz05HGRSfAavZI41iPTr44AvSp4"
+          "1PNg1ekMnPbv6piVrkkJZGHTji0gJ_zr7"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1MAz1iqr2Foe28hoCoddjPo3QQ_5sKi4GARaM3GPcvzk&v=1&s=AMedNnoAAAAAXFLKmtizKFR38mYKH4gr3lqLRvDocb37&sz=s220",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1zfzaHahRN6QzmMlMocuaEE8aAWivOp-2evjtxpG38Rk&v=1&s=AMedNnoAAAAAXGg6YTlef8Nv6_GkHx-bbnGQDR0s2x4M&sz=s220",
          "thumbnailVersion": "1",
          "permissions": [
           {
@@ -2762,6 +4068,31 @@ http_interactions:
           },
           {
            "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "05663488528055015696",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR COLLABORATOR ACCOUNT>",
+           "role": "reader",
+           "displayName": "Collaborator Openly",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "anyoneWithLink",
+           "type": "anyone",
+           "role": "reader",
+           "allowFileDiscovery": false
+          },
+          {
+           "kind": "drive#permission",
            "id": "11673017242486491425",
            "type": "user",
            "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
@@ -2772,10 +4103,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:50 GMT
+  recorded_at: Sat, 16 Feb 2019 14:29:21 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1MAz1iqr2Foe28hoCoddjPo3QQ_5sKi4GARaM3GPcvzk/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1zfzaHahRN6QzmMlMocuaEE8aAWivOp-2evjtxpG38Rk/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -2787,7 +4118,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:50 GMT
+      - Sat, 16 Feb 2019 14:29:21 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2798,9 +4129,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 31 Jan 2019 08:14:51 GMT
+      - Sat, 16 Feb 2019 14:29:21 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:51 GMT
+      - Sat, 16 Feb 2019 14:29:21 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -2827,15 +4158,15 @@ http_interactions:
       string: |
         {
          "kind": "drive#revision",
-         "id": "2",
+         "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2019-01-31T08:14:48.990Z"
+         "modifiedTime": "2019-02-16T14:29:01.237Z"
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:51 GMT
+  recorded_at: Sat, 16 Feb 2019 14:29:21 GMT
 - request:
     method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1MAz1iqr2Foe28hoCoddjPo3QQ_5sKi4GARaM3GPcvzk&s=AMedNnoAAAAAXFLKmtizKFR38mYKH4gr3lqLRvDocb37&sz=s350&v=1
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1zfzaHahRN6QzmMlMocuaEE8aAWivOp-2evjtxpG38Rk&s=AMedNnoAAAAAXGg6YTlef8Nv6_GkHx-bbnGQDR0s2x4M&sz=s350&v=1
     body:
       encoding: UTF-8
       string: ''
@@ -2847,7 +4178,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:51 GMT
+      - Sat, 16 Feb 2019 14:29:21 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -2878,7 +4209,7 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Date:
-      - Thu, 31 Jan 2019 08:14:51 GMT
+      - Sat, 16 Feb 2019 14:29:22 GMT
       Server:
       - fife
       Content-Length:
@@ -2892,13 +4223,13 @@ http_interactions:
       string: !binary |-
         iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:51 GMT
+  recorded_at: Sat, 16 Feb 2019 14:29:22 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1MAz1iqr2Foe28hoCoddjPo3QQ_5sKi4GARaM3GPcvzk/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1zfzaHahRN6QzmMlMocuaEE8aAWivOp-2evjtxpG38Rk/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"File 2","parents":["1zhSGWT_eHjq1BqOI8m7nLLiwLCIMFqum"]}'
+      string: '{"name":"File 1","parents":["1vxHubTssy190XAZQARfHmWxnl7Peu4_M"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -2907,7 +4238,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:51 GMT
+      - Sat, 16 Feb 2019 14:29:22 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -2924,7 +4255,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:53 GMT
+      - Sat, 16 Feb 2019 14:29:24 GMT
       Vary:
       - Origin
       - X-Origin
@@ -2948,12 +4279,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1zeZ7aaBhK5Ro-69t-F5Yn57XAs0DlA40jrChvuli83U",
-         "name": "File 2",
+         "id": "1LH1tc1sWqPoGSmCfuvs3wQ8kdXR_z73tV_iHfBojELE",
+         "name": "File 1",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1zhSGWT_eHjq1BqOI8m7nLLiwLCIMFqum"
+          "1vxHubTssy190XAZQARfHmWxnl7Peu4_M"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -2994,10 +4325,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:53 GMT
+  recorded_at: Sat, 16 Feb 2019 14:29:25 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1zeZ7aaBhK5Ro-69t-F5Yn57XAs0DlA40jrChvuli83U?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=files/id,files/name,files/mimeType,files/parents,files/permissions,files/trashed,files/thumbnailLink,files/thumbnailVersion&q=%271PNg1ekMnPbv6piVrkkJZGHTji0gJ_zr7%27%20in%20parents
     body:
       encoding: UTF-8
       string: ''
@@ -3009,7 +4340,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:53 GMT
+      - Sat, 16 Feb 2019 14:29:25 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -3020,9 +4351,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 31 Jan 2019 08:14:53 GMT
+      - Sat, 16 Feb 2019 14:29:25 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:53 GMT
+      - Sat, 16 Feb 2019 14:29:25 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -3048,12 +4379,304 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1zeZ7aaBhK5Ro-69t-F5Yn57XAs0DlA40jrChvuli83U",
-         "name": "File 2",
+         "files": [
+          {
+           "id": "1rmxLZo09qYHtZ7vEKCtBaeVTxvQwk0gOKF8UfMs5m5Y",
+           "name": "Subfile",
+           "mimeType": "application/vnd.google-apps.document",
+           "trashed": false,
+           "parents": [
+            "1PNg1ekMnPbv6piVrkkJZGHTji0gJ_zr7"
+           ],
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1rmxLZo09qYHtZ7vEKCtBaeVTxvQwk0gOKF8UfMs5m5Y&v=1&s=AMedNnoAAAAAXGg6ZXMwrQ61C9ZyUhDdf8Z166rThAbw&sz=s220",
+           "thumbnailVersion": "1",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "writer",
+             "displayName": "Upshift One",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "13193959451567607887",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+             "role": "reader",
+             "displayName": "Testuser Upshift One",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "05663488528055015696",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR COLLABORATOR ACCOUNT>",
+             "role": "reader",
+             "displayName": "Collaborator Openly",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "anyoneWithLink",
+             "type": "anyone",
+             "role": "reader",
+             "allowFileDiscovery": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "13769612645787867933",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR CONTRIBUTOR ACCOUNT>",
+             "role": "owner",
+             "displayName": "Contributor Openly",
+             "deleted": false
+            }
+           ]
+          },
+          {
+           "id": "1zfzaHahRN6QzmMlMocuaEE8aAWivOp-2evjtxpG38Rk",
+           "name": "File 1",
+           "mimeType": "application/vnd.google-apps.document",
+           "trashed": false,
+           "parents": [
+            "1PNg1ekMnPbv6piVrkkJZGHTji0gJ_zr7"
+           ],
+           "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1zfzaHahRN6QzmMlMocuaEE8aAWivOp-2evjtxpG38Rk&v=1&s=AMedNnoAAAAAXGg6ZcZUOIgeOS9bTQPzxoi0lDIReS4n&sz=s220",
+           "thumbnailVersion": "1",
+           "permissions": [
+            {
+             "kind": "drive#permission",
+             "id": "13769612645787867933",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR CONTRIBUTOR ACCOUNT>",
+             "role": "writer",
+             "displayName": "Contributor Openly",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "13193959451567607887",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+             "role": "reader",
+             "displayName": "Testuser Upshift One",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "05663488528055015696",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR COLLABORATOR ACCOUNT>",
+             "role": "reader",
+             "displayName": "Collaborator Openly",
+             "deleted": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "anyoneWithLink",
+             "type": "anyone",
+             "role": "reader",
+             "allowFileDiscovery": false
+            },
+            {
+             "kind": "drive#permission",
+             "id": "11673017242486491425",
+             "type": "user",
+             "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+             "role": "owner",
+             "displayName": "Upshift One",
+             "deleted": false
+            }
+           ]
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 14:29:25 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1rmxLZo09qYHtZ7vEKCtBaeVTxvQwk0gOKF8UfMs5m5Y/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 14:29:25 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 16 Feb 2019 14:29:26 GMT
+      Date:
+      - Sat, 16 Feb 2019 14:29:26 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "kind": "drive#revision",
+         "id": "1",
+         "mimeType": "application/vnd.google-apps.document",
+         "modifiedTime": "2019-02-16T14:29:19.080Z"
+        }
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 14:29:26 GMT
+- request:
+    method: get
+    uri: https://docs.google.com/feeds/vt?gd=true&id=1rmxLZo09qYHtZ7vEKCtBaeVTxvQwk0gOKF8UfMs5m5Y&s=AMedNnoAAAAAXGg6ZXMwrQ61C9ZyUhDdf8Z166rThAbw&sz=s350&v=1
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 14:29:26 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Expose-Headers:
+      - Content-Length
+      Etag:
+      - '"v1"'
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - private, max-age=86400, no-transform
+      Content-Disposition:
+      - inline;filename="unnamed.png"
+      Content-Type:
+      - image/png
+      Vary:
+      - Origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Timing-Allow-Origin:
+      - "*"
+      X-Content-Type-Options:
+      - nosniff
+      Date:
+      - Sat, 16 Feb 2019 14:29:26 GMT
+      Server:
+      - fife
+      Content-Length:
+      - '1022'
+      X-Xss-Protection:
+      - 1; mode=block
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        iVBORw0KGgoAAAANSUhEUgAAAPgAAAFeCAIAAAAngUUbAAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3SwQ3AIBDAsNL9dz62AInYE+SRNTMfvO6/HQAnGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMToLRSTA6CUYnwegkGJ0Eo5NgdBKMTsIGQUUFuSIDKQAAAAAASUVORK5CYII=
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 14:29:26 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1rmxLZo09qYHtZ7vEKCtBaeVTxvQwk0gOKF8UfMs5m5Y/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"Subfile","parents":["1vxHubTssy190XAZQARfHmWxnl7Peu4_M"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 14:29:26 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 16 Feb 2019 14:29:28 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1zqIX21pWVNxSXdBdUTNTE2tB7yFa6yeATS3U-6ckHvQ",
+         "name": "Subfile",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1zhSGWT_eHjq1BqOI8m7nLLiwLCIMFqum"
+          "1vxHubTssy190XAZQARfHmWxnl7Peu4_M"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -3094,10 +4717,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:53 GMT
+  recorded_at: Sat, 16 Feb 2019 14:29:28 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1zeZ7aaBhK5Ro-69t-F5Yn57XAs0DlA40jrChvuli83U/export?alt=media&mimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document
+    uri: https://www.googleapis.com/drive/v3/files/1zqIX21pWVNxSXdBdUTNTE2tB7yFa6yeATS3U-6ckHvQ?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -3109,7 +4732,107 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:53 GMT
+      - Sat, 16 Feb 2019 14:29:28 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 16 Feb 2019 14:29:29 GMT
+      Date:
+      - Sat, 16 Feb 2019 14:29:29 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1zqIX21pWVNxSXdBdUTNTE2tB7yFa6yeATS3U-6ckHvQ",
+         "name": "Subfile",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1vxHubTssy190XAZQARfHmWxnl7Peu4_M"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "reader",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "05663488528055015696",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR COLLABORATOR ACCOUNT>",
+           "role": "reader",
+           "displayName": "Collaborator Openly",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "anyoneWithLink",
+           "type": "anyone",
+           "role": "reader",
+           "allowFileDiscovery": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 14:29:29 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1zqIX21pWVNxSXdBdUTNTE2tB7yFa6yeATS3U-6ckHvQ/export?alt=media&mimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 14:29:29 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
   response:
@@ -3118,9 +4841,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 31 Jan 2019 08:14:54 GMT
+      - Sat, 16 Feb 2019 14:29:29 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:54 GMT
+      - Sat, 16 Feb 2019 14:29:29 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Disposition:
@@ -3137,7 +4860,7 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       Content-Length:
-      - '6328'
+      - '6071'
       Server:
       - GSE
       Alt-Svc:
@@ -3145,16 +4868,16 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        UEsDBBQACAgIANsBP04AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICADbAT9OAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgA2wE/TgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QVIBQ1rRAINuyAAwyOk1i1PdbYaejtcWl+SpFQGlZRPHnfG49fvNp8ahXtBDmJJmOLecIiYTjm0pQZe397mt2xyHkwOSg0ImN74dhmfbVq0gKNd1GQG5dqnrHKe5vGseOV0ODmaIUJxQJJgw+vVMYaaFvbGUdtwcsPqaTfx8skuWUtBjNWk0lbxExLTuiw8AdJikUhuWgfnYLG+B4lj8hrLYz/doxJqNADGldJ6zqankoLxaqD7P7axE6r7rvGjnHLCZpwFlodjRqk3BJy4VxYfTwWe+IiGTHAA6JXjGnhp2fXiQZpeswhGWeg3nsevNuhfaOGjQyzcGpMI8fSi/wgoP3vLmDCPE/1Vo5K8RkhqHxNfSCnIHgF5DuAmkJQyLcifwCzgz7MeTkqzmekXEJJoIeQuotOdpGcxeW1AisGWvk/2jNhbYe4X0+hnfyBi5vLAMsOsG7vv6hJDegQ/nuSoFj8a/1ZhBlLOFTi9spcfwFQSwcIrj+x2IABAAB0BQAAUEsDBBQACAgIANsBP04AAAAAAAAAAAAAAAAPAAAAd29yZC9zdHlsZXMueG1s3VdtTuMwED3B3qHKf0iahlBVBIRAsCshdrWwB5g6bmPh2JbttHRPv853mqQotJWotn/SmfG8GT+/dNyrm/eYjlZYKsJZYI3PHWuEGeIhYcvA+vP6cDa1RkoDC4FyhgNrg5V1c/3taj1TekOxGpl8pmYxCqxIazGzbYUiHIM65wIzE1xwGYM2plzaMci3RJwhHgvQZE4o0RvbdRzfKmB4YCWSzQqIs5ggyRVf6DRlxhcLgnDxKDPkkLp5yj1HSYyZziraElPTA2cqIkKVaPG+aCYYlSCrjzaximm5bi2GVAslrM1hxDQvtOYyFJIjrJTx3ufBCnHsDCAwhagyhrSwXbPsJAbCKphUGi2gqva5qV2QlkHVG6m5UHRII3noicwlyE23C9iDz2a+IINU3EIwWTqRlSD3gUARSF0C0H0QKEdvOLwDtoJKzOFykJxbSCGBpYS4Fqn61MmOnZZcXiIQuEZbHob2KHkiarl7+6A13sDxxecA3BLg2vwAhhzd4wUkVKvUlL9kYRZW9njgTKvRegYKERJYt5KAKb+eIdUwMCh9qwg0XNEtU9V6O4VSf417BeZFcd3Sc6e2fXZR2G63I9pWli8AGU4NBCXpC+xe+lZh/E6ocUCieQErCtgmkN3hIJsJBkJvhEkXIFMtiShFzUI/wsB6TrWX7THMM83YyfhkEONyOyxflNfOUrvwGuYUb0G/pp5B+NnK0fOAKv2b+I4hHZFd4CgPjMb5Ec1B4fAnK6N1QZOF33WfvzicN4zFc2NJAZi6n8wBqZa/PktYaGym4th10o7n2LzrZhve1Pn4bCvJztvIle68aVd3ua+hu31odHfS6H41jdMtFif+4SxO/C6Lue9AFic7WZycFovuEbTo9mjRPYYWvZ0sel/NorfNoncEFr0eFr0jsHixk8WLE2PRPQKLQ+bxPiz6O1n0T4xF5wgsOj0sOoew+Eq0uSB0Rn/m/f+m82WPCi8PUuFLMte9FFaBkxorw4dz+1b+iM0fIQLlvbxh1jfzhrO4m5eerDfS6hVxymXp87PPIdep8pu6/gdQSwcIqwTYwhcDAACyEQAAUEsDBBQACAgIANsBP04AAAAAAAAAAAAAAAARAAAAd29yZC9kb2N1bWVudC54bWztVttO4zAQ/YL9hyrvkLYqF1UUxIJYrcQiBOwHTJ1J4sWxrbHTUr5+7cROS0AodF+3L47ncmY8t87ZxUslRiskw5VcJJPDcTJCyVTGZbFIfj/dHJwmI2NBZiCUxEWyQZNcnH87W88zxeoKpR05BGnmFVskpbV6nqaGlViBOVQapWPmiiqw7kpFWgE91/qAqUqD5UsuuN2k0/H4OAkwapHUJOcB4qDijJRRufUqc5XnnGE4ogYNsduqXAeXG4spoXA+KGlKrk1Eq/ZFc8wygqw+e8SqElFurYdYywjWLh2VaA2tFWWaFENjHPW6ZXaIk/GAAHqITmOIC29tRk8q4LKD8cXRA+psHzrbIWgN1PYh21gYMcSRlnXLlwS0ee8F7BHPXX3NB1VxD8Fp2Zq6gtwHgpVANgKIfRCEYs+YXYFcQVfMWTGonHtIGYeCoNoWqflSZifjXrk8lqBxi1b8G9oPUrXelvtsH7SdDpwcfQ1gGgHO3QhcqmzjTz1az90EzR4WyTj8kkC6RvGeeP+e9HCNOdTCfsC5pzfEyWyugeBntkNtnLgnfzwj6jt8sU57Bd52kkbyLZdoevQ1z9T6SklLSvRY+nvWIFrl32c0MPQ8//0aPhpxyUWrIDC3wySXylpVDZMlXpRDYdGuEeUQ4XT7PlNmjplz4bhQW9WJMoFALbLHc8XnOJBbpAC4RNdG0YzgfgROT47j5aEWGBAbDC69HR+koNG8LHznnIy9bSBC+P+w6IdXCbFoc0w3LmE+k2AY54vkkjgIj8LMzgXB2EvDYYdUXkrTybch6yWd9+6mAiGuQPfrxljiz9gjMiUUdbS2NFvp10idTiPlyvRpdZcjt2oEsQG5cduLvRS8kJG3BIM+ASHPTdDSrkHos878oIPf9t//LOyTBRcs+3a8pF0YmwUyNqwmNEgrTM6ZcgOJuQi7DctL21anzWTjFDLbIuji0b+sdPvr0emsSZzbaibT6SxOsuIX+Ii0Y8exZq2Um2zbS9uY8RZ6M15LhKxr+1ypZgacTDv8u7p62mifCbcsk1cMj4xepvHfIt1uzud/AVBLBwhHOF0MIAMAAH4LAABQSwMEFAAICAgA2wE/TgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgA2wE/TgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgA2wE/TgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgA2wE/TgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIANsBP05JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICADbAT9Oj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICADbAT9Orj+x2IABAAB0BQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgA2wE/TqsE2MIXAwAAshEAAA8AAAAAAAAAAAAAAAAArAUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIANsBP05HOF0MIAMAAH4LAAARAAAAAAAAAAAAAAAAAAAJAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIANsBP06QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAF8MAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgA2wE/Ti1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAmg0AAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgA2wE/TiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAhA4AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIANsBP04zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAPMUAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAGAWAAAAAA==
+        UEsDBBQACAgIAK4zUE4AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICACuM1BOAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgArjNQTgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgArjNQTgAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlt1u2jAUx59g74By3yYkgSFUWnWt2k2qumrtrqeDY4hVx7ZsB8qefs43JKFKAxIdXICPff7n+Ofjj4urt4gOVlgqwtnMGp471gAzxAPCljPr98vd2cQaKA0sAMoZnlkbrKyryy8X66nSG4rVwPgzNY3QzAq1FlPbVijEEahzLjAznQsuI9CmKZd2BPI1FmeIRwI0mRNK9MZ2HWds5TJ8ZsWSTXOJs4ggyRVf6MRlyhcLgnD+U3jILnEzl1uO4ggznUa0JaYmB85USIQq1KK+aqYzLERW701iFdFi3Fp0iRZIWJvFiGgWaM1lICRHWCljvc06S8Wh0wFgIlF6dElhN2aRSQSElTJJadSEytjnJnYOLZWqJlKxULRLIlnXA5lLkJtmFtCD57a/IJ2quKZgvHQsy4LsI4FCkLoQoH0UKEevOLgBtoKymINlp3KuKQUElhKiqkjVh1Z26NTK5TkEgSu15WFq95LHoip3v4/a1g4cjj4m4BYCl+YADDi6xQuIqVZJUz7JvJm30p87zrQarKegECEz61oSMOHXU6S2GhiUvlYEtkzhNVPleDuRUn+NeQVmo7huYblRdRsFtixsmP25/5aY7Twfu56lqLdSWQGIpCqUJPva/Tq28savmBoDxJrnsiKX3RayG2jSq8JI6I0w7gJkUmIiTFTTrh/BzHpMSjKdepB5mtsoxcwgwsWMWDYoi526NuU1zCnekX5JLJ3005GDxw5R2ifxHUNyczaFw6xjMMxWaQ4KBz9Z0VsFNF74TbfZ88V5xVg8bg3JBRPzg1kgVbNXawkLjc1lOXSdJOM5NkeAmYbvOO+vbVnJVfn5TrP8MttWnfXB5u7F5n4ybN64K7Z5oezUd7HXsosz24EYvb0YvVNjnOxSdPtSRJxyWdael3wbh+Sk5ZCcHAGvvxev/7nwupOueHdwjtNPA6ffgtM/As7RXpyjT4bTPybOvVf4gTjHe3GO/1ecpCZ8ErwvRJtXReO9kFpPzHW8w/Xj9/moBdboIFjP8Vy38io7TozMc3sxO+Jrvizqthutvai9lneXt+fdVfxTl/8AUEsHCCmXCZwiAwAA4hEAAFBLAwQUAAgICACuM1BOAAAAAAAAAAAAAAAAEQAAAHdvcmQvZG9jdW1lbnQueG1spZXbbtswDIafYO8Q6D6xnWZda8TpRYMNA7YhaLsHUCTZFqoTKDlZ9vSTfMyhKNwsNwRJ8eNviZGWD3+kmOwYWK5VhpJZjCZMEU25KjL0++Xr9A5NrMOKYqEVy9CBWfSw+rTcp1STSjLlJp6gbCpJhkrnTBpFlpRMYjvThimfzDVI7LwLRSQxvFZmSrQ02PEtF9wdonkc36IWozNUgUpbxFRyAtrq3IWSVOc5J6w1XQWM6duUrFvJdccImPAatLIlN7ajyWtpPll2kN17H7GTolu3N2O6UcB7fxxSNI32GqgBTZi1Prpukj0xiUdsYED0FWMknPbslEjMVY8Jw3EG6nvPfO9202rU8CHDXlgxRkiT+sG3gOFwqQJfsZ/H9YaPmuIzgq9yFfQDeQ2ClBhcBxDXEIQmr4w+YrXD/TDTYtQ4n5EoxwVgOQyp/dDJJvHZuDyX2LCBVvwf7RvoygzjvriGdvQPTD5/DDDvACt/BW41PQRrJvvU36D0KUNx+0NtaM3EZXBzGXpasxxXwr2R2cBJMFmkBgP+To+itYgNBAMbiFbLaPDfE/KG4NN2LbE2TvglOxwwqGlRZ4JtGoZVlhHXrDfF819fUPpX5fbuZhH4/q5Jkvv4PpSHBT9xULfVzmk/qMliUatw2gyOYLkbPOBFeeSWDFPm5X6Z126utevctsOvSr4cDPNJ/4hBKG2ldzqj7hSj4UVb/QNQSwcIy/3mbRsCAAAWBwAAUEsDBBQACAgIAK4zUE4AAAAAAAAAAAAAAAAcAAAAd29yZC9fcmVscy9kb2N1bWVudC54bWwucmVsc62STWrDMBCFT9A7iNnXstMfSomcTQhkW9wDKPL4h1ojIU1KffuKlCQOBNOFl++JefPNjNabHzuIbwyxd6SgyHIQSMbVPbUKPqvd4xuIyJpqPThCBSNG2JQP6w8cNKea2PU+ihRCUUHH7N+ljKZDq2PmPFJ6aVywmpMMrfTafOkW5SrPX2WYZkB5kyn2tYKwrwsQ1ejxP9muaXqDW2eOFonvtJCcajEF6tAiKzjJP7PIUhjI+wyrJRkiMqflxivG2ZlDeFoSoXHElT4Mk1VcrDmI5yUh6GgPGNLcV4iLNQfxsugxeBxweoqTPreXN5+8/AVQSwcIkACr6/EAAAAsAwAAUEsDBBQACAgIAK4zUE4AAAAAAAAAAAAAAAALAAAAX3JlbHMvLnJlbHONzzsOwjAMBuATcIfIO03LgBBq0gUhdUXlAFHiphHNQ0l49PZkYADEwGj792e57R52JjeMyXjHoKlqIOikV8ZpBufhuN4BSVk4JWbvkMGCCTq+ak84i1x20mRCIgVxicGUc9hTmuSEVqTKB3RlMvpoRS5l1DQIeREa6aautzS+G8A/TNIrBrFXDZBhCfiP7cfRSDx4ebXo8o8TX4kii6gxM7j7qKh6tavCAuUt/XiRPwFQSwcILWjPIrEAAAAqAQAAUEsDBBQACAgIAK4zUE4AAAAAAAAAAAAAAAAVAAAAd29yZC90aGVtZS90aGVtZTEueG1s7VlLb9s2HL8P2HcgdG9l2VbqBHWK2LHbrU0bJG6HHmmJlthQokDSSXwb2uOAAcO6YYcV2G2HYVuBFtil+zTZOmwd0K+wvx6WKZvOo023Dq0PNkn9/u8HSfnylcOIoX0iJOVx23Iu1ixEYo/7NA7a1u1B/0LLQlLh2MeMx6RtTYi0rqx/+MFlvKZCEhEE9LFcw20rVCpZs23pwTKWF3lCYng24iLCCqYisH2BD4BvxOx6rbZiR5jGFopxBGxvjUbUI2iQsrTWp8x7DL5iJdMFj4ldL5OoU2RYf89Jf+REdplA+5i1LZDj84MBOVQWYlgqeNC2atnHstcv2yURU0toNbp+9inoCgJ/r57RiWBYEjr95uqlzZJ/Pee/iOv1et2eU/LLANjzwFJnAdvst5zOlKcGyoeLvLs1t9as4jX+jQX8aqfTcVcr+MYM31zAt2orzY16Bd+c4d1F/Tsb3e5KBe/O8CsL+P6l1ZVmFZ+BQkbjvQV0Gs8yMiVkxNk1I7wF8NY0AWYoW8uunD5Wy3Itwve46AMgCy5WNEZqkpAR9gDXxYwOBU0F4DWCtSf5kicXllJZSHqCJqptfZxgqIgZ5OWzH18+e4KO7j89uv/L0YMHR/d/NlBdw3GgU734/ou/H32K/nry3YuHX5nxUsf//tNnv/36pRmodODzrx//8fTx828+//OHhwb4hsBDHT6gEZHoJjlAOzwCwwwCyFCcjWIQYqpTbMSBxDFOaQzongor6JsTzLAB1yFVD94R0AJMwKvjexWFd0MxVtQAvB5GFeAW56zDhdGm66ks3QvjODALF2Mdt4Pxvkl2dy6+vXECuUxNLLshqai5zSDkOCAxUSh9xvcIMZDdpbTi1y3qCS75SKG7FHUwNbpkQIfKTHSNRhCXiUlBiHfFN1t3UIczE/tNsl9FQlVgZmJJWMWNV/FY4cioMY6YjryBVWhScncivIrDpYJIB4Rx1POJlCaaW2JSUfc6tA5z2LfYJKoihaJ7JuQNzLmO3OR73RBHiVFnGoc69iO5BymK0TZXRiV4tULSOcQBx0vDfYcSdbbavk2D0Jwg6ZOxMJUE4dV6nLARJnHR4Su9OqLxcY07gr6Nz7txQ6t8/u2j/1HL3gAnmGpmvlEvw8235y4XPn37u/MmHsfbBArifXN+35zfxea8rJ7PvyXPurCtH7QzNtHSU/eIMrarJozckFn/lmCe34fFbJIRlYf8JIRhIa6CCwTOxkhw9QlV4W6IExDjZBICWbAOJEq4hKuFtZR3dj+lYHO25k4vlYDGaov7+XJDv2yWbLJZIHVBjZTBaYU1Lr2eMCcHnlKa45qlucdKszVvQt0gnL5KcFbquWhIFMyIn/o9ZzANyxsMkVPTYhRinxiWNfucxhvxpnsmJc7HybUFJ9uL1cTi6gwdtK1Vt+5ayMNJ2xrBaQmGUQL8ZNppMAvituWp3MCTa3HO4lVzVjk1d5nBFRGJkGoTyzCnyh5NX6XEM/3rbjP1w/kYYGgmp9Oi0XL+Qy3s+dCS0Yh4asnKbFo842NFxG7oH6AhG4sdDHo38+zyqYROX59OBOR2s0i8auEWtTH/yqaoGcySEBfZ3tJin8OzcalDNtPUs5fo/oqmNM7RFPfdNSXNXDifNvzs0gS7uMAozdG2xYUKOXShJKReX8C+n8kCvRCURaoSYukL6FRXsj/rWzmPvMkFodqhARIUOp0KBSHbqrDzBGZOXd8ep4yKPlOqK5P8d0j2CRuk1buS2m+hcNpNCkdkuPmg2abqGgb9t/jg0nyljWcmqHmWza+pNX1tK1h9PRVOswFr4upmi+vu0p1nfqtN4JaB0i9o3FR4bHY8HfAdiD4q93kEiXihVZRfuTgEnVuacSmrf+sU1FoS7/M8O2rObixx9vHiXt3ZrsHX7vGuthdL1NbuIdls4Y8oPrwHsjfhejNm+YpMYJYPtkVm8JD7k2LIZN4SckdMWzqLd8gIUf9wGtY5jxb/9JSb+U4uILW9JGycTFjgZ5tISVw/mbikmN7xSuLsFmdiwGaSc3we5bJFlp5i8eu47BTKm11mzN7TuuwUgXoFl6nD411WeMo2JR45VAJ3p39dQf7as5Rd/wdQSwcIIVqihCwGAADbHQAAUEsDBBQACAgIAK4zUE4AAAAAAAAAAAAAAAATAAAAW0NvbnRlbnRfVHlwZXNdLnhtbLWTTW7CMBCFT9A7RN5WxNBFVVUEFv1Ztl3QAwzOBKz6T56Bwu07CZAFAqmVmo1l+82893kkT+c774otZrIxVGpSjlWBwcTahlWlPhevowdVEEOowcWAldojqfnsZrrYJ6RCmgNVas2cHrUms0YPVMaEQZQmZg8sx7zSCcwXrFDfjcf32sTAGHjErYeaTZ+xgY3j4ulw31pXClJy1gALlxYzVbzsRDxgtmf9i75tqM9gRkeQMqPramhtE92eB4hKbcK7TCbbGv8UEZvGGqyj2XhpKb9jrlOOBolkqN6VhMyyO6Z+QOY38GKr20p9UsvjI4dB4L3DawCdNmh8I14LWDq8TNDLg0KEjV9ilv1liF4eFKJXPNhwGaQv+UcOlo96ZfiddFgnp0jd/fbZD1BLBwgzrw+3LAEAAC0EAABQSwECFAAUAAgICACuM1BOSRNDf2gBAAA9BQAAEgAAAAAAAAAAAAAAAAAAAAAAd29yZC9udW1iZXJpbmcueG1sUEsBAhQAFAAICAgArjNQTo/2kL8FAgAA6gYAABEAAAAAAAAAAAAAAAAAqAEAAHdvcmQvc2V0dGluZ3MueG1sUEsBAhQAFAAICAgArjNQTq2HbQB5AQAAWgUAABIAAAAAAAAAAAAAAAAA7AMAAHdvcmQvZm9udFRhYmxlLnhtbFBLAQIUABQACAgIAK4zUE4plwmcIgMAAOIRAAAPAAAAAAAAAAAAAAAAAKUFAAB3b3JkL3N0eWxlcy54bWxQSwECFAAUAAgICACuM1BOy/3mbRsCAAAWBwAAEQAAAAAAAAAAAAAAAAAECQAAd29yZC9kb2N1bWVudC54bWxQSwECFAAUAAgICACuM1BOkACr6/EAAAAsAwAAHAAAAAAAAAAAAAAAAABeCwAAd29yZC9fcmVscy9kb2N1bWVudC54bWwucmVsc1BLAQIUABQACAgIAK4zUE4taM8isQAAACoBAAALAAAAAAAAAAAAAAAAAJkMAABfcmVscy8ucmVsc1BLAQIUABQACAgIAK4zUE4hWqKELAYAANsdAAAVAAAAAAAAAAAAAAAAAIMNAAB3b3JkL3RoZW1lL3RoZW1lMS54bWxQSwECFAAUAAgICACuM1BOM68PtywBAAAtBAAAEwAAAAAAAAAAAAAAAADyEwAAW0NvbnRlbnRfVHlwZXNdLnhtbFBLBQYAAAAACQAJAEICAABfFQAAAAA=
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:54 GMT
+  recorded_at: Sat, 16 Feb 2019 14:29:29 GMT
 - request:
     method: put
     uri: http://localhost:9998/tika
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        UEsDBBQACAgIANsBP04AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICADbAT9OAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgA2wE/TgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QVIBQ1rRAINuyAAwyOk1i1PdbYaejtcWl+SpFQGlZRPHnfG49fvNp8ahXtBDmJJmOLecIiYTjm0pQZe397mt2xyHkwOSg0ImN74dhmfbVq0gKNd1GQG5dqnrHKe5vGseOV0ODmaIUJxQJJgw+vVMYaaFvbGUdtwcsPqaTfx8skuWUtBjNWk0lbxExLTuiw8AdJikUhuWgfnYLG+B4lj8hrLYz/doxJqNADGldJ6zqankoLxaqD7P7axE6r7rvGjnHLCZpwFlodjRqk3BJy4VxYfTwWe+IiGTHAA6JXjGnhp2fXiQZpeswhGWeg3nsevNuhfaOGjQyzcGpMI8fSi/wgoP3vLmDCPE/1Vo5K8RkhqHxNfSCnIHgF5DuAmkJQyLcifwCzgz7MeTkqzmekXEJJoIeQuotOdpGcxeW1AisGWvk/2jNhbYe4X0+hnfyBi5vLAMsOsG7vv6hJDegQ/nuSoFj8a/1ZhBlLOFTi9spcfwFQSwcIrj+x2IABAAB0BQAAUEsDBBQACAgIANsBP04AAAAAAAAAAAAAAAAPAAAAd29yZC9zdHlsZXMueG1s3VdtTuMwED3B3qHKf0iahlBVBIRAsCshdrWwB5g6bmPh2JbttHRPv853mqQotJWotn/SmfG8GT+/dNyrm/eYjlZYKsJZYI3PHWuEGeIhYcvA+vP6cDa1RkoDC4FyhgNrg5V1c/3taj1TekOxGpl8pmYxCqxIazGzbYUiHIM65wIzE1xwGYM2plzaMci3RJwhHgvQZE4o0RvbdRzfKmB4YCWSzQqIs5ggyRVf6DRlxhcLgnDxKDPkkLp5yj1HSYyZziraElPTA2cqIkKVaPG+aCYYlSCrjzaximm5bi2GVAslrM1hxDQvtOYyFJIjrJTx3ufBCnHsDCAwhagyhrSwXbPsJAbCKphUGi2gqva5qV2QlkHVG6m5UHRII3noicwlyE23C9iDz2a+IINU3EIwWTqRlSD3gUARSF0C0H0QKEdvOLwDtoJKzOFykJxbSCGBpYS4Fqn61MmOnZZcXiIQuEZbHob2KHkiarl7+6A13sDxxecA3BLg2vwAhhzd4wUkVKvUlL9kYRZW9njgTKvRegYKERJYt5KAKb+eIdUwMCh9qwg0XNEtU9V6O4VSf417BeZFcd3Sc6e2fXZR2G63I9pWli8AGU4NBCXpC+xe+lZh/E6ocUCieQErCtgmkN3hIJsJBkJvhEkXIFMtiShFzUI/wsB6TrWX7THMM83YyfhkEONyOyxflNfOUrvwGuYUb0G/pp5B+NnK0fOAKv2b+I4hHZFd4CgPjMb5Ec1B4fAnK6N1QZOF33WfvzicN4zFc2NJAZi6n8wBqZa/PktYaGym4th10o7n2LzrZhve1Pn4bCvJztvIle68aVd3ua+hu31odHfS6H41jdMtFif+4SxO/C6Lue9AFic7WZycFovuEbTo9mjRPYYWvZ0sel/NorfNoncEFr0eFr0jsHixk8WLE2PRPQKLQ+bxPiz6O1n0T4xF5wgsOj0sOoew+Eq0uSB0Rn/m/f+m82WPCi8PUuFLMte9FFaBkxorw4dz+1b+iM0fIQLlvbxh1jfzhrO4m5eerDfS6hVxymXp87PPIdep8pu6/gdQSwcIqwTYwhcDAACyEQAAUEsDBBQACAgIANsBP04AAAAAAAAAAAAAAAARAAAAd29yZC9kb2N1bWVudC54bWztVttO4zAQ/YL9hyrvkLYqF1UUxIJYrcQiBOwHTJ1J4sWxrbHTUr5+7cROS0AodF+3L47ncmY8t87ZxUslRiskw5VcJJPDcTJCyVTGZbFIfj/dHJwmI2NBZiCUxEWyQZNcnH87W88zxeoKpR05BGnmFVskpbV6nqaGlViBOVQapWPmiiqw7kpFWgE91/qAqUqD5UsuuN2k0/H4OAkwapHUJOcB4qDijJRRufUqc5XnnGE4ogYNsduqXAeXG4spoXA+KGlKrk1Eq/ZFc8wygqw+e8SqElFurYdYywjWLh2VaA2tFWWaFENjHPW6ZXaIk/GAAHqITmOIC29tRk8q4LKD8cXRA+psHzrbIWgN1PYh21gYMcSRlnXLlwS0ee8F7BHPXX3NB1VxD8Fp2Zq6gtwHgpVANgKIfRCEYs+YXYFcQVfMWTGonHtIGYeCoNoWqflSZifjXrk8lqBxi1b8G9oPUrXelvtsH7SdDpwcfQ1gGgHO3QhcqmzjTz1az90EzR4WyTj8kkC6RvGeeP+e9HCNOdTCfsC5pzfEyWyugeBntkNtnLgnfzwj6jt8sU57Bd52kkbyLZdoevQ1z9T6SklLSvRY+nvWIFrl32c0MPQ8//0aPhpxyUWrIDC3wySXylpVDZMlXpRDYdGuEeUQ4XT7PlNmjplz4bhQW9WJMoFALbLHc8XnOJBbpAC4RNdG0YzgfgROT47j5aEWGBAbDC69HR+koNG8LHznnIy9bSBC+P+w6IdXCbFoc0w3LmE+k2AY54vkkjgIj8LMzgXB2EvDYYdUXkrTybch6yWd9+6mAiGuQPfrxljiz9gjMiUUdbS2NFvp10idTiPlyvRpdZcjt2oEsQG5cduLvRS8kJG3BIM+ASHPTdDSrkHos878oIPf9t//LOyTBRcs+3a8pF0YmwUyNqwmNEgrTM6ZcgOJuQi7DctL21anzWTjFDLbIuji0b+sdPvr0emsSZzbaibT6SxOsuIX+Ii0Y8exZq2Um2zbS9uY8RZ6M15LhKxr+1ypZgacTDv8u7p62mifCbcsk1cMj4xepvHfIt1uzud/AVBLBwhHOF0MIAMAAH4LAABQSwMEFAAICAgA2wE/TgAAAAAAAAAAAAAAABwAAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzrZJNasMwEIVP0DuI2dey0x9KiZxNCGRb3AMo8viHWiMhTUp9+4qUJA4E04WX74l5882M1psfO4hvDLF3pKDIchBIxtU9tQo+q93jG4jImmo9OEIFI0bYlA/rDxw0p5rY9T6KFEJRQcfs36WMpkOrY+Y8UnppXLCakwyt9Np86RblKs9fZZhmQHmTKfa1grCvCxDV6PE/2a5peoNbZ44Wie+0kJxqMQXq0CIrOMk/s8hSGMj7DKslGSIyp+XGK8bZmUN4WhKhccSVPgyTVVysOYjnJSHoaA8Y0txXiIs1B/Gy6DF4HHB6ipM+t5c3n7z8BVBLBwiQAKvr8QAAACwDAABQSwMEFAAICAgA2wE/TgAAAAAAAAAAAAAAAAsAAABfcmVscy8ucmVsc43POw7CMAwG4BNwh8g7TcuAEGrSBSF1ReUAUeKmEc1DSXj09mRgAMTAaPv3Z7ntHnYmN4zJeMegqWog6KRXxmkG5+G43gFJWTglZu+QwYIJOr5qTziLXHbSZEIiBXGJwZRz2FOa5IRWpMoHdGUy+mhFLmXUNAh5ERrppq63NL4bwD9M0isGsVcNkGEJ+I/tx9FIPHh5tejyjxNfiSKLqDEzuPuoqHq1q8IC5S39eJE/AVBLBwgtaM8isQAAACoBAABQSwMEFAAICAgA2wE/TgAAAAAAAAAAAAAAABUAAAB3b3JkL3RoZW1lL3RoZW1lMS54bWztWUtv2zYcvw/YdyB0b2XZVuoEdYrYsdutTRskboceaYmW2FCiQNJJfBva44ABw7phhxXYbYdhW4EW2KX7NNk6bB3Qr7C/HpYpm86jTbcOrQ82Sf3+7wdJ+fKVw4ihfSIk5XHbci7WLERij/s0DtrW7UH/QstCUuHYx4zHpG1NiLSurH/4wWW8pkISEQT0sVzDbStUKlmzbenBMpYXeUJieDbiIsIKpiKwfYEPgG/E7HqttmJHmMYWinEEbG+NRtQjaJCytNanzHsMvmIl0wWPiV0vk6hTZFh/z0l/5ER2mUD7mLUtkOPzgwE5VBZiWCp40LZq2cey1y/bJRFTS2g1un72KegKAn+vntGJYFgSOv3m6qXNkn8957+I6/V63Z5T8ssA2PPAUmcB2+y3nM6UpwbKh4u8uzW31qziNf6NBfxqp9NxVyv4xgzfXMC3aivNjXoF35zh3UX9Oxvd7koF787wKwv4/qXVlWYVn4FCRuO9BXQazzIyJWTE2TUjvAXw1jQBZihby66cPlbLci3C97joAyALLlY0RmqSkBH2ANfFjA4FTQXgNYK1J/mSJxeWUllIeoImqm19nGCoiBnk5bMfXz57go7uPz26/8vRgwdH9382UF3DcaBTvfj+i78ffYr+evLdi4dfmfFSx//+02e//fqlGah04POvH//x9PHzbz7/84eHBviGwEMdPqARkegmOUA7PALDDALIUJyNYhBiqlNsxIHEMU5pDOieCivomxPMsAHXIVUP3hHQAkzAq+N7FYV3QzFW1AC8HkYV4BbnrMOF0abrqSzdC+M4MAsXYx23g/G+SXZ3Lr69cQK5TE0suyGpqLnNIOQ4IDFRKH3G9wgxkN2ltOLXLeoJLvlIobsUdTA1umRAh8pMdI1GEJeJSUGId8U3W3dQhzMT+02yX0VCVWBmYklYxY1X8VjhyKgxjpiOvIFVaFJydyK8isOlgkgHhHHU84mUJppbYlJR9zq0DnPYt9gkqiKFonsm5A3MuY7c5HvdEEeJUWcahzr2I7kHKYrRNldGJXi1QtI5xAHHS8N9hxJ1ttq+TYPQnCDpk7EwlQTh1XqcsBEmcdHhK706ovFxjTuCvo3Pu3FDq3z+7aP/UcveACeYama+US/DzbfnLhc+ffu78yYex9sECuJ9c37fnN/F5rysns+/Jc+6sK0ftDM20dJT94gytqsmjNyQWf+WYJ7fh8VskhGVh/wkhGEhroILBM7GSHD1CVXhbogTEONkEgJZsA4kSriEq4W1lHd2P6Vgc7bmTi+VgMZqi/v5ckO/bJZsslkgdUGNlMFphTUuvZ4wJweeUprjmqW5x0qzNW9C3SCcvkpwVuq5aEgUzIif+j1nMA3LGwyRU9NiFGKfGJY1+5zGG/GmeyYlzsfJtQUn24vVxOLqDB20rVW37lrIw0nbGsFpCYZRAvxk2mkwC+K25ancwJNrcc7iVXNWOTV3mcEVEYmQahPLMKfKHk1fpcQz/etuM/XD+RhgaCan06LRcv5DLez50JLRiHhqycpsWjzjY0XEbugfoCEbix0Mejfz7PKphE5fn04E5HazSLxq4Ra1Mf/KpqgZzJIQF9ne0mKfw7NxqUM209Szl+j+iqY0ztEU9901Jc1cOJ82/OzSBLu4wCjN0bbFhQo5dKEkpF5fwL6fyQK9EJRFqhJi6QvoVFeyP+tbOY+8yQWh2qEBEhQ6nQoFIduqsPMEZk5d3x6njIo+U6ork/x3SPYJG6TVu5Lab6Fw2k0KR2S4+aDZpuoaBv23+ODSfKWNZyaoeZbNr6k1fW0rWH09FU6zAWvi6maL6+7SnWd+q03gloHSL2jcVHhsdjwd8B2IPir3eQSJeKFVlF+5OASdW5pxKat/6xTUWhLv8zw7as5uLHH28eJe3dmuwdfu8a62F0vU1u4h2Wzhjyg+vAeyN+F6M2b5ikxglg+2RWbwkPuTYshk3hJyR0xbOot3yAhR/3Aa1jmPFv/0lJv5Ti4gtb0kbJxMWOBnm0hJXD+ZuKSY3vFK4uwWZ2LAZpJzfB7lskWWnmLx67jsFMqbXWbM3tO67BSBegWXqcPjXVZ4yjYlHjlUAnenf11B/tqzlF3/B1BLBwghWqKELAYAANsdAABQSwMEFAAICAgA2wE/TgAAAAAAAAAAAAAAABMAAABbQ29udGVudF9UeXBlc10ueG1stZNNbsIwEIVP0DtE3lbE0EVVVQQW/Vm2XdADDM4ErPpPnoHC7TsJkAUCqZWajWX7zbz3eSRP5zvvii1msjFUalKOVYHBxNqGVaU+F6+jB1UQQ6jBxYCV2iOp+exmutgnpEKaA1VqzZwetSazRg9UxoRBlCZmDyzHvNIJzBesUN+Nx/faxMAYeMSth5pNn7GBjePi6XDfWlcKUnLWAAuXFjNVvOxEPGC2Z/2Lvm2oz2BGR5Ayo+tqaG0T3Z4HiEptwrtMJtsa/xQRm8YarKPZeGkpv2OuU44GiWSo3pWEzLI7pn5A5jfwYqvbSn1Sy+Mjh0HgvcNrAJ02aHwjXgtYOrxM0MuDQoSNX2KW/WWIXh4Uolc82HAZpC/5Rw6Wj3pl+J10WCenSN399tkPUEsHCDOvD7csAQAALQQAAFBLAQIUABQACAgIANsBP05JE0N/aAEAAD0FAAASAAAAAAAAAAAAAAAAAAAAAAB3b3JkL251bWJlcmluZy54bWxQSwECFAAUAAgICADbAT9Oj/aQvwUCAADqBgAAEQAAAAAAAAAAAAAAAACoAQAAd29yZC9zZXR0aW5ncy54bWxQSwECFAAUAAgICADbAT9Orj+x2IABAAB0BQAAEgAAAAAAAAAAAAAAAADsAwAAd29yZC9mb250VGFibGUueG1sUEsBAhQAFAAICAgA2wE/TqsE2MIXAwAAshEAAA8AAAAAAAAAAAAAAAAArAUAAHdvcmQvc3R5bGVzLnhtbFBLAQIUABQACAgIANsBP05HOF0MIAMAAH4LAAARAAAAAAAAAAAAAAAAAAAJAAB3b3JkL2RvY3VtZW50LnhtbFBLAQIUABQACAgIANsBP06QAKvr8QAAACwDAAAcAAAAAAAAAAAAAAAAAF8MAAB3b3JkL19yZWxzL2RvY3VtZW50LnhtbC5yZWxzUEsBAhQAFAAICAgA2wE/Ti1ozyKxAAAAKgEAAAsAAAAAAAAAAAAAAAAAmg0AAF9yZWxzLy5yZWxzUEsBAhQAFAAICAgA2wE/TiFaooQsBgAA2x0AABUAAAAAAAAAAAAAAAAAhA4AAHdvcmQvdGhlbWUvdGhlbWUxLnhtbFBLAQIUABQACAgIANsBP04zrw+3LAEAAC0EAAATAAAAAAAAAAAAAAAAAPMUAABbQ29udGVudF9UeXBlc10ueG1sUEsFBgAAAAAJAAkAQgIAAGAWAAAAAA==
+        UEsDBBQACAgIAK4zUE4AAAAAAAAAAAAAAAASAAAAd29yZC9udW1iZXJpbmcueG1spZNNTsMwEIVPwB0i79skFSAUNe2CCjbsgAO4jpNYtT3W2Eno7XGbv1IklIZV5Izf98bj5/X2S8mg5mgF6JTEy4gEXDPIhC5S8vnxsngigXVUZ1SC5ik5cku2m7t1k+hK7Tn6fYFHaJsolpLSOZOEoWUlV9QuwXDtizmgos4vsQgVxUNlFgyUoU7shRTuGK6i6JF0GEhJhTrpEAslGIKF3J0kCeS5YLz79Aqc4ttKdsAqxbU7O4bIpe8BtC2FsT1NzaX5YtlD6r8OUSvZ72vMFLcMaePnrGRr1ABmBoFxa/3fXVsciHE0YYAnxKCY0sJPz74TRYUeMKd0XIEG76X37oZ2Ro0HGWdh5ZRG2tKb2CPF4+8u6Ix5XuqNmJTiK4JXuQqHQM5BsJKi6wFyDkECO/DsmeqaDmHOiklxviJlghZI1RhSe9PNxtFVXN5LavhIK/5He0WozBj3+zm0ixcYP9wGWPWAcPMNUEsHCEkTQ39oAQAAPQUAAFBLAwQUAAgICACuM1BOAAAAAAAAAAAAAAAAEQAAAHdvcmQvc2V0dGluZ3MueG1spZXNbtswDMefYO8Q6J74o0k2GHV6WLHtsJ7SPQAjybYQfUGS4+XtJ8eW1aRA4WanSH+SP9IMTT8+/RV8caLGMiVLlK1StKASK8JkXaI/rz+W39DCOpAEuJK0RGdq0dPuy2NXWOqc97ILT5C2ELhEjXO6SBKLGyrArpSm0hsrZQQ4fzV1IsAcW73ESmhw7MA4c+ckT9MtGjGqRK2RxYhYCoaNsqpyfUihqophOv6ECDMn7xDyrHArqHSXjImh3NegpG2YtoEm7qV5YxMgp48e4iR48Ov0nGzEQOcbLfiQqFOGaKMwtdarz4NxImbpjAb2iCliTgnXOUMlApicMP1w3ICm3Cufe2zaBRUfJPbC8jmFDKbf7GDAnN9XAXf08228ZrOm+Ibgo1xrpoG8B4EbMC4A+D0ErvCRku8gTzANM6lnjfMNiTCoDYg4pPZT/2yW3ozLvgFNI63+P9pPo1odx319D+3NG5htPgfIA2DnVyChFbTcvcJh75RedMUJ/BR/zVOU9OZhy8XTftiYwS9bI3+UIPybc7UQXxShvak1bH5xfcrkKic3+z6IvoDWQ9pDnZWIs7pxWc93/kb8Qr5cDnU+2vKLLR9slwtg7Pec9x4PUcuD9sbvIWgPUVsHbR21TdA2UdsGbdtrzVlTw5k8+jaEY69XinPVUfIr2t9JYz/CV2r3D1BLBwiP9pC/BQIAAOoGAABQSwMEFAAICAgArjNQTgAAAAAAAAAAAAAAABIAAAB3b3JkL2ZvbnRUYWJsZS54bWyllE1OwzAQhU/AHSLv26QIEIqaVAgEG3bAAQbHSazaHmvsNPT2uDQ/UCSUhlWUjN/3xuMXrzcfWkU7QU6iydhqmbBIGI6FNFXG3l4fF7csch5MAQqNyNheOLbJL9ZtWqLxLgpy41LNM1Z7b9M4drwWGtwSrTChWCJp8OGVqlgDbRu74KgtePkulfT7+DJJbliHwYw1ZNIOsdCSEzos/UGSYllKLrpHr6ApvkfJA/JGC+O/HGMSKvSAxtXSup6m59JCse4hu782sdOqX9faKW4FQRvOQqujUYtUWEIunAtfH47FgbhKJgzwgBgUU1r46dl3okGaAXNIxglo8F4G725oX6hxI+MsnJrSyLH0LN8JaP+7C5gxz+96Kyel+IQQVL6hIZBzELwG8j1AzSEo5FtR3IPZwRDmopoU5xNSIaEi0GNI3Vknu0pO4vJSgxUjrfof7YmwsWPcr+bQvv2Bq+vzAJc9IO/uv6hNDegQ/juSoFicr+PuYsw/AVBLBwith20AeQEAAFoFAABQSwMEFAAICAgArjNQTgAAAAAAAAAAAAAAAA8AAAB3b3JkL3N0eWxlcy54bWzVlt1u2jAUx59g74By3yYkgSFUWnWt2k2qumrtrqeDY4hVx7ZsB8qefs43JKFKAxIdXICPff7n+Ofjj4urt4gOVlgqwtnMGp471gAzxAPCljPr98vd2cQaKA0sAMoZnlkbrKyryy8X66nSG4rVwPgzNY3QzAq1FlPbVijEEahzLjAznQsuI9CmKZd2BPI1FmeIRwI0mRNK9MZ2HWds5TJ8ZsWSTXOJs4ggyRVf6MRlyhcLgnD+U3jILnEzl1uO4ggznUa0JaYmB85USIQq1KK+aqYzLERW701iFdFi3Fp0iRZIWJvFiGgWaM1lICRHWCljvc06S8Wh0wFgIlF6dElhN2aRSQSElTJJadSEytjnJnYOLZWqJlKxULRLIlnXA5lLkJtmFtCD57a/IJ2quKZgvHQsy4LsI4FCkLoQoH0UKEevOLgBtoKymINlp3KuKQUElhKiqkjVh1Z26NTK5TkEgSu15WFq95LHoip3v4/a1g4cjj4m4BYCl+YADDi6xQuIqVZJUz7JvJm30p87zrQarKegECEz61oSMOHXU6S2GhiUvlYEtkzhNVPleDuRUn+NeQVmo7huYblRdRsFtixsmP25/5aY7Twfu56lqLdSWQGIpCqUJPva/Tq28savmBoDxJrnsiKX3RayG2jSq8JI6I0w7gJkUmIiTFTTrh/BzHpMSjKdepB5mtsoxcwgwsWMWDYoi526NuU1zCnekX5JLJ3005GDxw5R2ifxHUNyczaFw6xjMMxWaQ4KBz9Z0VsFNF74TbfZ88V5xVg8bg3JBRPzg1kgVbNXawkLjc1lOXSdJOM5NkeAmYbvOO+vbVnJVfn5TrP8MttWnfXB5u7F5n4ybN64K7Z5oezUd7HXsosz24EYvb0YvVNjnOxSdPtSRJxyWdael3wbh+Sk5ZCcHAGvvxev/7nwupOueHdwjtNPA6ffgtM/As7RXpyjT4bTPybOvVf4gTjHe3GO/1ecpCZ8ErwvRJtXReO9kFpPzHW8w/Xj9/moBdboIFjP8Vy38io7TozMc3sxO+Jrvizqthutvai9lneXt+fdVfxTl/8AUEsHCCmXCZwiAwAA4hEAAFBLAwQUAAgICACuM1BOAAAAAAAAAAAAAAAAEQAAAHdvcmQvZG9jdW1lbnQueG1spZXbbtswDIafYO8Q6D6xnWZda8TpRYMNA7YhaLsHUCTZFqoTKDlZ9vSTfMyhKNwsNwRJ8eNviZGWD3+kmOwYWK5VhpJZjCZMEU25KjL0++Xr9A5NrMOKYqEVy9CBWfSw+rTcp1STSjLlJp6gbCpJhkrnTBpFlpRMYjvThimfzDVI7LwLRSQxvFZmSrQ02PEtF9wdonkc36IWozNUgUpbxFRyAtrq3IWSVOc5J6w1XQWM6duUrFvJdccImPAatLIlN7ajyWtpPll2kN17H7GTolu3N2O6UcB7fxxSNI32GqgBTZi1Prpukj0xiUdsYED0FWMknPbslEjMVY8Jw3EG6nvPfO9202rU8CHDXlgxRkiT+sG3gOFwqQJfsZ/H9YaPmuIzgq9yFfQDeQ2ClBhcBxDXEIQmr4w+YrXD/TDTYtQ4n5EoxwVgOQyp/dDJJvHZuDyX2LCBVvwf7RvoygzjvriGdvQPTD5/DDDvACt/BW41PQRrJvvU36D0KUNx+0NtaM3EZXBzGXpasxxXwr2R2cBJMFmkBgP+To+itYgNBAMbiFbLaPDfE/KG4NN2LbE2TvglOxwwqGlRZ4JtGoZVlhHXrDfF819fUPpX5fbuZhH4/q5Jkvv4PpSHBT9xULfVzmk/qMliUatw2gyOYLkbPOBFeeSWDFPm5X6Z126utevctsOvSr4cDPNJ/4hBKG2ldzqj7hSj4UVb/QNQSwcIy/3mbRsCAAAWBwAAUEsDBBQACAgIAK4zUE4AAAAAAAAAAAAAAAAcAAAAd29yZC9fcmVscy9kb2N1bWVudC54bWwucmVsc62STWrDMBCFT9A7iNnXstMfSomcTQhkW9wDKPL4h1ojIU1KffuKlCQOBNOFl++JefPNjNabHzuIbwyxd6SgyHIQSMbVPbUKPqvd4xuIyJpqPThCBSNG2JQP6w8cNKea2PU+ihRCUUHH7N+ljKZDq2PmPFJ6aVywmpMMrfTafOkW5SrPX2WYZkB5kyn2tYKwrwsQ1ejxP9muaXqDW2eOFonvtJCcajEF6tAiKzjJP7PIUhjI+wyrJRkiMqflxivG2ZlDeFoSoXHElT4Mk1VcrDmI5yUh6GgPGNLcV4iLNQfxsugxeBxweoqTPreXN5+8/AVQSwcIkACr6/EAAAAsAwAAUEsDBBQACAgIAK4zUE4AAAAAAAAAAAAAAAALAAAAX3JlbHMvLnJlbHONzzsOwjAMBuATcIfIO03LgBBq0gUhdUXlAFHiphHNQ0l49PZkYADEwGj792e57R52JjeMyXjHoKlqIOikV8ZpBufhuN4BSVk4JWbvkMGCCTq+ak84i1x20mRCIgVxicGUc9hTmuSEVqTKB3RlMvpoRS5l1DQIeREa6aautzS+G8A/TNIrBrFXDZBhCfiP7cfRSDx4ebXo8o8TX4kii6gxM7j7qKh6tavCAuUt/XiRPwFQSwcILWjPIrEAAAAqAQAAUEsDBBQACAgIAK4zUE4AAAAAAAAAAAAAAAAVAAAAd29yZC90aGVtZS90aGVtZTEueG1s7VlLb9s2HL8P2HcgdG9l2VbqBHWK2LHbrU0bJG6HHmmJlthQokDSSXwb2uOAAcO6YYcV2G2HYVuBFtil+zTZOmwd0K+wvx6WKZvOo023Dq0PNkn9/u8HSfnylcOIoX0iJOVx23Iu1ixEYo/7NA7a1u1B/0LLQlLh2MeMx6RtTYi0rqx/+MFlvKZCEhEE9LFcw20rVCpZs23pwTKWF3lCYng24iLCCqYisH2BD4BvxOx6rbZiR5jGFopxBGxvjUbUI2iQsrTWp8x7DL5iJdMFj4ldL5OoU2RYf89Jf+REdplA+5i1LZDj84MBOVQWYlgqeNC2atnHstcv2yURU0toNbp+9inoCgJ/r57RiWBYEjr95uqlzZJ/Pee/iOv1et2eU/LLANjzwFJnAdvst5zOlKcGyoeLvLs1t9as4jX+jQX8aqfTcVcr+MYM31zAt2orzY16Bd+c4d1F/Tsb3e5KBe/O8CsL+P6l1ZVmFZ+BQkbjvQV0Gs8yMiVkxNk1I7wF8NY0AWYoW8uunD5Wy3Itwve46AMgCy5WNEZqkpAR9gDXxYwOBU0F4DWCtSf5kicXllJZSHqCJqptfZxgqIgZ5OWzH18+e4KO7j89uv/L0YMHR/d/NlBdw3GgU734/ou/H32K/nry3YuHX5nxUsf//tNnv/36pRmodODzrx//8fTx828+//OHhwb4hsBDHT6gEZHoJjlAOzwCwwwCyFCcjWIQYqpTbMSBxDFOaQzongor6JsTzLAB1yFVD94R0AJMwKvjexWFd0MxVtQAvB5GFeAW56zDhdGm66ks3QvjODALF2Mdt4Pxvkl2dy6+vXECuUxNLLshqai5zSDkOCAxUSh9xvcIMZDdpbTi1y3qCS75SKG7FHUwNbpkQIfKTHSNRhCXiUlBiHfFN1t3UIczE/tNsl9FQlVgZmJJWMWNV/FY4cioMY6YjryBVWhScncivIrDpYJIB4Rx1POJlCaaW2JSUfc6tA5z2LfYJKoihaJ7JuQNzLmO3OR73RBHiVFnGoc69iO5BymK0TZXRiV4tULSOcQBx0vDfYcSdbbavk2D0Jwg6ZOxMJUE4dV6nLARJnHR4Su9OqLxcY07gr6Nz7txQ6t8/u2j/1HL3gAnmGpmvlEvw8235y4XPn37u/MmHsfbBArifXN+35zfxea8rJ7PvyXPurCtH7QzNtHSU/eIMrarJozckFn/lmCe34fFbJIRlYf8JIRhIa6CCwTOxkhw9QlV4W6IExDjZBICWbAOJEq4hKuFtZR3dj+lYHO25k4vlYDGaov7+XJDv2yWbLJZIHVBjZTBaYU1Lr2eMCcHnlKa45qlucdKszVvQt0gnL5KcFbquWhIFMyIn/o9ZzANyxsMkVPTYhRinxiWNfucxhvxpnsmJc7HybUFJ9uL1cTi6gwdtK1Vt+5ayMNJ2xrBaQmGUQL8ZNppMAvituWp3MCTa3HO4lVzVjk1d5nBFRGJkGoTyzCnyh5NX6XEM/3rbjP1w/kYYGgmp9Oi0XL+Qy3s+dCS0Yh4asnKbFo842NFxG7oH6AhG4sdDHo38+zyqYROX59OBOR2s0i8auEWtTH/yqaoGcySEBfZ3tJin8OzcalDNtPUs5fo/oqmNM7RFPfdNSXNXDifNvzs0gS7uMAozdG2xYUKOXShJKReX8C+n8kCvRCURaoSYukL6FRXsj/rWzmPvMkFodqhARIUOp0KBSHbqrDzBGZOXd8ep4yKPlOqK5P8d0j2CRuk1buS2m+hcNpNCkdkuPmg2abqGgb9t/jg0nyljWcmqHmWza+pNX1tK1h9PRVOswFr4upmi+vu0p1nfqtN4JaB0i9o3FR4bHY8HfAdiD4q93kEiXihVZRfuTgEnVuacSmrf+sU1FoS7/M8O2rObixx9vHiXt3ZrsHX7vGuthdL1NbuIdls4Y8oPrwHsjfhejNm+YpMYJYPtkVm8JD7k2LIZN4SckdMWzqLd8gIUf9wGtY5jxb/9JSb+U4uILW9JGycTFjgZ5tISVw/mbikmN7xSuLsFmdiwGaSc3we5bJFlp5i8eu47BTKm11mzN7TuuwUgXoFl6nD411WeMo2JR45VAJ3p39dQf7as5Rd/wdQSwcIIVqihCwGAADbHQAAUEsDBBQACAgIAK4zUE4AAAAAAAAAAAAAAAATAAAAW0NvbnRlbnRfVHlwZXNdLnhtbLWTTW7CMBCFT9A7RN5WxNBFVVUEFv1Ztl3QAwzOBKz6T56Bwu07CZAFAqmVmo1l+82893kkT+c774otZrIxVGpSjlWBwcTahlWlPhevowdVEEOowcWAldojqfnsZrrYJ6RCmgNVas2cHrUms0YPVMaEQZQmZg8sx7zSCcwXrFDfjcf32sTAGHjErYeaTZ+xgY3j4ulw31pXClJy1gALlxYzVbzsRDxgtmf9i75tqM9gRkeQMqPramhtE92eB4hKbcK7TCbbGv8UEZvGGqyj2XhpKb9jrlOOBolkqN6VhMyyO6Z+QOY38GKr20p9UsvjI4dB4L3DawCdNmh8I14LWDq8TNDLg0KEjV9ilv1liF4eFKJXPNhwGaQv+UcOlo96ZfiddFgnp0jd/fbZD1BLBwgzrw+3LAEAAC0EAABQSwECFAAUAAgICACuM1BOSRNDf2gBAAA9BQAAEgAAAAAAAAAAAAAAAAAAAAAAd29yZC9udW1iZXJpbmcueG1sUEsBAhQAFAAICAgArjNQTo/2kL8FAgAA6gYAABEAAAAAAAAAAAAAAAAAqAEAAHdvcmQvc2V0dGluZ3MueG1sUEsBAhQAFAAICAgArjNQTq2HbQB5AQAAWgUAABIAAAAAAAAAAAAAAAAA7AMAAHdvcmQvZm9udFRhYmxlLnhtbFBLAQIUABQACAgIAK4zUE4plwmcIgMAAOIRAAAPAAAAAAAAAAAAAAAAAKUFAAB3b3JkL3N0eWxlcy54bWxQSwECFAAUAAgICACuM1BOy/3mbRsCAAAWBwAAEQAAAAAAAAAAAAAAAAAECQAAd29yZC9kb2N1bWVudC54bWxQSwECFAAUAAgICACuM1BOkACr6/EAAAAsAwAAHAAAAAAAAAAAAAAAAABeCwAAd29yZC9fcmVscy9kb2N1bWVudC54bWwucmVsc1BLAQIUABQACAgIAK4zUE4taM8isQAAACoBAAALAAAAAAAAAAAAAAAAAJkMAABfcmVscy8ucmVsc1BLAQIUABQACAgIAK4zUE4hWqKELAYAANsdAAAVAAAAAAAAAAAAAAAAAIMNAAB3b3JkL3RoZW1lL3RoZW1lMS54bWxQSwECFAAUAAgICACuM1BOM68PtywBAAAtBAAAEwAAAAAAAAAAAAAAAADyEwAAW0NvbnRlbnRfVHlwZXNdLnhtbFBLBQYAAAAACQAJAEICAABfFQAAAAA=
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
@@ -3172,7 +4895,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 31 Jan 2019 08:14:54 GMT
+      - Sat, 16 Feb 2019 14:29:29 GMT
       Content-Type:
       - text/html
       Transfer-Encoding:
@@ -3191,14 +4914,14 @@ http_interactions:
         </title>
         </head>
         <body>
-        <p>cool content</p>
+        <p/>
         </body>
         </html>
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:54 GMT
+  recorded_at: Sat, 16 Feb 2019 14:29:29 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Kn9WZb3pVj2daeA56Q8BC3LqPYtdtMkcgZX1CwCgEzw?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1zfzaHahRN6QzmMlMocuaEE8aAWivOp-2evjtxpG38Rk/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -3210,7 +4933,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:54 GMT
+      - Sat, 16 Feb 2019 14:29:29 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -3221,94 +4944,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 31 Jan 2019 08:14:54 GMT
+      - Sat, 16 Feb 2019 14:29:30 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:54 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1Kn9WZb3pVj2daeA56Q8BC3LqPYtdtMkcgZX1CwCgEzw",
-         "name": "File 1 Updated",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1WLQl2Yz05HGRSfAavZI41iPTr44AvSp4"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Kn9WZb3pVj2daeA56Q8BC3LqPYtdtMkcgZX1CwCgEzw&v=1&s=AMedNnoAAAAAXFLKnnhAziWv3PpRzgqRfCOWZH98blnJ&sz=s220",
-         "thumbnailVersion": "1",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13769612645787867933",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR CONTRIBUTOR ACCOUNT>",
-           "role": "writer",
-           "displayName": "Contributor Openly",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:54 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1Kn9WZb3pVj2daeA56Q8BC3LqPYtdtMkcgZX1CwCgEzw/revisions/head
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 31 Jan 2019 08:14:54 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Thu, 31 Jan 2019 08:14:55 GMT
-      Date:
-      - Thu, 31 Jan 2019 08:14:55 GMT
+      - Sat, 16 Feb 2019 14:29:30 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -3337,76 +4975,16 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2019-01-31T08:14:44.085Z"
+         "modifiedTime": "2019-02-16T14:29:01.237Z"
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:55 GMT
-- request:
-    method: get
-    uri: https://docs.google.com/feeds/vt?gd=true&id=1Kn9WZb3pVj2daeA56Q8BC3LqPYtdtMkcgZX1CwCgEzw&s=AMedNnoAAAAAXFLKnnhAziWv3PpRzgqRfCOWZH98blnJ&sz=s350&v=1
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 31 Jan 2019 08:14:55 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Expose-Headers:
-      - Content-Length
-      Etag:
-      - '"v1"'
-      Expires:
-      - Fri, 01 Jan 1990 00:00:00 GMT
-      Cache-Control:
-      - private, max-age=86400, no-transform
-      Content-Disposition:
-      - inline;filename="unnamed.png"
-      Content-Type:
-      - image/png
-      Vary:
-      - Origin
-      Access-Control-Allow-Origin:
-      - "*"
-      Timing-Allow-Origin:
-      - "*"
-      X-Content-Type-Options:
-      - nosniff
-      Date:
-      - Thu, 31 Jan 2019 08:14:55 GMT
-      Server:
-      - fife
-      Content-Length:
-      - '1022'
-      X-Xss-Protection:
-      - 1; mode=block
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39"
-    body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        iVBORw0KGgoAAAANSUhEUgAAAQ8AAAFeCAIAAAAUnw07AAAAA3NCSVQICAjb4U/gAAADtklEQVR4nO3TQQ0AIBDAMMC/58PCfoSkVbDP9swsIDivA+AbboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QOUWqNwClVugcgtUboHKLVC5BSq3QHUBmEIFueK0cc8AAAAASUVORK5CYII=
-    http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:55 GMT
+  recorded_at: Sat, 16 Feb 2019 14:29:30 GMT
 - request:
     method: post
-    uri: https://www.googleapis.com/drive/v3/files/1Kn9WZb3pVj2daeA56Q8BC3LqPYtdtMkcgZX1CwCgEzw/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"File 1 Updated","parents":["1zhSGWT_eHjq1BqOI8m7nLLiwLCIMFqum"]}'
+      string: '{"mimeType":"application/vnd.google-apps.folder","name":"Folder","parents":["1C0Tu4qvNOjnR7zggDWwDzPE9H-6qE0W-"]}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -3415,7 +4993,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:14:55 GMT
+      - Sat, 16 Feb 2019 14:29:31 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -3432,7 +5010,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 31 Jan 2019 08:14:57 GMT
+      - Sat, 16 Feb 2019 14:29:31 GMT
       Vary:
       - Origin
       - X-Origin
@@ -3456,114 +5034,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1eFQMfBBO04kZmiNO51086IGvO0Asrvpp1jUMjqyATds",
-         "name": "File 1 Updated",
-         "mimeType": "application/vnd.google-apps.document",
+         "id": "1ZeonsK23pmnklM48iCe9HGFL4D-Xh4yG",
+         "name": "Folder",
+         "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1zhSGWT_eHjq1BqOI8m7nLLiwLCIMFqum"
-         ],
-         "thumbnailVersion": "0",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "reader",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "05663488528055015696",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR COLLABORATOR ACCOUNT>",
-           "role": "reader",
-           "displayName": "Collaborator Openly",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "anyoneWithLink",
-           "type": "anyone",
-           "role": "reader",
-           "allowFileDiscovery": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "owner",
-           "displayName": "Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:14:57 GMT
-- request:
-    method: post
-    uri: https://www.googleapis.com/drive/v3/files/1zeZ7aaBhK5Ro-69t-F5Yn57XAs0DlA40jrChvuli83U/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: '{"name":"File 2","parents":["1l0pRWchdouxaP6-fvnhX8xjtjYeNFsmP"]}'
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 31 Jan 2019 08:14:59 GMT
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-cache, no-store, max-age=0, must-revalidate
-      Pragma:
-      - no-cache
-      Expires:
-      - Mon, 01 Jan 1990 00:00:00 GMT
-      Date:
-      - Thu, 31 Jan 2019 08:15:01 GMT
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1goX46rBD8H6T-g4H_e1pWguUK9EH_2DSSjE1e09POdI",
-         "name": "File 2",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1l0pRWchdouxaP6-fvnhX8xjtjYeNFsmP"
+          "1C0Tu4qvNOjnR7zggDWwDzPE9H-6qE0W-"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -3588,10 +5064,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:15:01 GMT
+  recorded_at: Sat, 16 Feb 2019 14:29:31 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1goX46rBD8H6T-g4H_e1pWguUK9EH_2DSSjE1e09POdI/revisions/head
+    uri: https://www.googleapis.com/drive/v3/files/1ZeonsK23pmnklM48iCe9HGFL4D-Xh4yG/revisions/head
     body:
       encoding: UTF-8
       string: ''
@@ -3603,7 +5079,160 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:15:01 GMT
+      - Sat, 16 Feb 2019 14:29:31 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      Date:
+      - Sat, 16 Feb 2019 14:29:32 GMT
+      Expires:
+      - Sat, 16 Feb 2019 14:29:32 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "error": {
+          "errors": [
+           {
+            "domain": "global",
+            "reason": "revisionsNotSupported",
+            "message": "The file does not support revisions."
+           }
+          ],
+          "code": 403,
+          "message": "The file does not support revisions."
+         }
+        }
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 14:29:32 GMT
+- request:
+    method: post
+    uri: https://www.googleapis.com/drive/v3/files/1zqIX21pWVNxSXdBdUTNTE2tB7yFa6yeATS3U-6ckHvQ/copy?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: '{"name":"Subfile","parents":["1ZeonsK23pmnklM48iCe9HGFL4D-Xh4yG"]}'
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 14:29:32 GMT
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Date:
+      - Sat, 16 Feb 2019 14:29:34 GMT
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "14Sl6bkKOEC60bx9Hx-a19p8vMPh86KzA9uX66rRW9eo",
+         "name": "Subfile",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1ZeonsK23pmnklM48iCe9HGFL4D-Xh4yG"
+         ],
+         "thumbnailVersion": "0",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "writer",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 14:29:34 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/14Sl6bkKOEC60bx9Hx-a19p8vMPh86KzA9uX66rRW9eo/revisions/head
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 14:29:34 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -3614,9 +5243,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 31 Jan 2019 08:15:01 GMT
+      - Sat, 16 Feb 2019 14:29:34 GMT
       Date:
-      - Thu, 31 Jan 2019 08:15:01 GMT
+      - Sat, 16 Feb 2019 14:29:34 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -3645,13 +5274,13 @@ http_interactions:
          "kind": "drive#revision",
          "id": "1",
          "mimeType": "application/vnd.google-apps.document",
-         "modifiedTime": "2019-01-31T08:15:00.203Z"
+         "modifiedTime": "2019-02-16T14:29:33.525Z"
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:15:01 GMT
+  recorded_at: Sat, 16 Feb 2019 14:29:34 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1wNZfJJYR2DdEuC_jbhDGgzNQv5inOfs-h6F_6KBN2rI?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1l0pRWchdouxaP6-fvnhX8xjtjYeNFsmP
+    uri: https://www.googleapis.com/drive/v3/files/1Dy_98XfeKpZkdDtJg4o2URGm5d1nc3u5T40ddkJS4Kg?addParents=1ZeonsK23pmnklM48iCe9HGFL4D-Xh4yG&fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion&removeParents=1C0Tu4qvNOjnR7zggDWwDzPE9H-6qE0W-
     body:
       encoding: UTF-8
       string: ''
@@ -3663,15 +5292,15 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:15:01 GMT
+      - Sat, 16 Feb 2019 14:29:34 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
       - application/x-www-form-urlencoded
   response:
     status:
-      code: 204
-      message: No Content
+      code: 200
+      message: OK
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
@@ -3680,25 +5309,68 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 31 Jan 2019 08:15:02 GMT
+      - Sat, 16 Feb 2019 14:29:35 GMT
       Vary:
       - Origin
       - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
       Server:
       - GSE
       Alt-Svc:
       - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
     body:
       encoding: UTF-8
-      string: ''
+      string: |
+        {
+         "id": "1Dy_98XfeKpZkdDtJg4o2URGm5d1nc3u5T40ddkJS4Kg",
+         "name": "File 1 (new)",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1ZeonsK23pmnklM48iCe9HGFL4D-Xh4yG"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Dy_98XfeKpZkdDtJg4o2URGm5d1nc3u5T40ddkJS4Kg&v=2&s=AMedNnoAAAAAXGg6b8GRCOq2GjWbcJx7nugdQx2jsoec&sz=s220",
+         "thumbnailVersion": "2",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:15:02 GMT
+  recorded_at: Sat, 16 Feb 2019 14:29:35 GMT
 - request:
     method: patch
-    uri: https://www.googleapis.com/drive/v3/files/1kpqOzQCX3NIVwRSb6TTdLdCgnf4U3Te1U4YJP8nx37s?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1Dy_98XfeKpZkdDtJg4o2URGm5d1nc3u5T40ddkJS4Kg?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
-      string: '{"name":"File 1 Updated"}'
+      string: '{"name":"File 1"}'
     headers:
       User-Agent:
       - "<USER AGENT>"
@@ -3707,7 +5379,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:15:02 GMT
+      - Sat, 16 Feb 2019 14:29:35 GMT
       Content-Type:
       - application/json
       Authorization:
@@ -3724,7 +5396,7 @@ http_interactions:
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Date:
-      - Thu, 31 Jan 2019 08:15:02 GMT
+      - Sat, 16 Feb 2019 14:29:36 GMT
       Vary:
       - Origin
       - X-Origin
@@ -3748,15 +5420,15 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1kpqOzQCX3NIVwRSb6TTdLdCgnf4U3Te1U4YJP8nx37s",
-         "name": "File 1 Updated",
+         "id": "1Dy_98XfeKpZkdDtJg4o2URGm5d1nc3u5T40ddkJS4Kg",
+         "name": "File 1",
          "mimeType": "application/vnd.google-apps.document",
          "trashed": false,
          "parents": [
-          "1l0pRWchdouxaP6-fvnhX8xjtjYeNFsmP"
+          "1ZeonsK23pmnklM48iCe9HGFL4D-Xh4yG"
          ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1kpqOzQCX3NIVwRSb6TTdLdCgnf4U3Te1U4YJP8nx37s&v=2&s=AMedNnoAAAAAXFLKpmBSrAgfuRQkTvVF5Xi7H5iiqQ09&sz=s220",
-         "thumbnailVersion": "2",
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Dy_98XfeKpZkdDtJg4o2URGm5d1nc3u5T40ddkJS4Kg&v=3&s=AMedNnoAAAAAXGg6cCh3AcHJjdanRvlErCJqrQRTUK9g&sz=s220",
+         "thumbnailVersion": "3",
          "permissions": [
           {
            "kind": "drive#permission",
@@ -3779,10 +5451,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:15:03 GMT
+  recorded_at: Sat, 16 Feb 2019 14:29:36 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1kpqOzQCX3NIVwRSb6TTdLdCgnf4U3Te1U4YJP8nx37s?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    uri: https://www.googleapis.com/drive/v3/files/1ZeonsK23pmnklM48iCe9HGFL4D-Xh4yG?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -3794,7 +5466,7 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:15:03 GMT
+      - Sat, 16 Feb 2019 14:29:36 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
       Content-Type:
@@ -3805,9 +5477,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 31 Jan 2019 08:15:03 GMT
+      - Sat, 16 Feb 2019 14:29:37 GMT
       Date:
-      - Thu, 31 Jan 2019 08:15:03 GMT
+      - Sat, 16 Feb 2019 14:29:37 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Vary:
@@ -3833,97 +5505,12 @@ http_interactions:
       encoding: UTF-8
       string: |
         {
-         "id": "1kpqOzQCX3NIVwRSb6TTdLdCgnf4U3Te1U4YJP8nx37s",
-         "name": "File 1 Updated",
-         "mimeType": "application/vnd.google-apps.document",
+         "id": "1ZeonsK23pmnklM48iCe9HGFL4D-Xh4yG",
+         "name": "Folder",
+         "mimeType": "application/vnd.google-apps.folder",
          "trashed": false,
          "parents": [
-          "1l0pRWchdouxaP6-fvnhX8xjtjYeNFsmP"
-         ],
-         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1kpqOzQCX3NIVwRSb6TTdLdCgnf4U3Te1U4YJP8nx37s&v=2&s=AMedNnoAAAAAXFLKp4jntzrHdZxz8Yli4LzByIFxjKZA&sz=s220",
-         "thumbnailVersion": "2",
-         "permissions": [
-          {
-           "kind": "drive#permission",
-           "id": "11673017242486491425",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
-           "role": "writer",
-           "displayName": "Upshift One",
-           "deleted": false
-          },
-          {
-           "kind": "drive#permission",
-           "id": "13193959451567607887",
-           "type": "user",
-           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
-           "role": "owner",
-           "displayName": "Testuser Upshift One",
-           "deleted": false
-          }
-         ]
-        }
-    http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:15:03 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/drive/v3/files/1goX46rBD8H6T-g4H_e1pWguUK9EH_2DSSjE1e09POdI?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      User-Agent:
-      - "<USER AGENT>"
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip,deflate
-      Date:
-      - Thu, 31 Jan 2019 08:15:03 GMT
-      Authorization:
-      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
-      Content-Type:
-      - application/x-www-form-urlencoded
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - Thu, 31 Jan 2019 08:15:03 GMT
-      Date:
-      - Thu, 31 Jan 2019 08:15:03 GMT
-      Cache-Control:
-      - private, max-age=0, must-revalidate, no-transform
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - quic=":443"; ma=2592000; v="44,43,39"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "id": "1goX46rBD8H6T-g4H_e1pWguUK9EH_2DSSjE1e09POdI",
-         "name": "File 2",
-         "mimeType": "application/vnd.google-apps.document",
-         "trashed": false,
-         "parents": [
-          "1l0pRWchdouxaP6-fvnhX8xjtjYeNFsmP"
+          "1C0Tu4qvNOjnR7zggDWwDzPE9H-6qE0W-"
          ],
          "thumbnailVersion": "0",
          "permissions": [
@@ -3948,10 +5535,10 @@ http_interactions:
          ]
         }
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:15:03 GMT
+  recorded_at: Sat, 16 Feb 2019 14:29:37 GMT
 - request:
     method: get
-    uri: https://www.googleapis.com/drive/v3/files/1goX46rBD8H6T-g4H_e1pWguUK9EH_2DSSjE1e09POdI/export?alt=media&mimeType=text/plain
+    uri: https://www.googleapis.com/drive/v3/files/1Dy_98XfeKpZkdDtJg4o2URGm5d1nc3u5T40ddkJS4Kg?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
     body:
       encoding: UTF-8
       string: ''
@@ -3963,7 +5550,177 @@ http_interactions:
       Accept-Encoding:
       - gzip,deflate
       Date:
-      - Thu, 31 Jan 2019 08:15:03 GMT
+      - Sat, 16 Feb 2019 14:29:37 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 16 Feb 2019 14:29:37 GMT
+      Date:
+      - Sat, 16 Feb 2019 14:29:37 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1Dy_98XfeKpZkdDtJg4o2URGm5d1nc3u5T40ddkJS4Kg",
+         "name": "File 1",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1ZeonsK23pmnklM48iCe9HGFL4D-Xh4yG"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Dy_98XfeKpZkdDtJg4o2URGm5d1nc3u5T40ddkJS4Kg&v=3&s=AMedNnoAAAAAXGg6cUsKOUXPel_-xJXeBZe9WTACeCHO&sz=s220",
+         "thumbnailVersion": "3",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 14:29:37 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1Bko8cwAWUDzpSd3z58BgACIvschFXF0RkLqbplg7D7g?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 14:29:37 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 16 Feb 2019 14:29:37 GMT
+      Date:
+      - Sat, 16 Feb 2019 14:29:37 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "1Bko8cwAWUDzpSd3z58BgACIvschFXF0RkLqbplg7D7g",
+         "name": "File 2 (new)",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1C0Tu4qvNOjnR7zggDWwDzPE9H-6qE0W-"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=1Bko8cwAWUDzpSd3z58BgACIvschFXF0RkLqbplg7D7g&v=2&s=AMedNnoAAAAAXGg6cdxkTtvnwe-gGgxyQ0dyQhPQveTj&sz=s220",
+         "thumbnailVersion": "2",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "writer",
+           "displayName": "Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "owner",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 14:29:37 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/1Bko8cwAWUDzpSd3z58BgACIvschFXF0RkLqbplg7D7g/export?alt=media&mimeType=text/plain
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 14:29:37 GMT
       Authorization:
       - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
   response:
@@ -3972,9 +5729,9 @@ http_interactions:
       message: OK
     headers:
       Expires:
-      - Thu, 31 Jan 2019 08:15:04 GMT
+      - Sat, 16 Feb 2019 14:29:38 GMT
       Date:
-      - Thu, 31 Jan 2019 08:15:04 GMT
+      - Sat, 16 Feb 2019 14:29:38 GMT
       Cache-Control:
       - private, max-age=0, must-revalidate, no-transform
       Content-Disposition:
@@ -4003,5 +5760,90 @@ http_interactions:
       string: !binary |-
         77u/Y29vbCBjb250ZW50
     http_version: 
-  recorded_at: Thu, 31 Jan 2019 08:15:04 GMT
+  recorded_at: Sat, 16 Feb 2019 14:29:38 GMT
+- request:
+    method: get
+    uri: https://www.googleapis.com/drive/v3/files/14Sl6bkKOEC60bx9Hx-a19p8vMPh86KzA9uX66rRW9eo?fields=id,name,mimeType,parents,permissions,trashed,thumbnailLink,thumbnailVersion
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - "<USER AGENT>"
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip,deflate
+      Date:
+      - Sat, 16 Feb 2019 14:29:38 GMT
+      Authorization:
+      - Bearer <ACCESS TOKEN FOR TRACKING ACCOUNT>
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Sat, 16 Feb 2019 14:29:38 GMT
+      Date:
+      - Sat, 16 Feb 2019 14:29:38 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Encoding:
+      - gzip
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="44,43,39"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: |
+        {
+         "id": "14Sl6bkKOEC60bx9Hx-a19p8vMPh86KzA9uX66rRW9eo",
+         "name": "Subfile",
+         "mimeType": "application/vnd.google-apps.document",
+         "trashed": false,
+         "parents": [
+          "1ZeonsK23pmnklM48iCe9HGFL4D-Xh4yG"
+         ],
+         "thumbnailLink": "https://docs.google.com/feeds/vt?gd=true&id=14Sl6bkKOEC60bx9Hx-a19p8vMPh86KzA9uX66rRW9eo&v=1&s=AMedNnoAAAAAXGg6cllFWUCuSIn9tpqU4oU1VpkXpaRR&sz=s220",
+         "thumbnailVersion": "1",
+         "permissions": [
+          {
+           "kind": "drive#permission",
+           "id": "13193959451567607887",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR USER ACCOUNT>",
+           "role": "writer",
+           "displayName": "Testuser Upshift One",
+           "deleted": false
+          },
+          {
+           "kind": "drive#permission",
+           "id": "11673017242486491425",
+           "type": "user",
+           "emailAddress": "<EMAIL ADDRESS FOR TRACKING ACCOUNT>",
+           "role": "owner",
+           "displayName": "Upshift One",
+           "deleted": false
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Sat, 16 Feb 2019 14:29:38 GMT
 recorded_with: VCR 4.0.0

--- a/spec/views/contributions/reviews/show_spec.rb
+++ b/spec/views/contributions/reviews/show_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'contributions/reviews/show', type: :view do
 
     it 'shows a warning about uncaptured changes being lost' do
       render
-      expect(rendered).to have_text 'lose any uncaptured changes'
+      expect(rendered).to have_text 'overwrite all uncaptured changes'
     end
 
     context 'when contribution has already been accepted' do


### PR DESCRIPTION
When calculating suggested changes in a contribution, calculate them relative to
the contribution's origin revision — **not the current latest revision in
project** — and do not overwrite any other files.

This makes contributions a lot more useful because many contributions can be
worked on at the same time without overwriting each other's changes. It also
makes contributions a lot less dangerous because the potential of overwriting
uncaptured changes in the master is limited to those files having changes
suggested by the contribution.

Resolves [#325](https://github.com/OpenlyOne/openly/issues/325)
Fixes [#328](https://github.com/OpenlyOne/openly/issues/328)