### PR TITLE
Contributions: Add link to open in Google Drive

### DIFF
--- a/app/views/contributions/_head.slim
+++ b/app/views/contributions/_head.slim
@@ -25,3 +25,10 @@
          div.tab
            = link_to 'Review', profile_project_contribution_review_path(project.owner, project, contribution),
                       class: ('active' if active_tab == :review)
+         - if contribution.files.root&.link_to_remote.present?
+          div.tab
+            = link_to contribution.files.root.link_to_remote, target: '_blank' do
+              svg style="width:24px;height:24px" viewBox="0 0 24 24" class="left"
+                path fill="currentColor" d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
+              | Open in Drive
+            end

--- a/spec/views/contributions/_head_spec.rb
+++ b/spec/views/contributions/_head_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+RSpec.describe 'contributions/_head', type: :view do
+  let(:contribution) { build_stubbed(:contribution) }
+  let(:project)      { build_stubbed(:project) }
+  let(:root)         { nil }
+
+  before do
+    allow(contribution).to receive_message_chain(:files, :root).and_return root
+    allow(root).to receive(:link_to_remote).and_return link_to_remote if root
+  end
+
+  before do
+    without_partial_double_verification do
+      allow(view).to receive(:project) { project }
+      allow(view).to receive(:contribution) { contribution }
+      allow(view).to receive(:active_tab) { nil }
+    end
+  end
+
+  it 'renders the title of the contribution' do
+    render
+    expect(rendered).to have_text contribution.title
+  end
+
+  it 'renders the creator of the contribution' do
+    render
+    expect(rendered).to have_link(
+      contribution.creator.name,
+      href: profile_path(contribution.creator)
+    )
+  end
+
+  it 'renders a link to the description' do
+    render
+    expect(rendered).to have_link(
+      'Description',
+      href: profile_project_contribution_path(
+        project.owner, project, contribution
+      )
+    )
+  end
+
+  it 'renders a link to the files' do
+    render
+    expect(rendered).to have_link(
+      'Files',
+      href: profile_project_contribution_root_folder_path(
+        project.owner, project, contribution
+      )
+    )
+  end
+
+  it 'renders a link to review the changes' do
+    render
+    expect(rendered).to have_link(
+      'Review',
+      href: profile_project_contribution_review_path(
+        project.owner, project, contribution
+      )
+    )
+  end
+
+  it 'does not render a link to open contribution in Google Drive' do
+    render
+    expect(rendered).not_to have_link('Open in Drive')
+  end
+
+  it 'does not render that the contribution is accepted' do
+    render
+    expect(rendered).not_to have_text 'accepted'
+  end
+
+  context 'when the contribution has been accepted' do
+    before { allow(contribution).to receive(:accepted?).and_return true }
+
+    it 'renders that it was accepted' do
+      render
+      expect(rendered).to have_text 'accepted'
+    end
+  end
+
+  context 'when link_to_remote is present' do
+    let(:root) { build_stubbed :vcs_file_in_branch, :root }
+    let(:link_to_remote) { 'link-to-remote' }
+
+    it 'renders a link to open the contribution root folder in Google Drive' do
+      render
+      expect(rendered).to have_link(
+        'Open in Drive', href: 'link-to-remote'
+      )
+    end
+  end
+end


### PR DESCRIPTION
Allow users to open the contribution's root folder in Google Drive via
the contribution header navigation.

Resolves [#273](https://github.com/OpenlyOne/openly/issues/273)