### PR TITLE
Change footer: Openly One Inc is now Team Openly

### DIFF
--- a/app/views/static/github_for_documents/index.slim
+++ b/app/views/static/github_for_documents/index.slim
@@ -267,24 +267,15 @@
 
       .col.s6.l4
         p
-          b Openly One Inc.
+          b Team Openly
           br
-          | Suite 631
-          br
-          | 1312 17th Street
-          br
-          | Denver, CO 80202
-          br
-          | USA
+          | Openly is an open source passion project :)
 
       .col.s6.l4
         p
+          b Contact Us
+          br
           = mail_to 'hello@open.ly', nil, class: 'white-text'
-          br
-          br
-          | Incorporated in Delaware.
-          br
-          | Built in Colorado.
 
     .spacing.v8px
 

--- a/app/views/static/open_collaboration/index.slim
+++ b/app/views/static/open_collaboration/index.slim
@@ -63,22 +63,15 @@
 
       .col.s6.l4
         p
-          b Openly One Inc.
+          b Team Openly
           br
-          | Suite 631
-          br
-          | 1312 17th Street
-          br
-          | Denver, CO 80202
-          br
-          | USA
+          | Openly is an open source passion project :)
 
       .col.s6.l4
         p
+          b Contact Us
+          br
           = mail_to 'hello@open.ly', nil, class: 'white-text'
-          br
-          br
-          | We are a public benefit corporation &hearts;
 
     .spacing.v8px
 


### PR DESCRIPTION
We are (soon) dissolving the legal entity called Openly One Inc. We will
continue to keep the website up as an open source passion project. The
footer now reflects that.