### PR TITLE
Account: Allow email update

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Devise-overwrite for editing, updating, and deleting accounts
+class AccountsController < Devise::RegistrationsController
+  protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  def account_update_params
+    params.require(:account)
+          .permit(:current_password, :password, :password_confirmation)
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -17,8 +17,6 @@ class Account < ApplicationRecord
 
   # Attributes
   accepts_nested_attributes_for :user
-  # Do not allow email change
-  attr_readonly :email
 
   # Delegations
   delegate :handle, to: :user, prefix: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,9 +41,9 @@ Rails.application.routes.draw do
     resource :account,
              only: %i[edit update destroy],
              path_names: { edit: '' },
-             controller: 'devise/registrations'
+             controller: 'accounts'
     # Stay on /account page after user updates their account
-    get '/account', to: 'devise/registrations#edit', as: :account_root
+    get '/account', to: 'accounts#edit', as: :account_root
   end
 
   # Routes for sessions

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'controllers/shared_examples/a_redirect_with_success.rb'
+require 'controllers/shared_examples/an_authenticated_action.rb'
+
+RSpec.describe AccountsController, type: :controller do
+  include Devise::Test::ControllerHelpers
+
+  let!(:account)        { create :account, password: 'password' }
+  let(:default_params)  { {} }
+
+  before do
+    @request.env['devise.mapping'] = Devise.mappings[:account]
+    sign_in account
+  end
+
+  describe 'GET #edit' do
+    let(:params)      { default_params }
+    let(:run_request) { get :edit, params: params }
+
+    it_should_behave_like 'an authenticated action'
+
+    it 'returns http success' do
+      run_request
+      expect(response).to have_http_status :success
+    end
+  end
+
+  describe 'PATCH #update' do
+    let(:add_params) do
+      {
+        account: {
+          current_password: 'password',
+          password: 'new-password',
+          password_confirmation: 'new-password'
+        }
+      }
+    end
+    let(:params)      { default_params.merge(add_params) }
+    let(:run_request) { patch :update, params: params }
+
+    it_should_behave_like 'an authenticated action'
+    it_should_behave_like 'a redirect with success' do
+      let(:redirect_location) { account_root_path }
+      let(:notice) do
+        'Your account has been updated successfully.'
+      end
+    end
+
+    it 'updates the account' do
+      run_request
+      expect(account.reload).to be_valid_password('new-password')
+    end
+
+    context 'when current password is incorrect' do
+      before { add_params[:account][:current_password] = 'passw0rd' }
+
+      it 'does not update the account' do
+        run_request
+        expect(account.reload).not_to be_valid_password('new-password')
+      end
+    end
+
+    context 'when trying to change email' do
+      before { add_params[:account][:email] = 'new@email.com' }
+
+      it 'does not update the email address' do
+        run_request
+        expect(account.reload.email).not_to eq 'new@email.com'
+      end
+    end
+  end
+end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe Account, type: :model do
 
   describe 'attributes' do
     it { is_expected.to accept_nested_attributes_for(:user) }
-    it { is_expected.to have_readonly_attribute(:email) }
 
     it 'sets is_premium to false by default' do
       expect(account).not_to be_premium

--- a/spec/routing/account_routing_spec.rb
+++ b/spec/routing/account_routing_spec.rb
@@ -8,18 +8,18 @@ end
 RSpec.describe 'routes for accounts', type: :routing do
   it 'has an edit route' do
     expect(edit_account_path).to eq '/account'
-    expect(get: '/account').to route_to 'devise/registrations#edit'
+    expect(get: '/account').to route_to 'accounts#edit'
   end
 
   it 'has an update route' do
     expect(account_path).to eq '/account'
-    expect(patch: '/account').to route_to 'devise/registrations#update'
-    expect(put:   '/account').to route_to 'devise/registrations#update'
+    expect(patch: '/account').to route_to 'accounts#update'
+    expect(put:   '/account').to route_to 'accounts#update'
   end
 
   it 'has a delete route' do
     expect(account_path).to eq '/account'
-    expect(delete: '/account').to route_to 'devise/registrations#destroy'
+    expect(delete: '/account').to route_to 'accounts#destroy'
   end
 
   it 'has a root route' do


### PR DESCRIPTION
Admins can update email addresses of accounts via the admin panel. Users
**cannot** update their own email address.

Resolves [#266](https://github.com/OpenlyOne/openly/issues/266)